### PR TITLE
feat(fase7.2): automatic translation of product descriptions

### DIFF
--- a/api/v1/endpoints/files.py
+++ b/api/v1/endpoints/files.py
@@ -2,24 +2,26 @@
 Endpoints para la gestión de archivos generados por los trabajos de scraping.
 
 Rutas expuestas:
-  GET    /api/v1/files/{job_id}        — Descargar el ZIP de imágenes (job fotos)
-  GET    /api/v1/files/{job_id}/csv    — Descargar el CSV de descripciones (job descripciones)
-  GET    /api/v1/files/{job_id}/seo    — (Fase 7.1) Descargar CSV de textos SEO (meta_title + meta_description)
-  GET    /api/v1/files/{job_id}/brands — (Fase 6) Descargar fichas de marca JSON
-  DELETE /api/v1/files/{job_id}        — Eliminar los archivos de un job
+  GET    /api/v1/files/{job_id}                        — Descargar el ZIP de imágenes (job fotos)
+  GET    /api/v1/files/{job_id}/csv                    — Descargar el CSV de descripciones (job descripciones)
+  GET    /api/v1/files/{job_id}/seo                    — (Fase 7.1) Descargar CSV de textos SEO (meta_title + meta_description)
+  GET    /api/v1/files/{job_id}/brands                 — (Fase 6) Descargar fichas de marca JSON
+  GET    /api/v1/files/{job_id}/translations/{lang}    — (Fase 7.2) Descargar CSV de traducciones por idioma
+  DELETE /api/v1/files/{job_id}                        — Eliminar los archivos de un job
 
 Solo gestiona la capa HTTP. El acceso al sistema de archivos se delega
 a StorageService para mantener la arquitectura limpia.
 
 :author: BenjaminDTS
-:version: 1.0.0
+:version: 1.1.0
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Path
 from fastapi.responses import FileResponse, JSONResponse
 from loguru import logger
 
 from api.core.config import get_settings
+from api.v1.schemas.job import SUPPORTED_LANGUAGES
 from services.storage_service import get_storage_service
 
 router = APIRouter(prefix="/files", tags=["Files"])
@@ -244,4 +246,70 @@ async def descargar_fichas_marca(job_id: str) -> FileResponse:
         media_type="text/csv",
         filename=f"marcas_{job_id}.csv",
         headers={"Content-Disposition": f'attachment; filename="marcas_{job_id}.csv"'},
+    )
+
+
+@router.get(
+    "/{job_id}/translations/{lang}",
+    summary="Descargar CSV de traducciones de descripciones por idioma",
+    response_class=FileResponse,
+    include_in_schema=True,
+)
+async def descargar_traducciones(
+    job_id: str,
+    lang: str = Path(
+        description=f"Código ISO 639-1 del idioma destino. Valores permitidos: {SUPPORTED_LANGUAGES}.",
+        examples=["en", "fr", "de"],
+    ),
+) -> FileResponse:
+    """
+    Devuelve el CSV de traducciones para el idioma especificado (Fase 7.2).
+
+    El CSV contiene: codigo, nombre, marca, categoria,
+    descripcion_corta, descripcion_larga, keywords, meta_description.
+
+    Args:
+        job_id: identificador UUID del trabajo.
+        lang: código ISO 639-1 del idioma destino (ej: 'en', 'fr', 'de', 'it', 'pt').
+
+    Returns:
+        FileResponse con el CSV de traducciones como adjunto descargable.
+
+    Raises:
+        HTTPException 400: si el idioma no está soportado.
+        HTTPException 404: si el CSV no existe o el job no ha completado.
+
+    :author: BenjaminDTS
+    """
+    if lang not in SUPPORTED_LANGUAGES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Idioma '{lang}' no soportado. "
+                f"Idiomas válidos: {list(SUPPORTED_LANGUAGES)}."
+            ),
+        )
+
+    storage = get_storage_service()
+    csv_path = storage.get_job_dir(job_id) / f"traducciones_{lang}.csv"
+
+    if not csv_path.exists():
+        logger.warning(
+            "CSV de traducciones no encontrado",
+            extra={"job_id": job_id, "lang": lang},
+        )
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"El archivo de traducciones para '{lang}' no existe. "
+                "El job puede no haber completado aún o no se solicitó ese idioma."
+            ),
+        )
+
+    filename = f"descripciones_{lang}_{job_id[:8]}.csv"
+    return FileResponse(
+        path=str(csv_path),
+        media_type="text/csv; charset=utf-8",
+        filename=filename,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )

--- a/api/v1/endpoints/jobs.py
+++ b/api/v1/endpoints/jobs.py
@@ -167,6 +167,15 @@ async def crear_job(
         str,
         Form(description="Tipo de tienda para el prompt de IA (ej: 'tiendas de mascotas'). Vacío = usa el del .env."),
     ] = "",
+    target_languages: Annotated[
+        list[str],
+        Form(
+            description=(
+                "Idiomas destino para traducción automática (Fase 7.2). "
+                "Enviar un valor por idioma. Valores permitidos: es, en, fr, de, it, pt."
+            )
+        ),
+    ] = None,
 ) -> JSONResponse:
     """
     Recibe un CSV de inventario, encola el trabajo de scraping y devuelve el job_id.
@@ -217,6 +226,7 @@ async def crear_job(
         query_personalizada=query_personalizada or None,
         groq_api_key_usuario=groq_api_key_usuario,
         store_type_usuario=store_type_usuario,
+        target_languages=target_languages or [],
         column_mapping=ColumnMapping(
             columna_codigo=columna_codigo,
             columna_ean=columna_ean,

--- a/api/v1/schemas/job.py
+++ b/api/v1/schemas/job.py
@@ -14,8 +14,10 @@ from enum import Enum
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+
+SUPPORTED_LANGUAGES = ("es", "en", "fr", "de", "it", "pt")
 
 # ── Enums ─────────────────────────────────────────────────────────────────────
 
@@ -150,10 +152,42 @@ class SearchConfig(BaseModel):
         description="Activa generación de textos SEO (meta_title + meta_description) con Groq (Fase 7.1). "
                     "Independiente de tipo_job, puede combinarse con FOTOS o DESCRIPCIONES.",
     )
+    target_languages: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Idiomas destino para traducción automática (Fase 7.2). "
+            f"Valores permitidos: {SUPPORTED_LANGUAGES}. "
+            "Lista vacía = sin traducción."
+        ),
+        examples=[["en", "fr"]],
+    )
     column_mapping: ColumnMapping = Field(
         default_factory=ColumnMapping,
         description="Mapeo de columnas del CSV del usuario a los campos internos del parser.",
     )
+
+    @field_validator("target_languages")
+    @classmethod
+    def validar_idiomas(cls, v: list[str]) -> list[str]:
+        """
+        Valida que todos los idiomas estén en SUPPORTED_LANGUAGES y elimina duplicados.
+
+        Args:
+            v: lista de códigos de idioma.
+
+        Returns:
+            Lista deduplicada de idiomas válidos.
+
+        Raises:
+            ValueError: si algún idioma no está soportado.
+        """
+        invalidos = [lang for lang in v if lang not in SUPPORTED_LANGUAGES]
+        if invalidos:
+            raise ValueError(
+                f"Idiomas no soportados: {invalidos}. "
+                f"Idiomas válidos: {list(SUPPORTED_LANGUAGES)}"
+            )
+        return list(dict.fromkeys(v))
 
 
 # ── Schemas de entrada ────────────────────────────────────────────────────────
@@ -207,6 +241,13 @@ class JobStatus(BaseModel):
         ge=0,
         description="Contador de errores durante generación SEO (Fase 7.1).",
     )
+    traducciones_generadas: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Contador de traducciones generadas por idioma (Fase 7.2). "
+            "Ejemplo: {'en': 42, 'fr': 42}."
+        ),
+    )
     marcas_procesadas: int = Field(
         default=0,
         ge=0,
@@ -258,6 +299,7 @@ class JobProgressEvent(BaseModel):
     imagenes_fallidas: int
     descripciones_generadas: int
     seo_generados: int = 0
+    traducciones_generadas: dict[str, int] = Field(default_factory=dict)
     marcas_procesadas: int = 0
     mensaje: str
     error: str | None = None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ import { JobHistory } from '@/components/JobHistory'
 import { HomeScreen } from '@/components/HomeScreen'
 import { BrandsPanel } from '@/components/BrandsPanel'
 import { NsLogo } from '@/components/NsLogo'
-import { apiClient, getBrands, resumeJob } from '@/api/client'
+import { apiClient, getBrands, resumeJob, downloadTranslationCsv } from '@/api/client'
 import type { ApiError, BrandEntry } from '@/api/client'
 import type { SearchConfigValues, TipoJob } from '@/components/SearchConfig'
 
@@ -40,6 +40,7 @@ const App: React.FC = () => {
   const [brandsData, setBrandsData] = useState<BrandEntry[] | null>(null)
   const [brandsPanelOpen, setBrandsPanelOpen] = useState(true)
   const [brandsLoadError, setBrandsLoadError] = useState<string | null>(null)
+  const [targetLanguages, setTargetLanguages] = useState<string[]>([])
 
   // ── Handlers de HomeScreen ───────────────────────────────────────────────
 
@@ -99,6 +100,9 @@ const App: React.FC = () => {
       formData.append('columna_nombre_foto', config.columnMapping.columnaNombreFoto)
       formData.append('groq_api_key_usuario', config.groqApiKey)
       formData.append('store_type_usuario', config.storeType)
+      config.targetLanguages.forEach((lang) =>
+        formData.append('target_languages', lang)
+      )
 
       const response = await apiClient.post<{
         success: boolean
@@ -108,6 +112,7 @@ const App: React.FC = () => {
 
       setJobId(response.data.data.job_id)
       setTipoJob(config.tipoJob)
+      setTargetLanguages(config.targetLanguages)
       setAppState('running')
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Error al iniciar el trabajo.'
@@ -265,6 +270,63 @@ const App: React.FC = () => {
                 onResume={resumeLoading ? undefined : handleResume}
               />
             )}
+
+            {/* Traducciones disponibles — visible cuando job de descripciones termina con idiomas seleccionados */}
+            {appState === 'done' &&
+              tipoJob === 'descripciones' &&
+              jobId !== null &&
+              targetLanguages.length > 0 && (
+                <section
+                  className="w-full max-w-2xl mx-auto rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4"
+                  aria-label="Descargar traducciones"
+                >
+                  <p className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+                    Traducciones generadas
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {(
+                      [
+                        { code: 'en', label: 'Inglés' },
+                        { code: 'fr', label: 'Francés' },
+                        { code: 'de', label: 'Alemán' },
+                        { code: 'it', label: 'Italiano' },
+                        { code: 'pt', label: 'Portugués' },
+                      ] as const
+                    )
+                      .filter(({ code }) => targetLanguages.includes(code))
+                      .map(({ code, label }) => (
+                        <button
+                          key={code}
+                          type="button"
+                          onClick={async () => {
+                            try {
+                              const blob = await downloadTranslationCsv(jobId, code)
+                              const url = URL.createObjectURL(blob)
+                              const a = document.createElement('a')
+                              a.href = url
+                              a.download = `descripciones_${code}_${jobId.slice(0, 8)}.csv`
+                              a.click()
+                              URL.revokeObjectURL(url)
+                            } catch {
+                              // Error silencioso — el botón simplemente no descarga
+                            }
+                          }}
+                          className={
+                            "flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors duration-150 " +
+                            "bg-green-50 dark:bg-green-900/20 border-green-300 dark:border-green-700 " +
+                            "text-green-700 dark:text-green-300 hover:bg-green-100 dark:hover:bg-green-900/40"
+                          }
+                          aria-label={`Descargar CSV en ${label}`}
+                        >
+                          <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                            <path d="M8 12l-4.5-4.5 1.06-1.06L7 9.38V2h2v7.38l2.44-2.94 1.06 1.06L8 12zM2 14h12v-2H2v2z" />
+                          </svg>
+                          {label}
+                        </button>
+                      ))}
+                  </div>
+                </section>
+              )}
 
             {/* Error al cargar marcas */}
             {appState === 'done' && tipoJob === 'marcas' && brandsLoadError !== null && (

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -156,3 +156,18 @@ export async function downloadBrandsCsv(jobId: string): Promise<Blob> {
   )
   return response.data
 }
+
+/**
+ * Descarga el CSV de traducciones para un idioma destino (Fase 7.2).
+ *
+ * @param jobId - Identificador UUID del job.
+ * @param lang  - Código ISO 639-1 del idioma (ej: 'en', 'fr').
+ * @returns Blob con el contenido del CSV de traducciones.
+ */
+export async function downloadTranslationCsv(jobId: string, lang: string): Promise<Blob> {
+  const response = await apiClient.get<Blob>(
+    `/files/${jobId}/translations/${lang}`,
+    { responseType: 'blob' },
+  )
+  return response.data
+}

--- a/frontend/src/components/SearchConfig.tsx
+++ b/frontend/src/components/SearchConfig.tsx
@@ -58,6 +58,8 @@ export interface SearchConfigValues {
   groqApiKey: string;
   /** Tipo de tienda inyectado en el prompt (ej: 'tiendas de mascotas'). Vacío = usa el del servidor. */
   storeType: string;
+  /** Idiomas destino para traducción automática (Fase 7.2). Lista vacía = sin traducción. */
+  targetLanguages: string[];
 }
 
 /**
@@ -334,6 +336,7 @@ export const SearchConfig: React.FC<SearchConfigProps> = ({
   const [columnaNombreFoto, setColumnaNombreFoto] = useState<string>("");
   const [groqApiKey, setGroqApiKey] = useState<string>("");
   const [storeType, setStoreType] = useState<string>("");
+  const [targetLanguages, setTargetLanguages] = useState<string[]>([]);
 
   /** Indica si `onLaunch` está en curso para bloquear el botón y mostrar spinner. */
   const [launching, setLaunching] = useState<boolean>(false);
@@ -376,6 +379,7 @@ export const SearchConfig: React.FC<SearchConfigProps> = ({
         },
         groqApiKey,
         storeType,
+        targetLanguages,
       });
     } finally {
       // Siempre desbloquear, incluso si onLaunch lanza una excepción.
@@ -396,6 +400,7 @@ export const SearchConfig: React.FC<SearchConfigProps> = ({
     columnaNombreFoto,
     groqApiKey,
     storeType,
+    targetLanguages,
   ]);
 
   // ── Render ───────────────────────────────────────────────────────────────────
@@ -834,6 +839,83 @@ export const SearchConfig: React.FC<SearchConfigProps> = ({
               Ejemplos: <em>tiendas de mascotas</em>, <em>ferreterías</em>, <em>ropa deportiva</em>.
               Vacío = usa el valor del servidor.
             </p>
+          </div>
+
+          {/* ── Traducción automática (Fase 7.2) ── */}
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+              Traducción automática
+            </span>
+            <p className="text-xs text-gray-400 dark:text-gray-500">
+              Genera un CSV de traducciones por cada idioma seleccionado (además del español).
+            </p>
+            <div
+              role="group"
+              aria-label="Idiomas para traducción automática"
+              className="flex flex-wrap gap-2"
+            >
+              {(
+                [
+                  { code: "en", label: "Inglés" },
+                  { code: "fr", label: "Francés" },
+                  { code: "de", label: "Alemán" },
+                  { code: "it", label: "Italiano" },
+                  { code: "pt", label: "Portugués" },
+                ] as const
+              ).map(({ code, label }) => {
+                const checked = targetLanguages.includes(code);
+                return (
+                  <label
+                    key={code}
+                    className={
+                      "flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium cursor-pointer select-none transition-colors duration-150 " +
+                      (checked
+                        ? "bg-blue-50 dark:bg-blue-900/30 border-blue-400 dark:border-blue-500 text-blue-700 dark:text-blue-300"
+                        : "bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-blue-300 dark:hover:border-blue-600")
+                    }
+                  >
+                    <input
+                      type="checkbox"
+                      className="sr-only"
+                      checked={checked}
+                      onChange={() =>
+                        setTargetLanguages((prev) =>
+                          checked ? prev.filter((l) => l !== code) : [...prev, code]
+                        )
+                      }
+                      aria-label={`Traducir al ${label}`}
+                    />
+                    <span
+                      aria-hidden="true"
+                      className={
+                        "w-3.5 h-3.5 rounded border flex items-center justify-center shrink-0 " +
+                        (checked
+                          ? "bg-blue-500 border-blue-500"
+                          : "bg-white dark:bg-gray-700 border-gray-400 dark:border-gray-500")
+                      }
+                    >
+                      {checked && (
+                        <svg
+                          className="w-2.5 h-2.5 text-white"
+                          viewBox="0 0 10 8"
+                          fill="none"
+                          aria-hidden="true"
+                        >
+                          <path
+                            d="M1 4l2.5 2.5L9 1"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      )}
+                    </span>
+                    {label}
+                  </label>
+                );
+              })}
+            </div>
           </div>
         </fieldset>
       )}

--- a/services/ai/description_generator.py
+++ b/services/ai/description_generator.py
@@ -49,6 +49,25 @@ _PROMPT_DEFAULT = (
     "}}]}}"
 )
 
+_PROMPT_TRADUCCION = (
+    "Eres un traductor experto en catálogos de productos de {store_type}. "
+    "Traduce las descripciones de los siguientes productos al idioma: {idioma_destino}.\n\n"
+    "{productos_json}\n\n"
+    "REGLAS ESTRICTAS:\n"
+    "1. Traduce SOLO los campos: descripcion_corta, descripcion_larga, keywords, meta_description.\n"
+    "2. NO traduzcas: id_interno, nombre, marca, categoria.\n"
+    "3. Mantén el mismo tono comercial y SEO del texto original.\n"
+    "4. keywords: lista separada por comas en el idioma destino.\n\n"
+    "RESPONDE EXCLUSIVAMENTE EN JSON, sin texto adicional, sin bloques de código markdown:\n"
+    "{{\"productos\": [{{"
+    "\"id_interno\": \"...\", "
+    "\"descripcion_corta\": \"...\", "
+    "\"descripcion_larga\": \"...\", "
+    "\"keywords\": \"...\", "
+    "\"meta_description\": \"...\""
+    "}}]}}"
+)
+
 _PROMPT_SEO = (
     "Eres un experto en SEO técnico especializado en {store_type}. "
     "Para cada producto genera meta_title y meta_description optimizados para "
@@ -108,6 +127,27 @@ class ResultadoSEO:
     marca: str
     categoria: str
     meta_title: str = ""
+    meta_description: str = ""
+    exitoso: bool = True
+    error: str = ""
+
+
+@dataclass
+class ResultadoTraduccion:
+    """
+    Resultado de la traducción automática de descripciones de un producto (Fase 7.2).
+
+    :author: BenjaminDTS
+    """
+
+    codigo: str
+    nombre: str
+    marca: str
+    categoria: str
+    idioma: str
+    descripcion_corta: str = ""
+    descripcion_larga: str = ""
+    keywords: str = ""
     meta_description: str = ""
     exitoso: bool = True
     error: str = ""
@@ -361,6 +401,165 @@ class DescriptionGenerator:
             },
         )
         return resultados
+
+    def translate_descriptions(
+        self,
+        productos: list[Producto],
+        descripciones: list[ResultadoDescripcion],
+        idioma_destino: str,
+    ) -> list[ResultadoTraduccion]:
+        """
+        Traduce las descripciones SEO generadas a un idioma destino en una sola llamada.
+
+        Combina los datos de Producto con los de ResultadoDescripcion para construir
+        el contexto de traducción. Solo traduce productos cuya descripción fue exitosa.
+        Productos con error en la descripción se marcan directamente como fallidos.
+
+        Args:
+            productos: lista de productos original (para nombre, marca, categoria).
+            descripciones: lista de ResultadoDescripcion ya generadas (mismo orden que productos).
+            idioma_destino: código ISO 639-1 del idioma destino (ej: "en", "fr").
+
+        Returns:
+            Lista de ResultadoTraduccion en el mismo orden que productos.
+            Los productos sin descripción exitosa o sin resultado de Claude se marcan con exitoso=False.
+
+        Raises:
+            No lanza excepciones — errores se capturan y devuelven en ResultadoTraduccion.error.
+        """
+        if not productos:
+            return []
+
+        # Separar exitosos y fallidos para solo llamar a Claude con los exitosos
+        mapa_desc: dict[str, ResultadoDescripcion] = {d.codigo: d for d in descripciones}
+
+        exitosos: list[Producto] = []
+        resultados_previos: list[ResultadoTraduccion] = []
+        for producto in productos:
+            desc = mapa_desc.get(producto.codigo)
+            if desc is not None and desc.exitoso:
+                exitosos.append(producto)
+            else:
+                resultados_previos.append(
+                    ResultadoTraduccion(
+                        codigo=producto.codigo,
+                        nombre=producto.nombre,
+                        marca=producto.marca,
+                        categoria=producto.categoria,
+                        idioma=idioma_destino,
+                        exitoso=False,
+                        error=desc.error if desc else "Sin descripción generada.",
+                    )
+                )
+
+        if not exitosos:
+            return resultados_previos
+
+        productos_input = [
+            {
+                "id_interno": p.codigo,
+                "nombre": p.nombre or p.codigo,
+                "marca": p.marca or "—",
+                "categoria": p.categoria or "- Sin Departamento -",
+                "descripcion_corta": mapa_desc[p.codigo].corta,
+                "descripcion_larga": mapa_desc[p.codigo].larga,
+                "keywords": "",
+                "meta_description": "",
+            }
+            for p in exitosos
+        ]
+
+        _NOMBRE_IDIOMA = {
+            "es": "español",
+            "en": "inglés",
+            "fr": "francés",
+            "de": "alemán",
+            "it": "italiano",
+            "pt": "portugués",
+        }
+        nombre_idioma = _NOMBRE_IDIOMA.get(idioma_destino, idioma_destino)
+
+        prompt = _PROMPT_TRADUCCION.format(
+            store_type=self._store_type,
+            idioma_destino=nombre_idioma,
+            productos_json=json.dumps(productos_input, ensure_ascii=False, indent=2),
+        )
+
+        try:
+            respuesta_raw = self._client.completar(prompt)
+            resultados_claude = self._parsear_respuesta(respuesta_raw)
+        except Exception as exc:
+            logger.error(
+                "Error en llamada batch de traducción a Claude",
+                exc_info=exc,
+                extra={"batch_size": len(exitosos), "idioma": idioma_destino},
+            )
+            fallidos = [
+                ResultadoTraduccion(
+                    codigo=p.codigo,
+                    nombre=p.nombre,
+                    marca=p.marca,
+                    categoria=p.categoria,
+                    idioma=idioma_destino,
+                    exitoso=False,
+                    error=str(exc),
+                )
+                for p in exitosos
+            ]
+            return resultados_previos + fallidos
+
+        mapa_claude: dict[str, dict] = {r["id_interno"]: r for r in resultados_claude}
+
+        resultados_exitosos: list[ResultadoTraduccion] = []
+        for producto in exitosos:
+            datos = mapa_claude.get(producto.codigo)
+            if datos is None:
+                logger.warning(
+                    "Claude no devolvió traducción para el producto",
+                    extra={"codigo": producto.codigo, "idioma": idioma_destino},
+                )
+                resultados_exitosos.append(
+                    ResultadoTraduccion(
+                        codigo=producto.codigo,
+                        nombre=producto.nombre,
+                        marca=producto.marca,
+                        categoria=producto.categoria,
+                        idioma=idioma_destino,
+                        exitoso=False,
+                        error="Sin resultado en la respuesta de Claude.",
+                    )
+                )
+            else:
+                resultados_exitosos.append(
+                    ResultadoTraduccion(
+                        codigo=producto.codigo,
+                        nombre=producto.nombre,
+                        marca=producto.marca,
+                        categoria=producto.categoria,
+                        idioma=idioma_destino,
+                        descripcion_corta=datos.get("descripcion_corta", ""),
+                        descripcion_larga=datos.get("descripcion_larga", ""),
+                        keywords=datos.get("keywords", ""),
+                        meta_description=datos.get("meta_description", ""),
+                        exitoso=True,
+                    )
+                )
+
+        # Reconstruir en el mismo orden que productos de entrada
+        mapa_resultado: dict[str, ResultadoTraduccion] = {
+            r.codigo: r for r in resultados_previos + resultados_exitosos
+        }
+        resultados_ordenados = [mapa_resultado[p.codigo] for p in productos]
+
+        logger.info(
+            "Batch de traducciones generado",
+            extra={
+                "batch_size": len(productos),
+                "idioma": idioma_destino,
+                "exitosos": sum(1 for r in resultados_ordenados if r.exitoso),
+            },
+        )
+        return resultados_ordenados
 
     # ------------------------------------------------------------------
     # Helpers privados

--- a/services/ai/description_pipeline.py
+++ b/services/ai/description_pipeline.py
@@ -195,6 +195,8 @@ class DescripcionPipeline:
             "descripciones_generadas": descripciones_ok,
             "descripciones_fallidas": descripciones_fail,
             "errores_csv": resultado_csv.errores,
+            "_productos": productos,
+            "_resultados": descripciones,
         }
 
         logger.info(

--- a/services/ai/translation_pipeline.py
+++ b/services/ai/translation_pipeline.py
@@ -1,0 +1,208 @@
+"""
+Pipeline de traducción automática de descripciones de producto (Fase 7.2).
+
+Traduce las descripciones generadas por DescripcionPipeline a uno o varios
+idiomas destino usando la API de Claude/Groq. Procesa todos los productos
+en un único batch por idioma para minimizar llamadas a la API.
+
+Flujo:
+  1. Recibe lista de Producto + lista de ResultadoDescripcion (ya generadas)
+  2. DescriptionGenerator.translate_descriptions() → traducciones por idioma
+  3. Exportar traducciones_{lang}.csv al storage del job
+
+:author: BenjaminDTS
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+
+from loguru import logger
+
+from api.core.config import get_settings
+from api.v1.schemas.job import SearchConfig
+from services.ai.claude_client import ClaudeClient
+from services.ai.description_generator import (
+    DescriptionGenerator,
+    ResultadoDescripcion,
+    ResultadoTraduccion,
+)
+from services.csv_parser import Producto
+from services.storage_service import StorageService, get_storage_service
+
+
+class TranslationPipeline:
+    """
+    Orquestador del proceso de traducción de descripciones SEO para un job.
+
+    Recibe los productos y descripciones ya generadas en memoria,
+    llama a DescriptionGenerator.translate_descriptions() por cada idioma destino
+    y guarda un CSV independiente por idioma en el storage del job.
+
+    :author: BenjaminDTS
+    """
+
+    def __init__(
+        self,
+        job_id: str,
+        config: SearchConfig,
+        storage: StorageService | None = None,
+        carpeta_job_id: str | None = None,
+    ) -> None:
+        """
+        Inicializa el pipeline de traducción para un job concreto.
+
+        Args:
+            job_id: identificador del job (usado para progreso y logs).
+            config: configuración del job (lee target_languages, api keys).
+            storage: servicio de almacenamiento. Si None, usa el factory por defecto.
+            carpeta_job_id: job_id cuya carpeta de almacenamiento se reutiliza.
+                Si None usa job_id.
+        """
+        self._job_id = job_id
+        self._carpeta_id = carpeta_job_id or job_id
+        self._config = config
+        self._storage = storage or get_storage_service()
+
+    def ejecutar(
+        self,
+        productos: list[Producto],
+        descripciones: list[ResultadoDescripcion],
+        idioma_destino: str,
+    ) -> dict:
+        """
+        Traduce las descripciones al idioma destino y guarda el CSV resultante.
+
+        Args:
+            productos: lista de productos del job (mismo orden que descripciones).
+            descripciones: lista de ResultadoDescripcion generadas previamente.
+            idioma_destino: código ISO 639-1 del idioma destino (ej: 'en', 'fr').
+
+        Returns:
+            Diccionario con: idioma, total_productos, traducciones_generadas,
+            traducciones_fallidas.
+        """
+        logger.info(
+            "Pipeline de traducción iniciado",
+            extra={"job_id": self._job_id, "idioma": idioma_destino},
+        )
+
+        # ── Inicializar cliente IA ────────────────────────────────────────────
+        settings = get_settings()
+        if settings.ai_provider == "groq":
+            ai_api_key = self._config.groq_api_key_usuario or settings.groq_api_key
+            ai_model = settings.groq_model
+        else:
+            ai_api_key = settings.claude_api_key
+            ai_model = settings.claude_model
+
+        claude_client = ClaudeClient(
+            api_key=ai_api_key,
+            model=ai_model,
+            max_tokens=settings.claude_max_tokens,
+            timeout=settings.claude_timeout,
+            max_retries=settings.claude_max_retries,
+            provider=settings.ai_provider,
+        )
+        store_type = self._config.store_type_usuario or settings.claude_store_type
+        generator = DescriptionGenerator(
+            client=claude_client,
+            store_type=store_type,
+        )
+
+        # ── Traducir en batch ─────────────────────────────────────────────────
+        resultados = generator.translate_descriptions(
+            productos=productos,
+            descripciones=descripciones,
+            idioma_destino=idioma_destino,
+        )
+
+        traducciones_ok = sum(1 for r in resultados if r.exitoso)
+        traducciones_fail = sum(1 for r in resultados if not r.exitoso)
+
+        # ── Guardar CSV ───────────────────────────────────────────────────────
+        self._guardar_csv(resultados, idioma_destino)
+
+        resumen = {
+            "idioma": idioma_destino,
+            "total_productos": len(productos),
+            "traducciones_generadas": traducciones_ok,
+            "traducciones_fallidas": traducciones_fail,
+        }
+
+        logger.info(
+            "Pipeline de traducción completado",
+            extra={
+                "job_id": self._job_id,
+                "idioma": idioma_destino,
+                "traducciones_generadas": traducciones_ok,
+                "traducciones_fallidas": traducciones_fail,
+            },
+        )
+        return resumen
+
+    def _guardar_csv(
+        self,
+        traducciones: list[ResultadoTraduccion],
+        idioma_destino: str,
+    ) -> None:
+        """
+        Serializa las traducciones a CSV y las guarda en el storage del job.
+
+        El archivo se guarda como traducciones_{lang}.csv en la carpeta del job.
+
+        Args:
+            traducciones: lista de ResultadoTraduccion del generador.
+            idioma_destino: código ISO 639-1 del idioma (ej: 'en').
+        """
+        fieldnames = [
+            "codigo",
+            "nombre",
+            "marca",
+            "categoria",
+            "idioma",
+            "descripcion_corta",
+            "descripcion_larga",
+            "keywords",
+            "meta_description",
+            "exitoso",
+            "error",
+        ]
+        buffer = io.StringIO()
+        writer = csv.DictWriter(buffer, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+
+        for r in traducciones:
+            writer.writerow({
+                "codigo": r.codigo,
+                "nombre": r.nombre,
+                "marca": r.marca,
+                "categoria": r.categoria,
+                "idioma": r.idioma,
+                "descripcion_corta": r.descripcion_corta,
+                "descripcion_larga": r.descripcion_larga,
+                "keywords": r.keywords,
+                "meta_description": r.meta_description,
+                "exitoso": r.exitoso,
+                "error": r.error,
+            })
+
+        filename = f"traducciones_{idioma_destino}.csv"
+        try:
+            self._storage.save_image(
+                self._carpeta_id,
+                filename,
+                buffer.getvalue().encode("utf-8-sig"),
+            )
+            logger.info(
+                f"{filename} guardado",
+                extra={"job_id": self._job_id, "filas": len(traducciones)},
+            )
+        except Exception as exc:
+            logger.error(
+                f"Error al guardar {filename}",
+                exc_info=exc,
+                extra={"job_id": self._carpeta_id},
+            )

--- a/tests/integration/test_translation_endpoint.py
+++ b/tests/integration/test_translation_endpoint.py
@@ -1,0 +1,177 @@
+"""
+Tests de integración para el endpoint de traducciones (Fase 7.2).
+
+Cubre:
+- Descarga exitosa de CSV de traducciones para idioma válido
+- Respuesta 404 cuando el CSV no existe
+- Respuesta 400 para idioma no soportado
+- Cabecera Content-Disposition correcta
+- Content-Type text/csv
+- Validación de todos los idiomas soportados
+- Compatibilidad UTF-8 BOM para Excel
+
+:author: BenjaminDTS
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+# ── Variables de entorno ─────────────────────────────────────────────────────
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("SECRET_KEY", "test-secret-32-chars-long-enough")
+os.environ.setdefault("BROWSER_BINARY_PATH", "/usr/bin/google-chrome")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_BROKER_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_RESULT_BACKEND", "redis://localhost:6379/1")
+
+from api.core.config import get_settings  # noqa: E402
+get_settings.cache_clear()
+
+from api.main import app  # noqa: E402
+
+
+class TestDescargarTraducciones:
+    """Suite de tests para GET /api/v1/files/{job_id}/translations/{lang}."""
+
+    @pytest_asyncio.fixture
+    async def client(self) -> AsyncClient:
+        """Cliente HTTP async."""
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            yield ac
+
+    @pytest.mark.asyncio
+    async def test_descarga_exitosa_csv_en(self, client: AsyncClient, tmp_path: Path):
+        """Verifica descarga exitosa del CSV de traducciones al inglés."""
+        job_id = "job-trad-en"
+        job_dir = tmp_path / job_id
+        job_dir.mkdir(parents=True, exist_ok=True)
+
+        csv_content = (
+            "codigo,nombre,marca,categoria,idioma,descripcion_corta,descripcion_larga,"
+            "keywords,meta_description,exitoso,error\n"
+            "PROD001,Dog food,Royal Canin,Food,en,Premium nutrition.,Complete food.,dog food,Dog food.,True,\n"
+        )
+        (job_dir / "traducciones_en.csv").write_bytes(csv_content.encode("utf-8-sig"))
+
+        storage = MagicMock()
+        storage.get_job_dir.return_value = job_dir
+
+        with patch("api.v1.endpoints.files.get_storage_service", return_value=storage):
+            response = await client.get(f"/api/v1/files/{job_id}/translations/en")
+
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_content_type_es_csv(self, client: AsyncClient, tmp_path: Path):
+        """Verifica que el Content-Type es text/csv."""
+        job_id = "job-trad-ct"
+        job_dir = tmp_path / job_id
+        job_dir.mkdir(parents=True, exist_ok=True)
+        (job_dir / "traducciones_fr.csv").write_bytes(b"codigo,idioma\nPROD001,fr\n")
+
+        storage = MagicMock()
+        storage.get_job_dir.return_value = job_dir
+
+        with patch("api.v1.endpoints.files.get_storage_service", return_value=storage):
+            response = await client.get(f"/api/v1/files/{job_id}/translations/fr")
+
+        assert "text/csv" in response.headers.get("content-type", "")
+
+    @pytest.mark.asyncio
+    async def test_content_disposition_contiene_nombre_archivo(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """Verifica que Content-Disposition incluye el nombre del archivo correcto."""
+        job_id = "abcd1234-5678-90ef-ghij-klmnopqrstuv"
+        job_dir = tmp_path / job_id
+        job_dir.mkdir(parents=True, exist_ok=True)
+        (job_dir / "traducciones_de.csv").write_bytes(b"codigo,idioma\nPROD001,de\n")
+
+        storage = MagicMock()
+        storage.get_job_dir.return_value = job_dir
+
+        with patch("api.v1.endpoints.files.get_storage_service", return_value=storage):
+            response = await client.get(f"/api/v1/files/{job_id}/translations/de")
+
+        disposition = response.headers.get("content-disposition", "")
+        assert "descripciones_de_" in disposition
+        assert ".csv" in disposition
+
+    @pytest.mark.asyncio
+    async def test_retorna_404_si_csv_no_existe(self, client: AsyncClient, tmp_path: Path):
+        """Verifica que retorna 404 cuando el CSV de traducción no existe."""
+        job_id = "job-trad-missing"
+        job_dir = tmp_path / job_id
+        job_dir.mkdir(parents=True, exist_ok=True)
+
+        storage = MagicMock()
+        storage.get_job_dir.return_value = job_dir
+
+        with patch("api.v1.endpoints.files.get_storage_service", return_value=storage):
+            response = await client.get(f"/api/v1/files/{job_id}/translations/en")
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_retorna_400_para_idioma_no_soportado(self, client: AsyncClient):
+        """Verifica que retorna 400 para idioma no en SUPPORTED_LANGUAGES."""
+        response = await client.get("/api/v1/files/cualquier-job/translations/zh")
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_retorna_400_para_idioma_invalido(self, client: AsyncClient):
+        """Verifica que retorna 400 para código de idioma inválido."""
+        response = await client.get("/api/v1/files/cualquier-job/translations/xx")
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_todos_idiomas_soportados_retornan_200(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """Verifica que todos los idiomas de SUPPORTED_LANGUAGES devuelven 200 si el CSV existe."""
+        from api.v1.schemas.job import SUPPORTED_LANGUAGES
+
+        job_id = "job-all-langs"
+        job_dir = tmp_path / job_id
+        job_dir.mkdir(parents=True, exist_ok=True)
+
+        idiomas_traducibles = [l for l in SUPPORTED_LANGUAGES if l != "es"]
+        for lang in idiomas_traducibles:
+            (job_dir / f"traducciones_{lang}.csv").write_bytes(
+                f"codigo,idioma\nPROD001,{lang}\n".encode("utf-8")
+            )
+
+        storage = MagicMock()
+        storage.get_job_dir.return_value = job_dir
+
+        with patch("api.v1.endpoints.files.get_storage_service", return_value=storage):
+            for lang in idiomas_traducibles:
+                response = await client.get(f"/api/v1/files/{job_id}/translations/{lang}")
+                assert response.status_code == 200, f"Falló para idioma: {lang}"
+
+    @pytest.mark.asyncio
+    async def test_csv_con_utf8_bom(self, client: AsyncClient, tmp_path: Path):
+        """Verifica que el CSV se retorna con UTF-8 BOM (compatible con Excel)."""
+        job_id = "job-trad-bom"
+        job_dir = tmp_path / job_id
+        job_dir.mkdir(parents=True, exist_ok=True)
+
+        header = "codigo,nombre,idioma\n"
+        (job_dir / "traducciones_it.csv").write_bytes(header.encode("utf-8-sig"))
+
+        storage = MagicMock()
+        storage.get_job_dir.return_value = job_dir
+
+        with patch("api.v1.endpoints.files.get_storage_service", return_value=storage):
+            response = await client.get(f"/api/v1/files/{job_id}/translations/it")
+
+        assert response.status_code == 200
+        assert response.content[:3] == b"\xef\xbb\xbf"

--- a/tests/unit/test_translation_generator.py
+++ b/tests/unit/test_translation_generator.py
@@ -1,0 +1,398 @@
+"""
+Tests unitarios para el generador de traducciones (Fase 7.2).
+
+Verifica:
+- Traducción batch en una sola llamada a Claude
+- Mapeo correcto de resultados por id_interno
+- Manejo de productos con descripción fallida (no se traduce, se marca error)
+- Manejo de errores cuando Claude falla
+- Preservación del orden original de productos
+- Lista vacía de entrada
+- Campos requeridos en ResultadoTraduccion
+- Nunca loguea GROQ_API_KEY
+
+:author: BenjaminDTS
+:version: 1.0.0
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.ai.claude_client import ClaudeClient
+from services.ai.description_generator import (
+    DescriptionGenerator,
+    ResultadoDescripcion,
+    ResultadoTraduccion,
+)
+from services.csv_parser import Producto
+
+
+class TestTranslateDescriptions:
+    """Suite de tests para translate_descriptions()."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Mock de ClaudeClient que devuelve respuesta JSON válida."""
+        return MagicMock(spec=ClaudeClient)
+
+    @pytest.fixture
+    def generator(self, mock_client):
+        """Instancia de DescriptionGenerator con cliente mockeado."""
+        return DescriptionGenerator(
+            client=mock_client,
+            store_type="tiendas de mascotas",
+        )
+
+    @pytest.fixture
+    def productos_sample(self):
+        """Productos de prueba con dos entradas."""
+        return [
+            Producto(
+                codigo="PROD001",
+                nombre="Alimento para perros Premium",
+                marca="Royal Canin",
+                categoria="Alimentos",
+            ),
+            Producto(
+                codigo="PROD002",
+                nombre="Juguete de goma resistente",
+                marca="Kong",
+                categoria="Juguetes",
+            ),
+        ]
+
+    @pytest.fixture
+    def descripciones_exitosas(self):
+        """Descripciones generadas exitosamente para ambos productos."""
+        return [
+            ResultadoDescripcion(
+                codigo="PROD001",
+                nombre="Alimento para perros Premium",
+                marca="Royal Canin",
+                categoria="Alimentos",
+                corta="Nutrición premium para tu perro.",
+                larga="Alimento completo y equilibrado para perros adultos.",
+                exitoso=True,
+            ),
+            ResultadoDescripcion(
+                codigo="PROD002",
+                nombre="Juguete de goma resistente",
+                marca="Kong",
+                categoria="Juguetes",
+                corta="Juguete resistente para masticar.",
+                larga="Juguete de goma natural ideal para perros activos.",
+                exitoso=True,
+            ),
+        ]
+
+    def test_translates_batch_in_single_call(
+        self, generator, mock_client, productos_sample, descripciones_exitosas
+    ):
+        """Verifica que procesa todos los productos en una sola llamada a Claude."""
+        mock_client.completar.return_value = json.dumps({
+            "productos": [
+                {
+                    "id_interno": "PROD001",
+                    "descripcion_corta": "Premium nutrition for your dog.",
+                    "descripcion_larga": "Complete balanced food for adult dogs.",
+                    "keywords": "dog food, premium, nutrition",
+                    "meta_description": "Premium dog food for adult dogs.",
+                },
+                {
+                    "id_interno": "PROD002",
+                    "descripcion_corta": "Resistant chew toy.",
+                    "descripcion_larga": "Natural rubber toy ideal for active dogs.",
+                    "keywords": "dog toy, chew, rubber",
+                    "meta_description": "Durable chew toy for active dogs.",
+                },
+            ]
+        })
+
+        resultados = generator.translate_descriptions(
+            productos=productos_sample,
+            descripciones=descripciones_exitosas,
+            idioma_destino="en",
+        )
+
+        assert mock_client.completar.call_count == 1
+        assert len(resultados) == 2
+
+    def test_returns_list_same_length_as_input(
+        self, generator, mock_client, productos_sample, descripciones_exitosas
+    ):
+        """Verifica que la lista resultado tiene la misma longitud que la entrada."""
+        mock_client.completar.return_value = json.dumps({
+            "productos": [
+                {
+                    "id_interno": "PROD001",
+                    "descripcion_corta": "Premium nutrition.",
+                    "descripcion_larga": "Complete food.",
+                    "keywords": "dog food",
+                    "meta_description": "Dog food.",
+                },
+                {
+                    "id_interno": "PROD002",
+                    "descripcion_corta": "Chew toy.",
+                    "descripcion_larga": "Rubber toy.",
+                    "keywords": "toy",
+                    "meta_description": "Toy.",
+                },
+            ]
+        })
+
+        resultados = generator.translate_descriptions(
+            productos=productos_sample,
+            descripciones=descripciones_exitosas,
+            idioma_destino="fr",
+        )
+
+        assert len(resultados) == len(productos_sample)
+
+    def test_result_has_required_fields(
+        self, generator, mock_client, productos_sample, descripciones_exitosas
+    ):
+        """Verifica que cada ResultadoTraduccion tiene todos los campos requeridos."""
+        mock_client.completar.return_value = json.dumps({
+            "productos": [
+                {
+                    "id_interno": "PROD001",
+                    "descripcion_corta": "Nutrition.",
+                    "descripcion_larga": "Complete food.",
+                    "keywords": "food",
+                    "meta_description": "Dog food.",
+                },
+            ]
+        })
+
+        resultados = generator.translate_descriptions(
+            productos=[productos_sample[0]],
+            descripciones=[descripciones_exitosas[0]],
+            idioma_destino="en",
+        )
+
+        r = resultados[0]
+        assert isinstance(r, ResultadoTraduccion)
+        assert hasattr(r, "codigo")
+        assert hasattr(r, "descripcion_corta")
+        assert hasattr(r, "descripcion_larga")
+        assert hasattr(r, "keywords")
+        assert hasattr(r, "meta_description")
+        assert hasattr(r, "idioma")
+        assert r.idioma == "en"
+
+    def test_skips_failed_descriptions(
+        self, generator, mock_client, productos_sample
+    ):
+        """Verifica que productos con descripción fallida se marcan como fallidos sin llamar a Claude."""
+        descripciones_fallidas = [
+            ResultadoDescripcion(
+                codigo="PROD001",
+                nombre="Alimento para perros Premium",
+                marca="Royal Canin",
+                categoria="Alimentos",
+                exitoso=False,
+                error="Error en Claude.",
+            ),
+            ResultadoDescripcion(
+                codigo="PROD002",
+                nombre="Juguete de goma resistente",
+                marca="Kong",
+                categoria="Juguetes",
+                exitoso=False,
+                error="Timeout.",
+            ),
+        ]
+
+        resultados = generator.translate_descriptions(
+            productos=productos_sample,
+            descripciones=descripciones_fallidas,
+            idioma_destino="en",
+        )
+
+        assert mock_client.completar.call_count == 0
+        assert len(resultados) == 2
+        for r in resultados:
+            assert not r.exitoso
+
+    def test_mixed_success_failure_preserves_order(
+        self, generator, mock_client, productos_sample
+    ):
+        """Verifica que el orden original se preserva con productos mixtos (exitosos y fallidos)."""
+        descripciones_mixtas = [
+            ResultadoDescripcion(
+                codigo="PROD001",
+                nombre="Alimento para perros Premium",
+                marca="Royal Canin",
+                categoria="Alimentos",
+                corta="Gancho.",
+                larga="Texto largo.",
+                exitoso=True,
+            ),
+            ResultadoDescripcion(
+                codigo="PROD002",
+                nombre="Juguete de goma resistente",
+                marca="Kong",
+                categoria="Juguetes",
+                exitoso=False,
+                error="Descripción fallida.",
+            ),
+        ]
+        mock_client.completar.return_value = json.dumps({
+            "productos": [
+                {
+                    "id_interno": "PROD001",
+                    "descripcion_corta": "Premium hook.",
+                    "descripcion_larga": "Long text.",
+                    "keywords": "food",
+                    "meta_description": "Dog food.",
+                },
+            ]
+        })
+
+        resultados = generator.translate_descriptions(
+            productos=productos_sample,
+            descripciones=descripciones_mixtas,
+            idioma_destino="en",
+        )
+
+        assert len(resultados) == 2
+        assert resultados[0].codigo == "PROD001"
+        assert resultados[0].exitoso
+        assert resultados[1].codigo == "PROD002"
+        assert not resultados[1].exitoso
+
+    def test_handles_empty_product_list(self, generator):
+        """Verifica que maneja lista vacía sin llamar a Claude."""
+        resultados = generator.translate_descriptions(
+            productos=[],
+            descripciones=[],
+            idioma_destino="en",
+        )
+
+        assert resultados == []
+
+    def test_raises_error_on_claude_failure(
+        self, generator, mock_client, productos_sample, descripciones_exitosas
+    ):
+        """Verifica que cuando Claude falla, todos los productos se marcan con exitoso=False."""
+        mock_client.completar.side_effect = Exception("Claude API Error")
+
+        resultados = generator.translate_descriptions(
+            productos=productos_sample,
+            descripciones=descripciones_exitosas,
+            idioma_destino="en",
+        )
+
+        assert len(resultados) == len(productos_sample)
+        for r in resultados:
+            assert not r.exitoso
+            assert "Claude API Error" in r.error
+
+    def test_missing_product_in_claude_response_marked_failed(
+        self, generator, mock_client, productos_sample, descripciones_exitosas
+    ):
+        """Verifica que si Claude no devuelve un producto, se marca como fallido."""
+        mock_client.completar.return_value = json.dumps({
+            "productos": [
+                {
+                    "id_interno": "PROD001",
+                    "descripcion_corta": "Premium nutrition.",
+                    "descripcion_larga": "Complete food.",
+                    "keywords": "dog",
+                    "meta_description": "Dog food.",
+                },
+            ]
+        })
+
+        resultados = generator.translate_descriptions(
+            productos=productos_sample,
+            descripciones=descripciones_exitosas,
+            idioma_destino="de",
+        )
+
+        assert len(resultados) == 2
+        assert resultados[0].codigo == "PROD001"
+        assert resultados[0].exitoso
+        assert resultados[1].codigo == "PROD002"
+        assert not resultados[1].exitoso
+
+    def test_idioma_stored_in_resultado(
+        self, generator, mock_client, productos_sample, descripciones_exitosas
+    ):
+        """Verifica que el idioma destino se almacena en cada ResultadoTraduccion."""
+        mock_client.completar.return_value = json.dumps({
+            "productos": [
+                {
+                    "id_interno": "PROD001",
+                    "descripcion_corta": "Nutrition de qualité.",
+                    "descripcion_larga": "Aliment complet pour chiens.",
+                    "keywords": "nourriture chien",
+                    "meta_description": "Nourriture premium pour chien.",
+                },
+                {
+                    "id_interno": "PROD002",
+                    "descripcion_corta": "Jouet résistant.",
+                    "descripcion_larga": "Jouet en caoutchouc naturel.",
+                    "keywords": "jouet chien",
+                    "meta_description": "Jouet pour chien actif.",
+                },
+            ]
+        })
+
+        resultados = generator.translate_descriptions(
+            productos=productos_sample,
+            descripciones=descripciones_exitosas,
+            idioma_destino="fr",
+        )
+
+        for r in resultados:
+            assert r.idioma == "fr"
+
+    def test_never_logs_api_key(
+        self, generator, mock_client, productos_sample, descripciones_exitosas
+    ):
+        """Verifica que GROQ_API_KEY nunca aparece en logs de error."""
+        mock_client.completar.side_effect = Exception("API Key leaked in error")
+
+        with patch("services.ai.description_generator.logger") as mock_logger:
+            generator.translate_descriptions(
+                productos=productos_sample,
+                descripciones=descripciones_exitosas,
+                idioma_destino="en",
+            )
+
+            for call in mock_logger.error.call_args_list:
+                logged_text = str(call)
+                assert "gsk_" not in logged_text
+                assert "GROQ_API_KEY" not in logged_text
+
+    def test_successful_result_has_translated_content(
+        self, generator, mock_client, productos_sample, descripciones_exitosas
+    ):
+        """Verifica que el contenido traducido se asigna correctamente a los campos."""
+        mock_client.completar.return_value = json.dumps({
+            "productos": [
+                {
+                    "id_interno": "PROD001",
+                    "descripcion_corta": "Premium nutrition for your dog.",
+                    "descripcion_larga": "Complete and balanced food for adult dogs.",
+                    "keywords": "dog food, premium, adult",
+                    "meta_description": "Premium dog food Royal Canin.",
+                },
+            ]
+        })
+
+        resultados = generator.translate_descriptions(
+            productos=[productos_sample[0]],
+            descripciones=[descripciones_exitosas[0]],
+            idioma_destino="en",
+        )
+
+        r = resultados[0]
+        assert r.exitoso
+        assert r.descripcion_corta == "Premium nutrition for your dog."
+        assert r.descripcion_larga == "Complete and balanced food for adult dogs."
+        assert r.keywords == "dog food, premium, adult"
+        assert r.meta_description == "Premium dog food Royal Canin."

--- a/workers/tasks.py
+++ b/workers/tasks.py
@@ -225,6 +225,37 @@ def ejecutar_scraping(
         )
         _actualizar_estado(redis_client, job_status)
 
+    def _callback_traducciones(
+        jid: str,
+        idioma: str,
+        total: int,
+        traducciones_ok: int,
+    ) -> None:
+        """
+        Actualiza el estado del job de traducciones en Redis tras procesar cada idioma.
+
+        Args:
+            jid: job_id.
+            idioma: código ISO 639-1 del idioma destino.
+            total: total de productos a traducir.
+            traducciones_ok: traducciones generadas exitosamente en este idioma.
+
+        Raises:
+            JobCancelledError: si el job fue cancelado desde la API.
+        """
+        raw = redis_client.get(_JOB_KEY.format(job_id=jid))
+        if raw:
+            current = JobStatus.model_validate_json(raw)
+            if current.estado == EstadoJob.CANCELADO:
+                raise JobCancelledError(f"Job {jid} cancelado por el usuario.")
+
+        job_status.traducciones_generadas[idioma] = traducciones_ok
+        job_status.actualizado_en = datetime.utcnow()
+        job_status.mensaje = (
+            f"Traduciendo al {idioma}: {traducciones_ok}/{total} completadas."
+        )
+        _actualizar_estado(redis_client, job_status)
+
     def _callback_seo(
         jid: str,
         procesados: int,
@@ -268,6 +299,30 @@ def ejecutar_scraping(
                 callback=_callback_descripciones,
                 offset_productos=offset_productos,
             )
+
+            # ── Fase 7.2: traducciones automáticas ───────────────────────────
+            if config.target_languages:
+                from services.ai.translation_pipeline import TranslationPipeline  # noqa: PLC0415
+                _productos_desc = resumen.get("_productos", [])
+                _resultados_desc = resumen.get("_resultados", [])
+
+                for idioma in config.target_languages:
+                    pipeline_trad = TranslationPipeline(
+                        job_id=job_id,
+                        config=config,
+                        carpeta_job_id=carpeta_job_id,
+                    )
+                    resumen_trad = pipeline_trad.ejecutar(
+                        productos=_productos_desc,
+                        descripciones=_resultados_desc,
+                        idioma_destino=idioma,
+                    )
+                    _callback_traducciones(
+                        job_id,
+                        idioma,
+                        resumen_trad["total_productos"],
+                        resumen_trad["traducciones_generadas"],
+                    )
         elif config.tipo_job == TipoJob.SEO:
             from services.ai.seo_pipeline import SeoPipeline  # noqa: PLC0415
             pipeline_seo = SeoPipeline(job_id=job_id, config=config, carpeta_job_id=carpeta_job_id)
@@ -299,10 +354,17 @@ def ejecutar_scraping(
         if config.tipo_job == TipoJob.DESCRIPCIONES:
             job_status.total_productos = resumen["total_productos"]
             job_status.descripciones_generadas = resumen.get("descripciones_generadas", 0)
-            job_status.mensaje = (
-                f"Completado: {resumen.get('descripciones_generadas', 0)} descripciones generadas "
-                f"de {resumen['total_productos']} productos."
-            )
+            if config.target_languages:
+                job_status.mensaje = (
+                    f"Completado: {resumen.get('descripciones_generadas', 0)} descripciones generadas "
+                    f"de {resumen['total_productos']} productos. "
+                    f"Idiomas traducidos: {', '.join(config.target_languages)}."
+                )
+            else:
+                job_status.mensaje = (
+                    f"Completado: {resumen.get('descripciones_generadas', 0)} descripciones generadas "
+                    f"de {resumen['total_productos']} productos."
+                )
         elif config.tipo_job == TipoJob.SEO:
             job_status.total_productos = resumen["total_productos"]
             job_status.productos_procesados = resumen["total_productos"]


### PR DESCRIPTION
## Summary

- Add `target_languages` field to `SearchConfig` with validator against `SUPPORTED_LANGUAGES` (es, en, fr, de, it, pt)
- Add `translate_descriptions()` method and `ResultadoTraduccion` dataclass to `DescriptionGenerator`
- Add `TranslationPipeline` service that translates descriptions per language and saves `traducciones_{lang}.csv`
- Integrate translation step in Celery task after DESCRIPCIONES pipeline completes
- Add `GET /api/v1/files/{job_id}/translations/{lang}` endpoint (400 for unsupported lang, 404 if missing)
- Add multi-language checkbox selector in `SearchConfig.tsx` (EN/FR/DE/IT/PT)
- Add per-language download buttons in `App.tsx` when job completes

## Test plan

- [x] 11 unit tests for `translate_descriptions()` — 100% pass
- [x] 8 integration tests for `/translations/{lang}` endpoint — 100% pass
- [x] Full suite: 196/196 passing (was 177 before)
- [x] `npm run type-check` — no errors
- [x] `npm run build` — clean production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)