### PR TITLE
fix: definitive brand extraction — skip non-numeric EANs, add UPC Ite…

### DIFF
--- a/services/scraper/brand_scraper.py
+++ b/services/scraper/brand_scraper.py
@@ -7,20 +7,28 @@ Estrategia en cascada (se detiene en cuanto encuentra la marca):
      con campo `brands` estructurado. Cubre alimentación, mascotas, cosmética
      y productos genéricos. Rápido (~100 ms), sin riesgo de CAPTCHA.
 
-  2. JSON-LD / Schema.org + título de página en las primeras URLs de Bing.
-     Casi todas las tiendas online incluyen `{"@type":"Product","brand":{"name":"X"}}`
-     para Google Shopping. Como fallback secundario se analiza el título de la
-     página (`Producto - Marca` es el patrón estándar en e-commerce), el meta
-     `og:site_name` y el atributo `itemprop="brand"`.
-     Se intentan hasta 3 URLs: si Bing muestra paneles de compras sin resultados
-     orgánicos, se usa un selector ampliado para extraer igualmente las URLs.
+  1b. UPC Item DB API (sin Selenium) — base de datos generalista de códigos
+     de barras. Complementa a Open*Facts para productos no alimenticios.
+
+  Si el EAN no es numérico (p. ej. "LECHUGA ICEBERG") ninguna de las dos
+  puede ayudar y el producto se devuelve inmediatamente como no resoluble.
+  No tiene sentido buscar en Bing un código que no es un EAN real.
+
+  2. Visita Selenium de las primeras URLs de Bing — usa el mismo driver ya
+     abierto para visitar la página del producto. Al ser un navegador real
+     evita el bloqueo anti-bot que sufre `requests`. Extrae la marca de:
+       a) JSON-LD Schema.org  `{"@type":"Product","brand":{"name":"X"}}`
+       b) `itemprop="brand"` (microdata)
+       c) `og:site_name` (meta Open Graph)
+       d) Título de página  "Nombre producto - Marca"
+       e) Patrón "Marca: X" en el HTML
 
   3. Patrón "Marca: X" en snippets de Bing — campo explícito en descripciones.
 
   4. Frecuencia de unigramas en títulos de Bing — último recurso estadístico.
 
 :author: BenjaminDTS
-:version: 6.0.0
+:version: 7.0.0
 """
 
 from __future__ import annotations
@@ -45,9 +53,10 @@ from api.core.config import get_settings
 # ── Constantes ────────────────────────────────────────────────────────────────
 
 _NUM_RESULTADOS = 6
-_MAX_URLS_PASO2 = 3          # Número máximo de URLs a intentar en el paso 2
+_MAX_URLS_PASO2 = 2          # URLs a visitar con Selenium en el paso 2
 _MIN_LONGITUD_PALABRA = 3
 _HTTP_TIMEOUT_S = 6
+_SELENIUM_PAGE_TIMEOUT_S = 8
 
 # APIs Open*Facts — misma estructura, distintas bases de datos.
 _OPEN_FACTS_APIS: tuple[str, ...] = (
@@ -57,40 +66,35 @@ _OPEN_FACTS_APIS: tuple[str, ...] = (
     "https://world.openbeautyfacts.org/api/v0/product/{ean}.json",
 )
 
+# UPC Item DB — base de datos generalista de códigos de barras (tier gratuito)
+_UPC_ITEM_DB_URL = "https://api.upcitemdb.com/prod/trial/lookup?upc={ean}"
+
 # URL de búsqueda en Bing
 _BING_URL = "https://www.bing.com/search?q={query}&setlang=es"
 
 # Selectores Bing
 _SEL_RESULTADOS = "#b_results"
 _SEL_TITULOS = "li.b_algo h2"
-_SEL_ENLACES_ORGANICOS = "li.b_algo h2 a"   # resultados orgánicos (prioritario)
+_SEL_ENLACES_ORGANICOS = "li.b_algo h2 a"
 _SEL_SNIPPETS = "li.b_algo .b_caption p"
 _SEL_COOKIES = "#bnp_btn_accept, .bnp_btn_accept, button[id*='accept']"
 
 # Dominios de Bing/Microsoft que hay que excluir al buscar URLs de producto
 _DOMINIOS_EXCLUIDOS = ("bing.com", "microsoft.com", "msn.com", "live.com")
 
-# Cabeceras HTTP para parecer un navegador normal
-_HEADERS_HTTP = {
-    "User-Agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/124.0.0.0 Safari/537.36"
-    ),
-    "Accept-Language": "es-ES,es;q=0.9",
-}
+# Cabeceras HTTP para las llamadas a APIs (Open*Facts, UPC Item DB)
+_HEADERS_API = {"User-Agent": "Harvist/1.0"}
 
-# Patrón para "Marca: X" en snippets (paso 3)
+# Separadores "Nombre producto <sep> Marca" en títulos de página de e-commerce
+_SEPARADORES_TITULO: tuple[str, ...] = (" - ", " | ", " – ", " · ", " — ")
+
+# Patrón para "Marca: X" en snippets y HTML (paso 3 / fallback paso 2)
 _PATRON_MARCA: re.Pattern[str] = re.compile(
     r'(?:marca|fabricante|manufacturer|brand)\s*[:\s·]\s*'
     r'([\w\u00C0-\u024F][\w\u00C0-\u024F\s\-&]{1,30}?)'
     r'(?=\s*[|·,;\n\r]|\s{2,}|$)',
     re.IGNORECASE,
 )
-
-# Separadores comunes entre nombre de producto y marca en el título de página
-# Ej: "Collar para perro - Trixie" | "Collar para perro | Trixie"
-_SEPARADORES_TITULO: tuple[str, ...] = (" - ", " | ", " – ", " · ", " — ")
 
 # Filtros para el paso 4 (frecuencia de títulos)
 _PALABRAS_COMERCIALES: frozenset[str] = frozenset({
@@ -131,7 +135,7 @@ class ResultadoMarca:
 
 class EanBrandResolver:
     """
-    Resuelve EAN a nombre de marca mediante una cascada de cuatro estrategias.
+    Resuelve EAN a nombre de marca mediante una cascada de estrategias.
 
     :author: BenjaminDTS
     """
@@ -150,9 +154,6 @@ class EanBrandResolver:
     def _descartar_cookies(driver: WebDriver) -> None:
         """
         Descarta el banner de consentimiento de cookies de Bing si está presente.
-
-        Se puede llamar tanto al inicio de la sesión como antes de cada búsqueda,
-        ya que Bing puede volver a mostrar el banner en cualquier carga de página.
 
         Args:
             driver: WebDriver con cualquier página de Bing cargada o cargándose.
@@ -188,17 +189,42 @@ class EanBrandResolver:
         """
         resultado = ResultadoMarca(codigo=codigo, ean=ean)
 
+        # ── Guardia: EAN no numérico → no resoluble ────────────────────────────
+        # Los pasos 1, 1b y 2 requieren un EAN de 8-14 dígitos. Buscar en Bing
+        # un código como "LECHUGA ICEBERG" devolvería resultados del producto en
+        # cuestión, no de una marca, generando falsos positivos.
+        if not self._es_ean_numerico(ean):
+            resultado.error = (
+                "El código no es un EAN numérico válido "
+                "(debe tener entre 8 y 14 dígitos)."
+            )
+            logger.debug(
+                "EAN no numérico, omitido",
+                extra={"codigo": codigo, "ean": ean},
+            )
+            return resultado
+
         # ── Paso 1: APIs Open*Facts ───────────────────────────────────────────
-        if self._es_ean_numerico(ean):
-            marca = self._buscar_en_api(ean)
-            if marca:
-                resultado.marca_detectada = marca
-                resultado.exitoso = True
-                logger.info(
-                    "Marca resuelta — API Open*Facts",
-                    extra={"codigo": codigo, "ean": ean, "marca": marca},
-                )
-                return resultado
+        marca = self._buscar_en_open_facts(ean)
+        if marca:
+            resultado.marca_detectada = marca
+            resultado.exitoso = True
+            logger.info(
+                "Marca resuelta — Open*Facts",
+                extra={"codigo": codigo, "ean": ean, "marca": marca},
+            )
+            return resultado
+
+        # ── Paso 1b: UPC Item DB ──────────────────────────────────────────────
+        marca = self._buscar_en_upc_db(ean)
+        if marca:
+            resultado.marca_detectada = marca
+            resultado.exitoso = True
+            logger.info(
+                "Marca resuelta — UPC Item DB",
+                extra={"codigo": codigo, "ean": ean, "marca": marca},
+            )
+            return resultado
 
         # ── Buscar en Bing (pasos 2, 3 y 4) ──────────────────────────────────
         settings = get_settings()
@@ -207,14 +233,11 @@ class EanBrandResolver:
         try:
             url_busqueda = _BING_URL.format(query=quote_plus(f'"{ean}"'))
             driver.get(url_busqueda)
-            # Descartar el banner de cookies si vuelve a aparecer en la búsqueda
             self._descartar_cookies(driver)
             wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, _SEL_RESULTADOS)))
             time.sleep(0.4)
 
-            # URLs de los primeros resultados para el paso 2.
-            # Si Bing no muestra resultados orgánicos (li.b_algo vacío) se usa
-            # un selector ampliado que cubre también paneles de compras.
+            # Extraer URLs, títulos y snippets ANTES de navegar a otra página
             enlaces = self._obtener_enlaces_resultado(driver, n=_MAX_URLS_PASO2)
 
             titulos: list[str] = [
@@ -238,14 +261,16 @@ class EanBrandResolver:
             )
             return resultado
 
-        # ── Paso 2: extracción de marca en las primeras URLs de resultado ─────
+        # ── Paso 2: visita Selenium de las primeras URLs ──────────────────────
+        # Usamos el driver (navegador real) en lugar de requests para sortear
+        # la protección anti-bot de muchas tiendas online.
         for enlace in enlaces:
-            marca = self._extraer_de_pagina(enlace)
+            marca = self._extraer_de_pagina_con_driver(enlace, driver)
             if marca:
                 resultado.marca_detectada = marca
                 resultado.exitoso = True
                 logger.info(
-                    "Marca resuelta — página producto",
+                    "Marca resuelta — página producto (Selenium)",
                     extra={"codigo": codigo, "ean": ean, "marca": marca, "url": enlace},
                 )
                 return resultado
@@ -274,7 +299,7 @@ class EanBrandResolver:
 
         return resultado
 
-    # ── Paso 1: APIs ─────────────────────────────────────────────────────────
+    # ── Paso 1: Open*Facts ────────────────────────────────────────────────────
 
     @staticmethod
     def _es_ean_numerico(ean: str) -> bool:
@@ -282,7 +307,7 @@ class EanBrandResolver:
         return bool(re.fullmatch(r"\d{8,14}", ean.strip()))
 
     @staticmethod
-    def _buscar_en_api(ean: str) -> str:
+    def _buscar_en_open_facts(ean: str) -> str:
         """
         Consulta las APIs Open*Facts en cascada para obtener el campo `brands`.
 
@@ -297,7 +322,7 @@ class EanBrandResolver:
                 resp = http_requests.get(
                     url_tpl.format(ean=ean),
                     timeout=_HTTP_TIMEOUT_S,
-                    headers={"User-Agent": "Harvist/1.0"},
+                    headers=_HEADERS_API,
                 )
                 if not resp.ok:
                     continue
@@ -317,10 +342,48 @@ class EanBrandResolver:
                 )
         return ""
 
-    # ── Paso 2: extracción desde páginas de producto ──────────────────────────
+    # ── Paso 1b: UPC Item DB ──────────────────────────────────────────────────
 
     @staticmethod
-    def _obtener_enlaces_resultado(driver: WebDriver, n: int = 3) -> list[str]:
+    def _buscar_en_upc_db(ean: str) -> str:
+        """
+        Consulta UPC Item DB para obtener la marca del producto.
+
+        Base de datos generalista que complementa a Open*Facts para productos
+        no alimenticios (electrónica, mascotas, hogar, etc.).
+
+        Args:
+            ean: código EAN numérico del producto.
+
+        Returns:
+            Marca en Title Case, o cadena vacía si no se encuentra.
+        """
+        try:
+            resp = http_requests.get(
+                _UPC_ITEM_DB_URL.format(ean=ean),
+                timeout=_HTTP_TIMEOUT_S,
+                headers=_HEADERS_API,
+            )
+            if not resp.ok:
+                return ""
+            data = resp.json()
+            items = data.get("items", [])
+            if items:
+                brand: str = items[0].get("brand", "").strip()
+                if brand:
+                    return brand.title()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "Error en UPC Item DB",
+                exc_info=exc,
+                extra={"ean": ean},
+            )
+        return ""
+
+    # ── Paso 2: visita Selenium de páginas de producto ────────────────────────
+
+    @staticmethod
+    def _obtener_enlaces_resultado(driver: WebDriver, n: int = 2) -> list[str]:
         """
         Extrae hasta N URLs de resultados de Bing, excluyendo dominios propios.
 
@@ -345,7 +408,6 @@ class EanBrandResolver:
         hrefs: list[str] = []
 
         try:
-            # Prioridad: resultados orgánicos
             for el in driver.find_elements(By.CSS_SELECTOR, _SEL_ENLACES_ORGANICOS):
                 href = el.get_attribute("href") or ""
                 if _es_externo(href) and href not in hrefs:
@@ -353,7 +415,6 @@ class EanBrandResolver:
                 if len(hrefs) >= n:
                     return hrefs
 
-            # Fallback: cualquier enlace externo en el contenedor de resultados
             if not hrefs:
                 for el in driver.find_elements(By.CSS_SELECTOR, "#b_results a[href]"):
                     href = el.get_attribute("href") or ""
@@ -368,111 +429,126 @@ class EanBrandResolver:
         return hrefs
 
     @staticmethod
-    def _extraer_de_pagina(url: str) -> str:
+    def _extraer_de_pagina_con_driver(url: str, driver: WebDriver) -> str:
         """
-        Descarga la página del resultado y extrae la marca con múltiples estrategias.
+        Navega a la URL con el driver Selenium y extrae la marca de la página.
 
-        Orden de preferencia:
-        1. JSON-LD `{"@type":"Product","brand":{"name":"X"}}` (Schema.org)
-        2. `itemprop="brand"` (microdata)
-        3. `og:site_name` (meta Open Graph — suele ser el nombre de la tienda/marca)
-        4. Título de página con patrón "Producto - Marca" / "Producto | Marca"
-        5. Patrón "Marca: X" directo en el HTML
+        Usar el driver en lugar de `requests` evita el bloqueo anti-bot y
+        permite obtener el HTML completo tras la ejecución de JavaScript.
 
         Args:
-            url: URL de un resultado de Bing.
+            url: URL de la página del producto.
+            driver: WebDriver activo.
 
         Returns:
             Nombre de marca en Title Case, o cadena vacía si no se encuentra.
         """
         try:
-            resp = http_requests.get(
-                url,
-                timeout=_HTTP_TIMEOUT_S,
-                headers=_HEADERS_HTTP,
-                allow_redirects=True,
+            driver.get(url)
+            WebDriverWait(driver, _SELENIUM_PAGE_TIMEOUT_S).until(
+                EC.presence_of_element_located((By.TAG_NAME, "body"))
             )
-            if not resp.ok:
-                return ""
-
-            html = resp.text
-
-            # ── 1. JSON-LD con @type Product ──────────────────────────────────
-            for ld_raw in re.findall(
-                r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
-                html,
-                re.DOTALL | re.IGNORECASE,
-            ):
-                try:
-                    ld = json.loads(ld_raw.strip())
-                    items = ld if isinstance(ld, list) else [ld]
-                    for item in items:
-                        if not isinstance(item, dict):
-                            continue
-                        tipo = item.get("@type", "")
-                        if isinstance(tipo, list):
-                            tipo = " ".join(tipo)
-                        if "product" not in tipo.lower():
-                            continue
-                        brand = item.get("brand", {})
-                        if isinstance(brand, dict):
-                            nombre = brand.get("name", "")
-                        elif isinstance(brand, str):
-                            nombre = brand
-                        else:
-                            nombre = ""
-                        if nombre and nombre.strip():
-                            return nombre.strip().title()
-                except (json.JSONDecodeError, AttributeError, TypeError):
-                    continue
-
-            # ── 2. itemprop="brand" ───────────────────────────────────────────
-            m = re.search(
-                r'itemprop=["\']brand["\'][^>]*>(?:<[^>]+>)*([^<]{2,40})',
-                html,
-                re.IGNORECASE,
+            time.sleep(0.5)   # margen para que el JS inicialice el JSON-LD
+            return EanBrandResolver._extraer_marca_de_html(driver.page_source)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "Error en visita Selenium de página",
+                exc_info=exc,
+                extra={"url": url},
             )
-            if m:
-                valor = m.group(1).strip()
-                if valor:
-                    return valor.title()
+            return ""
 
-            # ── 3. og:site_name ───────────────────────────────────────────────
-            for patron_og in (
-                r'<meta[^>]+property=["\']og:site_name["\'][^>]+content=["\']([^"\']{2,50})["\']',
-                r'<meta[^>]+content=["\']([^"\']{2,50})["\'][^>]+property=["\']og:site_name["\']',
-            ):
-                m = re.search(patron_og, html, re.IGNORECASE)
-                if m:
-                    valor = m.group(1).strip()
-                    palabras = valor.split()
-                    if 1 <= len(palabras) <= 4 and not any(p.isdigit() for p in palabras):
-                        return valor.title()
+    @staticmethod
+    def _extraer_marca_de_html(html: str) -> str:
+        """
+        Extrae el nombre de marca de un HTML de página de producto.
 
-            # ── 4. Título de página "Producto - Marca" ────────────────────────
-            m = re.search(r'<title[^>]*>([^<]{5,150})</title>', html, re.IGNORECASE)
-            if m:
-                titulo_pag = _html_lib.unescape(m.group(1)).strip()
-                for sep in _SEPARADORES_TITULO:
-                    partes = titulo_pag.rsplit(sep, 1)
-                    if len(partes) == 2:
-                        candidato = partes[1].strip()
-                        palabras = candidato.split()
-                        if 1 <= len(palabras) <= 4 and not any(
-                            c.isdigit() for c in candidato
-                        ):
-                            return candidato.title()
+        Orden de preferencia:
+          1. JSON-LD Schema.org  ``{"@type":"Product","brand":{"name":"X"}}``
+          2. ``itemprop="brand"`` (microdata)
+          3. ``og:site_name`` (meta Open Graph)
+          4. Título de página  "Nombre producto - Marca"
+          5. Patrón "Marca: X" en el HTML
 
-            # ── 5. "Marca: X" en el HTML de la página ────────────────────────
-            m = re.search(_PATRON_MARCA, html)
+        Args:
+            html: contenido HTML completo de la página.
+
+        Returns:
+            Nombre de marca en Title Case, o cadena vacía si no se encuentra.
+        """
+        # ── 1. JSON-LD con @type Product ──────────────────────────────────────
+        for ld_raw in re.findall(
+            r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+            html,
+            re.DOTALL | re.IGNORECASE,
+        ):
+            try:
+                ld = json.loads(ld_raw.strip())
+                items = ld if isinstance(ld, list) else [ld]
+                for item in items:
+                    if not isinstance(item, dict):
+                        continue
+                    tipo = item.get("@type", "")
+                    if isinstance(tipo, list):
+                        tipo = " ".join(tipo)
+                    if "product" not in tipo.lower():
+                        continue
+                    brand = item.get("brand", {})
+                    if isinstance(brand, dict):
+                        nombre = brand.get("name", "")
+                    elif isinstance(brand, str):
+                        nombre = brand
+                    else:
+                        nombre = ""
+                    if nombre and nombre.strip():
+                        return nombre.strip().title()
+            except (json.JSONDecodeError, AttributeError, TypeError):
+                continue
+
+        # ── 2. itemprop="brand" ───────────────────────────────────────────────
+        m = re.search(
+            r'itemprop=["\']brand["\'][^>]*>(?:<[^>]+>)*([^<]{2,40})',
+            html,
+            re.IGNORECASE,
+        )
+        if m:
+            valor = m.group(1).strip()
+            if valor:
+                return valor.title()
+
+        # ── 3. og:site_name ───────────────────────────────────────────────────
+        for patron_og in (
+            r'<meta[^>]+property=["\']og:site_name["\'][^>]+content=["\']([^"\']{2,50})["\']',
+            r'<meta[^>]+content=["\']([^"\']{2,50})["\'][^>]+property=["\']og:site_name["\']',
+        ):
+            m = re.search(patron_og, html, re.IGNORECASE)
             if m:
                 valor = m.group(1).strip()
                 palabras = valor.split()
                 if 1 <= len(palabras) <= 4 and not any(p.isdigit() for p in palabras):
                     return valor.title()
 
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Error extrayendo marca de página", exc_info=exc, extra={"url": url})
+        # ── 4. Título de página "Producto - Marca" ────────────────────────────
+        m = re.search(r'<title[^>]*>([^<]{5,150})</title>', html, re.IGNORECASE)
+        if m:
+            titulo_pag = _html_lib.unescape(m.group(1)).strip()
+            for sep in _SEPARADORES_TITULO:
+                partes = titulo_pag.rsplit(sep, 1)
+                if len(partes) == 2:
+                    candidato = partes[1].strip()
+                    palabras = candidato.split()
+                    if 1 <= len(palabras) <= 4 and not any(
+                        c.isdigit() for c in candidato
+                    ):
+                        return candidato.title()
+
+        # ── 5. "Marca: X" en el HTML de la página ────────────────────────────
+        m = re.search(_PATRON_MARCA, html)
+        if m:
+            valor = m.group(1).strip()
+            palabras = valor.split()
+            if 1 <= len(palabras) <= 4 and not any(p.isdigit() for p in palabras):
+                return valor.title()
 
         return ""
 


### PR DESCRIPTION
…m DB, use Selenium for page visits

- Non-numeric EANs (e.g. "LECHUGA ICEBERG") now return immediately with exitoso=False instead of searching Bing and extracting garbage words
- Add UPC Item DB API (step 1b) as a free generalista barcode database that complements Open*Facts for non-food products
- Replace requests with Selenium driver for product page visits (step 2): real browser bypasses anti-bot protection and executes JavaScript, fixing failures on sites that block requests with 403
- Extract _extraer_marca_de_html as shared method used by Selenium path