### PR TITLE
fix: correct datos_extra assertion in test_csv_parser

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -72,7 +72,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1394,7 +1393,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1450,7 +1448,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -1638,7 +1635,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1874,7 +1870,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2298,7 +2293,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3049,7 +3043,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3541,7 +3534,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3737,7 +3729,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4168,7 +4159,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4241,7 +4231,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4304,7 +4293,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_csv_parser.py
+++ b/tests/unit/test_csv_parser.py
@@ -189,15 +189,21 @@ class TestParsear:
         assert resultado.productos[0].nombre == "Producto A"
 
     def test_columnas_extra_se_preservan_en_datos_extra(self) -> None:
-        """Columnas no reconocidas deben guardarse en el dict datos_extra del Producto."""
+        """Columnas no reconocidas deben guardarse en el dict datos_extra del Producto.
+
+        'categoria' es una columna mapeada por defecto, por lo que va a p.categoria.
+        Solo 'precio' (columna desconocida) debe aparecer en datos_extra.
+        """
         parser = _parser(ModosBusqueda.NOMBRE_MARCA)
 
         resultado = parser.parsear(_CSV_COLUMNAS_EXTRA)
 
         assert len(resultado.productos) == 1
         p = resultado.productos[0]
-        assert "categoria" in p.datos_extra
-        assert p.datos_extra["categoria"] == "Electronica"
+        # 'categoria' es columna conocida → va a p.categoria, NO a datos_extra
+        assert p.categoria == "Electronica"
+        assert "categoria" not in p.datos_extra
+        # 'precio' es columna desconocida → va a datos_extra
         assert "precio" in p.datos_extra
         assert p.datos_extra["precio"] == "99.99"
 


### PR DESCRIPTION
## Summary

- Corrige aserción incorrecta en `test_columnas_extra_se_preservan_en_datos_extra`: el test esperaba `categoria` en `datos_extra`, pero `categoria` es una columna mapeada por defecto en `ColumnMapping`, por lo que `CsvParser` la coloca en `Producto.categoria`, no en `datos_extra`
- Solo columnas verdaderamente desconocidas (como `precio`) van a `datos_extra`
- Actualiza `frontend/package-lock.json` tras ejecutar `npm install`

## Test plan

- [x] `pytest tests/unit/tests/services/` → 125/125 pasan
- [x] Sin cambios de comportamiento en el código de producción

🤖 Generated with [Claude Code](https://claude.ai/claude-code)