### PR TITLE
fix: correct Vite proxy target from port 8001 to 8000

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,12 +21,12 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:8001',
+        target: 'http://localhost:8000',
         changeOrigin: true,
         ws: true,
       },
       '/ws': {
-        target: 'ws://localhost:8001',
+        target: 'ws://localhost:8000',
         ws: true,
         changeOrigin: true,
       },


### PR DESCRIPTION
## Summary

- Vite proxy apuntaba a `localhost:8001` — FastAPI corre en `8000`
- Todos los endpoints del frontend devolvían 500 (historial, jobs, WS)

## Test plan

- [ ] Cargar `localhost:5173` → Historial carga sin error 500
- [ ] Lanzar job → WebSocket conecta y progreso se actualiza en tiempo real
- [ ] Verificar `vite.config.ts` proxy targets apuntan a `:8000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)