### PR TITLE
fix: persist jobs across server restarts (Redis AOF + startup recovery)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -6,19 +6,108 @@ inicializa el logging y aplica los middlewares de seguridad.
 Importar como: uvicorn api.main:app
 
 :author: BenjaminDTS
-:version: 1.0.0
+:version: 1.1.0
 """
 
 from contextlib import asynccontextmanager
+from datetime import datetime
 from typing import AsyncGenerator
 
+import redis.asyncio as aioredis
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from loguru import logger
 
-from api.core.config import get_settings
+from api.core.config import Settings, get_settings
 from api.core.logging import setup_logging
 from api.core.security import apply_security_middleware
+
+_HISTORY_KEY = "jobs:history"
+_JOB_KEY = "job:{job_id}"
+
+
+async def _recuperar_jobs_interrumpidos(settings: Settings) -> None:
+    """
+    Detecta jobs que quedaron en estado EN_PROCESO o PENDIENTE debido a un
+    reinicio del servidor y los marca como FALLIDO.
+
+    Esto permite al usuario verlos en el historial y reanudarlos manualmente.
+    Si Redis no está disponible en el arranque, se omite sin bloquear el inicio.
+
+    Args:
+        settings: configuración de la aplicación con la URL de Redis.
+    """
+    from api.v1.schemas.job import EstadoJob, JobStatus
+
+    redis_client: aioredis.Redis | None = None
+    try:
+        redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+        await redis_client.ping()
+    except Exception as exc:
+        logger.warning(
+            "Redis no disponible en el arranque — se omite la recuperación de jobs",
+            exc_info=exc,
+        )
+        if redis_client is not None:
+            await redis_client.aclose()
+        return
+
+    try:
+        job_ids: list[str] = await redis_client.zrevrange(_HISTORY_KEY, 0, -1)
+        if not job_ids:
+            return
+
+        # Leer todos los estados en un solo round-trip
+        pipe_read = redis_client.pipeline()
+        for job_id in job_ids:
+            pipe_read.get(_JOB_KEY.format(job_id=job_id))
+        raw_values: list[str | None] = await pipe_read.execute()
+
+        # Identificar los interrumpidos y actualizarlos en otro pipeline
+        pipe_write = redis_client.pipeline()
+        recuperados = 0
+        for job_id, raw in zip(job_ids, raw_values):
+            if raw is None:
+                continue
+            try:
+                status = JobStatus.model_validate_json(raw)
+            except Exception:
+                continue
+
+            if status.estado not in (EstadoJob.EN_PROCESO, EstadoJob.PENDIENTE):
+                continue
+
+            status.estado = EstadoJob.FALLIDO
+            status.error = "Servidor reiniciado durante la ejecución."
+            status.mensaje = (
+                "El servidor se reinició mientras este trabajo estaba en proceso. "
+                "Puedes reanudarlo desde el historial."
+            )
+            status.actualizado_en = datetime.utcnow()
+            # keepttl=True preserva el TTL original sin restablecerlo
+            pipe_write.set(
+                _JOB_KEY.format(job_id=job_id),
+                status.model_dump_json(),
+                keepttl=True,
+            )
+            recuperados += 1
+
+        if recuperados:
+            await pipe_write.execute()
+            logger.warning(
+                "Jobs interrumpidos marcados como FALLIDO al reiniciar",
+                extra={"total_recuperados": recuperados},
+            )
+        else:
+            logger.debug("Sin jobs interrumpidos detectados en el arranque")
+
+    except Exception as exc:
+        logger.error(
+            "Error durante la recuperación de jobs interrumpidos",
+            exc_info=exc,
+        )
+    finally:
+        await redis_client.aclose()
 
 
 @asynccontextmanager
@@ -26,10 +115,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """
     Gestor de ciclo de vida de la aplicación (startup / shutdown).
 
-    Se ejecuta antes de que la app empiece a servir tráfico (yield)
-    y después de que pare (post-yield). Aquí se validan las dependencias
-    externas (Redis, directorios de salida) para fallar rápido si algo
-    no está disponible.
+    En el arranque:
+      1. Crea el directorio de salida si no existe.
+      2. Detecta jobs interrumpidos en Redis y los marca como FALLIDO.
 
     Args:
         app: instancia FastAPI gestionada.
@@ -43,6 +131,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     from pathlib import Path
     output_path = Path(settings.output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
+
+    # Marcar como FALLIDO los jobs que quedaron activos antes del reinicio
+    await _recuperar_jobs_interrumpidos(settings)
 
     logger.info(
         "Aplicación iniciada",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+# Servicios de infraestructura para desarrollo local de Harvist.
+#
+# Uso:
+#   docker compose up -d        Arrancar Redis en segundo plano
+#   docker compose down         Parar y conservar los datos (volumen persiste)
+#   docker compose down -v      Parar Y borrar todos los datos
+#
+# Redis se configura con AOF (Append Only File): los datos sobreviven
+# reinicios del container. appendfsync everysec equilibra rendimiento
+# y durabilidad sin riesgo de pérdida de más de 1 segundo de escrituras.
+#
+# @author BenjaminDTS
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: harvist-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - harvist-redis-data:/data
+    command: redis-server --appendonly yes --appendfsync everysec
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  harvist-redis-data:
+    name: harvist-redis-data


### PR DESCRIPTION
## Problema

Al cerrar la aplicación y volver a abrirla, todos los trabajos del historial desaparecían. Había dos causas independientes:

1. **Redis sin persistencia** — el container arrancaba en modo solo-memoria. Al parar Docker, todos los datos (estados, CSV, historial) se perdían irremediablemente.
2. **Jobs huérfanos** — si FastAPI o Celery se reiniciaban con un job en `EN_PROCESO`, nadie lo marcaba como fallido. Quedaba bloqueado en ese estado para siempre, sin poder reanudarse.

## Solución

### `docker-compose.yml` (nuevo)
- Sustituye el `docker run` manual por un compose con Redis configurado con **AOF** (`appendonly yes`, `appendfsync everysec`).
- Volumen nombrado `harvist-redis-data` que sobrevive a `docker compose down` (usar `-v` para borrar datos).
- `restart: unless-stopped` para que Redis arranque automáticamente con Docker Desktop.
- Healthcheck incluido.

### `api/main.py` — hook de startup
- Nueva función `_recuperar_jobs_interrumpidos()` ejecutada en el `lifespan` antes de servir tráfico.
- Escanea `jobs:history` y marca como `FALLIDO` todos los jobs en estado `EN_PROCESO` o `PENDIENTE`.
- El mensaje de error es legible: _"El servidor se reinició mientras este trabajo estaba en proceso. Puedes reanudarlo desde el historial."_
- Usa dos pipelines Redis (lectura + escritura) para minimizar round-trips.
- `keepttl=True` preserva el TTL original de cada job.
- Falla de forma silenciosa si Redis no está disponible en el arranque.

## Cómo migrar el container existente

```bash
# Parar el container antiguo (sin volumen, sin persistencia)
docker stop harvist-redis && docker rm harvist-redis

# Arrancar con el nuevo compose (crea el volumen automáticamente)
docker compose up -d
```

## Test plan

- [ ] `docker compose up -d` crea el container con AOF activo (`redis-cli CONFIG GET appendonly` devuelve `yes`)
- [ ] Lanzar un job de fotos, esperar a que esté en curso, parar FastAPI con Ctrl+C
- [ ] Reiniciar FastAPI — el job aparece en el historial con estado `FALLIDO` y el mensaje de reinicio
- [ ] Pulsar "Reanudar" en el historial — el job continúa desde donde se quedó
- [ ] Parar Docker Desktop y volver a arrancarlo — el historial de jobs sigue intacto

🤖 Generated with [Claude Code](https://claude.com/claude-code)