### PR TITLE
fix: extend FILE_TTL_SECONDS from 24h to 7 days

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,8 +97,8 @@ DOWNLOAD_TIMEOUT=10
 STORAGE_BACKEND=local
 # Directorio raíz (solo si STORAGE_BACKEND=local)
 OUTPUT_DIR=imagenes_descargadas
-# Tiempo de vida de los archivos de trabajo en segundos (24h por defecto)
-FILE_TTL_SECONDS=86400
+# Tiempo de vida de los archivos de trabajo en segundos (7 días por defecto)
+FILE_TTL_SECONDS=604800
  
 # ── AWS S3 (solo si STORAGE_BACKEND=s3) ──────────────────────────────────────
 AWS_S3_BUCKET=


### PR DESCRIPTION
## Summary

- `FILE_TTL_SECONDS` era 86400 (24h) — jobs con CSV grande (6000+ productos) tardan más de 24h
- El CSV expiraba en Redis antes de que el usuario pudiera reanudar → error "CSV ya no disponible"
- Nuevo valor: 604800 (7 días)

## Test plan

- [ ] Verificar `.env.example` y `.env.development` tienen `FILE_TTL_SECONDS=604800`
- [ ] Lanzar job, cancelar, esperar >24h, reanudar → debe funcionar sin error de expiración

🤖 Generated with [Claude Code](https://claude.com/claude-code)