### PR TITLE
fix: update Vite proxy targets from port 8000 to 8001

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ $RECYCLE.BIN/
 .idea/
 *.suo
 *.sw?
+
+.githooks

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,12 +21,12 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: 'http://localhost:8001',
         changeOrigin: true,
         ws: true,
       },
       '/ws': {
-        target: 'ws://localhost:8000',
+        target: 'ws://localhost:8001',
         ws: true,
         changeOrigin: true,
       },


### PR DESCRIPTION
## Summary

- Puerto 8000 estaba ocupado por `cuadernofp_nginx` (Docker), por lo que FastAPI se movió al 8001
- El proxy de Vite no se actualizó en su momento, causando que las llamadas `/api` y `/ws` desde el frontend fallasen en desarrollo
- Actualiza ambas entradas del proxy (`/api` y `/ws`) a `localhost:8001`

## Test plan

- [ ] Arrancar FastAPI en el puerto 8001: `python -m uvicorn api.main:app --port 8001`
- [ ] Arrancar Vite: `npm run dev` en `frontend/`
- [ ] Verificar que `http://localhost:5173` carga y las llamadas a `/api/v1/jobs` responden correctamente (sin errores CORS ni 502)

🤖 Generated with [Claude Code](https://claude.com/claude-code)