### PR TITLE
feat(fase7.3): manual description review panel

### DIFF
--- a/api/v1/endpoints/files.py
+++ b/api/v1/endpoints/files.py
@@ -3,7 +3,7 @@ Endpoints para la gestión de archivos generados por los trabajos de scraping.
 
 Rutas expuestas:
   GET    /api/v1/files/{job_id}                        — Descargar el ZIP de imágenes (job fotos)
-  GET    /api/v1/files/{job_id}/csv                    — Descargar el CSV de descripciones (job descripciones)
+  GET    /api/v1/files/{job_id}/csv                    — Descargar el CSV de descripciones (?only_approved=true para solo aprobadas, Fase 7.3)
   GET    /api/v1/files/{job_id}/seo                    — (Fase 7.1) Descargar CSV de textos SEO (meta_title + meta_description)
   GET    /api/v1/files/{job_id}/brands                 — (Fase 6) Descargar fichas de marca JSON
   GET    /api/v1/files/{job_id}/translations/{lang}    — (Fase 7.2) Descargar CSV de traducciones por idioma
@@ -13,15 +13,20 @@ Solo gestiona la capa HTTP. El acceso al sistema de archivos se delega
 a StorageService para mantener la arquitectura limpia.
 
 :author: BenjaminDTS
-:version: 1.1.0
+:author: Carlitos6712
+:version: 1.2.0
 """
 
-from fastapi import APIRouter, HTTPException, Path
-from fastapi.responses import FileResponse, JSONResponse
+import csv
+import io
+
+import redis.asyncio as aioredis
+from fastapi import APIRouter, HTTPException, Path, Query
+from fastapi.responses import FileResponse, JSONResponse, Response
 from loguru import logger
 
 from api.core.config import get_settings
-from api.v1.schemas.job import SUPPORTED_LANGUAGES
+from api.v1.schemas.job import SUPPORTED_LANGUAGES, DescriptionReviewState, ReviewStatus
 from services.storage_service import get_storage_service
 
 router = APIRouter(prefix="/files", tags=["Files"])
@@ -126,20 +131,39 @@ async def eliminar_archivos_job(job_id: str) -> JSONResponse:
 @router.get(
     "/{job_id}/csv",
     summary="Descargar el CSV de descripciones de un trabajo",
-    response_class=FileResponse,
+    include_in_schema=True,
 )
-async def descargar_csv(job_id: str) -> FileResponse:
+async def descargar_csv(
+    job_id: str,
+    only_approved: bool = Query(
+        default=False,
+        description=(
+            "Si True, devuelve solo las descripciones con estado de revisión 'approved' (Fase 7.3). "
+            "Devuelve 204 si no hay ninguna aprobada. "
+            "Si False (por defecto), devuelve todas las descripciones sin filtrar."
+        ),
+    ),
+) -> Response:
     """
     Devuelve el archivo descripciones.csv generado por el pipeline de IA.
 
+    Con ?only_approved=true filtra las filas por estado de revisión en Redis,
+    devolviendo solo las descripciones que el usuario ha aprobado (Fase 7.3).
+    Sin el parámetro (o con only_approved=false), el comportamiento es idéntico
+    al original: devuelve el CSV completo sin filtrar.
+
     Args:
         job_id: identificador UUID del trabajo.
+        only_approved: si True, filtra por status=approved en Redis.
 
     Returns:
-        FileResponse con el CSV de descripciones como adjunto descargable.
+        FileResponse con el CSV completo, o Response con CSV filtrado en memoria,
+        o Response 204 si only_approved=True y no hay descripciones aprobadas.
 
     Raises:
         HTTPException 404: si el CSV no existe o el job no ha completado.
+
+    :author: Carlitos6712
     """
     storage = get_storage_service()
     csv_path = storage.get_job_dir(job_id) / "descripciones.csv"
@@ -154,12 +178,62 @@ async def descargar_csv(job_id: str) -> FileResponse:
             detail="El CSV no existe. El job puede no haber completado aún.",
         )
 
-    return FileResponse(
-        path=str(csv_path),
-        media_type="text/csv",
-        filename=f"descripciones_{job_id}.csv",
-        headers={"Content-Disposition": f'attachment; filename="descripciones_{job_id}.csv"'},
-    )
+    # Comportamiento original: sin filtro
+    if not only_approved:
+        return FileResponse(
+            path=str(csv_path),
+            media_type="text/csv",
+            filename=f"descripciones_{job_id}.csv",
+            headers={"Content-Disposition": f'attachment; filename="descripciones_{job_id}.csv"'},
+        )
+
+    # Filtrado por estado de revisión approved
+    redis: aioredis.Redis | None = None
+    try:
+        redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+
+        rows_aprobadas: list[dict] = []
+        fieldnames: list[str] = []
+
+        with open(csv_path, encoding="utf-8-sig") as f:
+            reader = csv.DictReader(f)
+            fieldnames = reader.fieldnames or []
+            for row in reader:
+                codigo = row.get("codigo", "")
+                if not codigo:
+                    continue
+                review_key = f"job:{job_id}:review:{codigo}"
+                raw_review = await redis.get(review_key)
+                if raw_review:
+                    state = DescriptionReviewState.model_validate_json(raw_review)
+                    if state.status == ReviewStatus.APPROVED:
+                        if state.edited_text:
+                            row["corta"] = state.edited_text
+                        rows_aprobadas.append(row)
+
+        if not rows_aprobadas:
+            logger.info(
+                "No hay descripciones aprobadas para exportar",
+                extra={"job_id": job_id},
+            )
+            return Response(status_code=204)
+
+        buffer = io.StringIO()
+        writer = csv.DictWriter(buffer, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows_aprobadas)
+
+        csv_bytes = buffer.getvalue().encode("utf-8-sig")
+        filename = f"descripciones_aprobadas_{job_id}.csv"
+        return Response(
+            content=csv_bytes,
+            media_type="text/csv; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    finally:
+        if redis:
+            await redis.aclose()
 
 
 @router.get(

--- a/api/v1/endpoints/jobs.py
+++ b/api/v1/endpoints/jobs.py
@@ -24,6 +24,7 @@ import io
 import json
 import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Annotated
 
 import redis.asyncio as aioredis
@@ -54,6 +55,7 @@ from api.v1.schemas.job import (
     JobResponse,
     JobStatus,
     ModosBusqueda,
+    ReviewAction,
     ReviewStatus,
     SearchConfig,
     TipoJob,
@@ -649,8 +651,6 @@ async def revisar_descripcion(
 
     :author: Carlitos6712
     """
-    from pathlib import Path  # noqa: PLC0415
-
     redis = await _get_redis()
     try:
         job_status = await _get_job_status(redis, job_id)
@@ -696,7 +696,6 @@ async def revisar_descripcion(
             old_status = old_state.status
 
         # Construir nuevo estado según la acción
-        from api.v1.schemas.job import ReviewAction  # noqa: PLC0415
         if body.action == ReviewAction.APPROVE:
             new_status = ReviewStatus.APPROVED
             edited_text = None
@@ -789,8 +788,6 @@ async def obtener_estado_revisiones(
 
     :author: Carlitos6712
     """
-    from pathlib import Path  # noqa: PLC0415
-
     if not (1 <= limit <= 100):
         raise HTTPException(status_code=400, detail="limit debe estar entre 1 y 100.")
 

--- a/api/v1/endpoints/jobs.py
+++ b/api/v1/endpoints/jobs.py
@@ -2,18 +2,21 @@
 Endpoints HTTP y WebSocket para la gestión de trabajos de scraping.
 
 Rutas expuestas:
-  POST   /api/v1/jobs                  — Crear un nuevo job con CSV + configuración
-  GET    /api/v1/jobs/{job_id}         — Consultar el estado de un job
-  GET    /api/v1/jobs/{job_id}/brands  — Obtener marcas resueltas como JSON (Fase 6.4)
-  POST   /api/v1/jobs/{job_id}/cancel  — Cancelar un job en curso
-  POST   /api/v1/jobs/{job_id}/resume  — Reanudar un job cancelado o fallido
-  WS     /api/v1/jobs/{job_id}/ws      — Stream de progreso en tiempo real
+  POST   /api/v1/jobs                                          — Crear un nuevo job con CSV + configuración
+  GET    /api/v1/jobs/{job_id}                                 — Consultar el estado de un job
+  GET    /api/v1/jobs/{job_id}/brands                          — Obtener marcas resueltas como JSON (Fase 6.4)
+  POST   /api/v1/jobs/{job_id}/cancel                          — Cancelar un job en curso
+  POST   /api/v1/jobs/{job_id}/resume                          — Reanudar un job cancelado o fallido
+  PATCH  /api/v1/jobs/{job_id}/descriptions/{codigo}           — Revisar (aprobar/rechazar/editar) una descripción (Fase 7.3)
+  GET    /api/v1/jobs/{job_id}/descriptions/review             — Estado de revisión de todas las descripciones (Fase 7.3)
+  WS     /api/v1/jobs/{job_id}/ws                              — Stream de progreso en tiempo real
 
 Este módulo solo maneja HTTP: valida, delega a workers y devuelve respuesta.
 Ninguna lógica de negocio vive aquí.
 
 :author: BenjaminDTS
-:version: 1.2.0
+:author: Carlitos6712
+:version: 1.3.0
 """
 
 import csv
@@ -42,12 +45,15 @@ from api.core.security import limiter
 from services.storage_service import get_storage_service
 from api.v1.schemas.job import (
     ColumnMapping,
+    DescriptionReviewRequest,
+    DescriptionReviewState,
     EstadoJob,
     JobCreate,
     JobProgressEvent,
     JobResponse,
     JobStatus,
     ModosBusqueda,
+    ReviewStatus,
     SearchConfig,
     TipoJob,
 )
@@ -63,6 +69,8 @@ _JOB_CSV_KEY = "job:{job_id}:csv"
 _JOB_CONFIG_KEY = "job:{job_id}:config"
 # Tiempo de vida de la clave en Redis (igual al TTL de archivos)
 _KEY_TTL = settings.file_ttl_seconds
+# Clave Redis donde se almacena el estado de revisión de una descripción individual
+_JOB_REVIEW_KEY = "job:{job_id}:review:{codigo}"
 
 
 async def _get_redis() -> aioredis.Redis:
@@ -608,6 +616,232 @@ async def reanudar_job(job_id: str) -> JSONResponse:
             "message": f"Trabajo reanudado desde el producto {offset_productos + 1}.",
         },
     )
+
+
+@router.patch(
+    "/{job_id}/descriptions/{codigo}",
+    response_model=dict,
+    summary="Revisar una descripción generada por IA (aprobar / rechazar / editar)",
+)
+async def revisar_descripcion(
+    job_id: str,
+    codigo: str,
+    body: DescriptionReviewRequest,
+) -> JSONResponse:
+    """
+    Aplica una acción de revisión (approve / reject / edit) sobre una descripción individual.
+
+    La acción se persiste en Redis bajo job:{job_id}:review:{codigo} con el mismo TTL
+    que el job. Los contadores de revisión en JobStatus se actualizan en consecuencia.
+
+    Args:
+        job_id: identificador UUID del trabajo.
+        codigo: código del producto cuya descripción se revisa.
+        body: acción a aplicar y, si action='edit', el texto editado.
+
+    Returns:
+        JSONResponse con el DescriptionReviewState actualizado.
+
+    Raises:
+        HTTPException 404: si el job o el producto no existen.
+        HTTPException 409: si el job no está en estado COMPLETADO.
+
+    :author: Carlitos6712
+    """
+    from pathlib import Path  # noqa: PLC0415
+
+    redis = await _get_redis()
+    try:
+        job_status = await _get_job_status(redis, job_id)
+
+        if job_status.estado != EstadoJob.COMPLETADO:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"El job '{job_id}' no está COMPLETADO (estado actual: {job_status.estado.value}). "
+                    "Solo se pueden revisar descripciones de jobs completados."
+                ),
+            )
+
+        # Verificar que el producto existe en descripciones.csv
+        storage = get_storage_service()
+        csv_path: Path = storage.get_job_dir(job_id) / "descripciones.csv"
+        if not csv_path.exists():
+            raise HTTPException(
+                status_code=404,
+                detail=f"No se encontraron descripciones para el job '{job_id}'.",
+            )
+
+        codigos_en_csv: set[str] = set()
+        with open(csv_path, encoding="utf-8-sig") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                if row.get("codigo"):
+                    codigos_en_csv.add(row["codigo"])
+
+        if codigo not in codigos_en_csv:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Producto '{codigo}' no encontrado en las descripciones del job '{job_id}'.",
+            )
+
+        review_key = _JOB_REVIEW_KEY.format(job_id=job_id, codigo=codigo)
+
+        # Leer estado previo para ajustar contadores
+        raw_review = await redis.get(review_key)
+        old_status = ReviewStatus.PENDING
+        if raw_review:
+            old_state = DescriptionReviewState.model_validate_json(raw_review)
+            old_status = old_state.status
+
+        # Construir nuevo estado según la acción
+        from api.v1.schemas.job import ReviewAction  # noqa: PLC0415
+        if body.action == ReviewAction.APPROVE:
+            new_status = ReviewStatus.APPROVED
+            edited_text = None
+        elif body.action == ReviewAction.REJECT:
+            new_status = ReviewStatus.REJECTED
+            edited_text = None
+        else:  # EDIT
+            new_status = ReviewStatus.APPROVED
+            edited_text = body.edited_text
+
+        new_review_state = DescriptionReviewState(
+            codigo=codigo,
+            status=new_status,
+            edited_text=edited_text,
+        )
+
+        # Persistir en Redis con TTL
+        await redis.set(review_key, new_review_state.model_dump_json(), ex=_KEY_TTL)
+
+        # Actualizar contadores en JobStatus
+        raw_job = await redis.get(_JOB_KEY.format(job_id=job_id))
+        if raw_job:
+            job_status = JobStatus.model_validate_json(raw_job)
+
+            # Revertir contadores del estado anterior
+            if old_status == ReviewStatus.PENDING:
+                job_status.revisiones_pendientes = max(0, job_status.revisiones_pendientes - 1)
+            elif old_status == ReviewStatus.APPROVED:
+                job_status.revisiones_aprobadas = max(0, job_status.revisiones_aprobadas - 1)
+            elif old_status == ReviewStatus.REJECTED:
+                job_status.revisiones_rechazadas = max(0, job_status.revisiones_rechazadas - 1)
+
+            # Aplicar nuevo estado
+            if new_status == ReviewStatus.APPROVED:
+                job_status.revisiones_aprobadas += 1
+            elif new_status == ReviewStatus.REJECTED:
+                job_status.revisiones_rechazadas += 1
+
+            job_status.actualizado_en = datetime.utcnow()
+            await redis.set(
+                _JOB_KEY.format(job_id=job_id),
+                job_status.model_dump_json(),
+                ex=_KEY_TTL,
+            )
+
+        logger.info(
+            "Descripción revisada",
+            extra={"job_id": job_id, "codigo": codigo, "action": body.action.value},
+        )
+
+        return JSONResponse(
+            content={
+                "success": True,
+                "data": new_review_state.model_dump(),
+                "message": f"Descripción '{codigo}' marcada como {new_status.value}.",
+            }
+        )
+
+    finally:
+        await redis.aclose()
+
+
+@router.get(
+    "/{job_id}/descriptions/review",
+    response_model=dict,
+    summary="Obtener estado de revisión de todas las descripciones (paginado)",
+)
+async def obtener_estado_revisiones(
+    job_id: str,
+    limit: int = 25,
+    offset: int = 0,
+) -> JSONResponse:
+    """
+    Devuelve el estado de revisión de todas las descripciones de un job, paginado.
+
+    Las descripciones sin entrada en Redis se devuelven con status=pending por defecto.
+    Requiere que descripciones.csv exista en el storage del job.
+
+    Args:
+        job_id: identificador UUID del trabajo.
+        limit: máximo de registros por página (1-100, por defecto 25).
+        offset: número de registros a saltar (por defecto 0).
+
+    Returns:
+        JSONResponse con lista paginada de DescriptionReviewState.
+
+    Raises:
+        HTTPException 400: si limit > 100 o < 1.
+        HTTPException 404: si el job no existe o no tiene descripciones.
+
+    :author: Carlitos6712
+    """
+    from pathlib import Path  # noqa: PLC0415
+
+    if not (1 <= limit <= 100):
+        raise HTTPException(status_code=400, detail="limit debe estar entre 1 y 100.")
+
+    redis = await _get_redis()
+    try:
+        await _get_job_status(redis, job_id)  # 404 si no existe
+
+        storage = get_storage_service()
+        csv_path: Path = storage.get_job_dir(job_id) / "descripciones.csv"
+        if not csv_path.exists():
+            raise HTTPException(
+                status_code=404,
+                detail=f"No se encontraron descripciones para el job '{job_id}'.",
+            )
+
+        # Leer todos los productos del CSV
+        codigos: list[str] = []
+        with open(csv_path, encoding="utf-8-sig") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                if row.get("codigo"):
+                    codigos.append(row["codigo"])
+
+        total = len(codigos)
+        pagina = codigos[offset:offset + limit]
+
+        # Obtener estado de revisión para cada producto de la página
+        revisiones: list[dict] = []
+        for cod in pagina:
+            review_key = _JOB_REVIEW_KEY.format(job_id=job_id, codigo=cod)
+            raw_review = await redis.get(review_key)
+            if raw_review:
+                state = DescriptionReviewState.model_validate_json(raw_review)
+            else:
+                state = DescriptionReviewState(codigo=cod)
+            revisiones.append(state.model_dump())
+
+        return JSONResponse(
+            content={
+                "success": True,
+                "data": {
+                    "items": revisiones,
+                    "total": total,
+                    "limit": limit,
+                    "offset": offset,
+                },
+                "message": f"{len(revisiones)} revisiones devueltas.",
+            }
+        )
+
+    finally:
+        await redis.aclose()
 
 
 @router.websocket("/{job_id}/ws")

--- a/api/v1/endpoints/jobs.py
+++ b/api/v1/endpoints/jobs.py
@@ -45,6 +45,7 @@ from api.core.security import limiter
 from services.storage_service import get_storage_service
 from api.v1.schemas.job import (
     ColumnMapping,
+    DescriptionReviewEntry,
     DescriptionReviewRequest,
     DescriptionReviewState,
     EstadoJob,
@@ -805,27 +806,36 @@ async def obtener_estado_revisiones(
                 detail=f"No se encontraron descripciones para el job '{job_id}'.",
             )
 
-        # Leer todos los productos del CSV
-        codigos: list[str] = []
+        # Leer todos los productos del CSV (con contenido de descripción)
+        filas: list[dict] = []
         with open(csv_path, encoding="utf-8-sig") as f:
             reader = csv.DictReader(f)
             for row in reader:
                 if row.get("codigo"):
-                    codigos.append(row["codigo"])
+                    filas.append(row)
 
-        total = len(codigos)
-        pagina = codigos[offset:offset + limit]
+        total = len(filas)
+        pagina = filas[offset:offset + limit]
 
         # Obtener estado de revisión para cada producto de la página
         revisiones: list[dict] = []
-        for cod in pagina:
+        for fila in pagina:
+            cod = fila["codigo"]
             review_key = _JOB_REVIEW_KEY.format(job_id=job_id, codigo=cod)
             raw_review = await redis.get(review_key)
             if raw_review:
-                state = DescriptionReviewState.model_validate_json(raw_review)
+                base_state = DescriptionReviewState.model_validate_json(raw_review)
             else:
-                state = DescriptionReviewState(codigo=cod)
-            revisiones.append(state.model_dump())
+                base_state = DescriptionReviewState(codigo=cod)
+            entry = DescriptionReviewEntry(
+                codigo=cod,
+                status=base_state.status,
+                edited_text=base_state.edited_text,
+                nombre=fila.get("nombre", ""),
+                descripcion_corta=fila.get("corta", ""),
+                descripcion_larga=fila.get("larga", ""),
+            )
+            revisiones.append(entry.model_dump())
 
         return JSONResponse(
             content={

--- a/api/v1/schemas/job.py
+++ b/api/v1/schemas/job.py
@@ -6,7 +6,8 @@ del pipeline. Estos tipos son el único punto de verdad compartido entre
 la capa HTTP (api/) y la capa de servicios (services/).
 
 :author: BenjaminDTS
-:version: 1.0.0
+:author: Carlitos6712
+:version: 2.0.0
 """
 
 from datetime import datetime
@@ -14,7 +15,7 @@ from enum import Enum
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 SUPPORTED_LANGUAGES = ("es", "en", "fr", "de", "it", "pt")
@@ -62,6 +63,81 @@ class TipoJob(str, Enum):
     DESCRIPCIONES = "descripciones"         # Generación de descripciones con Claude API
     SEO = "seo"                             # Generación de meta_title + meta_description (Fase 7.1)
     MARCAS = "marcas"                       # Scraping de información de marca (Fase 6)
+
+
+# ── Revisión manual de descripciones (Fase 7.3) ──────────────────────────────
+
+class ReviewAction(str, Enum):
+    """
+    Acción que el usuario aplica sobre una descripción en revisión.
+
+    :author: Carlitos6712
+    """
+
+    APPROVE = "approve"
+    REJECT = "reject"
+    EDIT = "edit"
+
+
+class ReviewStatus(str, Enum):
+    """
+    Estado de revisión de una descripción individual.
+
+    :author: Carlitos6712
+    """
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class DescriptionReviewRequest(BaseModel):
+    """
+    Body de la petición PATCH para revisar una descripción.
+
+    :author: Carlitos6712
+    """
+
+    action: ReviewAction = Field(description="Acción a aplicar: approve, reject o edit.")
+    edited_text: str | None = Field(
+        default=None,
+        description="Requerido si action es 'edit'. Texto editado por el usuario.",
+    )
+
+    @model_validator(mode="after")
+    def edited_text_required_when_edit(self) -> "DescriptionReviewRequest":
+        """
+        Valida que edited_text esté presente cuando action es 'edit'.
+
+        Returns:
+            La instancia validada.
+
+        Raises:
+            ValueError: si action es 'edit' y edited_text está ausente o vacío.
+        """
+        if self.action == ReviewAction.EDIT and not self.edited_text:
+            raise ValueError("edited_text es requerido cuando action es 'edit'")
+        return self
+
+
+class DescriptionReviewState(BaseModel):
+    """
+    Estado de revisión almacenado en Redis para cada descripción individual.
+
+    Clave Redis: job:{job_id}:review:{codigo}
+
+    :author: Carlitos6712
+    """
+
+    codigo: str = Field(description="Código del producto.")
+    status: ReviewStatus = Field(
+        default=ReviewStatus.PENDING,
+        description="Estado de revisión de la descripción.",
+    )
+    edited_text: str | None = Field(
+        default=None,
+        description="Texto editado por el usuario (solo cuando action='edit').",
+    )
 
 
 # ── Configuración de búsqueda ─────────────────────────────────────────────────
@@ -218,6 +294,7 @@ class JobStatus(BaseModel):
     El WebSocket de progreso emite actualizaciones de este modelo.
 
     :author: BenjaminDTS
+    :author: Carlitos6712
     """
 
     job_id: UUID = Field(description="Identificador único del trabajo.")
@@ -252,6 +329,21 @@ class JobStatus(BaseModel):
         default=0,
         ge=0,
         description="Contador de marcas procesadas (Fase 6).",
+    )
+    revisiones_pendientes: int = Field(
+        default=0,
+        ge=0,
+        description="Contador de descripciones pendientes de revisión (Fase 7.3).",
+    )
+    revisiones_aprobadas: int = Field(
+        default=0,
+        ge=0,
+        description="Contador de descripciones aprobadas por el usuario (Fase 7.3).",
+    )
+    revisiones_rechazadas: int = Field(
+        default=0,
+        ge=0,
+        description="Contador de descripciones rechazadas por el usuario (Fase 7.3).",
     )
     mensaje: str = Field(default="", description="Mensaje de estado legible por humanos.")
     error: str | None = Field(default=None, description="Detalle del error si estado=FALLIDO.")

--- a/api/v1/schemas/job.py
+++ b/api/v1/schemas/job.py
@@ -140,6 +140,21 @@ class DescriptionReviewState(BaseModel):
     )
 
 
+class DescriptionReviewEntry(DescriptionReviewState):
+    """
+    Entrada de revisión enriquecida con el contenido de la descripción.
+
+    Combina el estado de revisión de Redis con los datos del CSV de descripciones,
+    para devolver al frontend toda la información necesaria en un solo objeto.
+
+    :author: Carlitos6712
+    """
+
+    nombre: str = Field(default="", description="Nombre del producto.")
+    descripcion_corta: str = Field(default="", description="Descripción corta generada por IA.")
+    descripcion_larga: str = Field(default="", description="Descripción larga generada por IA.")
+
+
 # ── Configuración de búsqueda ─────────────────────────────────────────────────
 
 class ColumnMapping(BaseModel):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { JobProgress } from '@/components/JobProgress'
 import { JobHistory } from '@/components/JobHistory'
 import { HomeScreen } from '@/components/HomeScreen'
 import { BrandsPanel } from '@/components/BrandsPanel'
+import { ReviewPanel } from '@/components/ReviewPanel'
 import { NsLogo } from '@/components/NsLogo'
 import { apiClient, getBrands, resumeJob, downloadTranslationCsv } from '@/api/client'
 import type { ApiError, BrandEntry } from '@/api/client'
@@ -41,6 +42,8 @@ const App: React.FC = () => {
   const [brandsPanelOpen, setBrandsPanelOpen] = useState(true)
   const [brandsLoadError, setBrandsLoadError] = useState<string | null>(null)
   const [targetLanguages, setTargetLanguages] = useState<string[]>([])
+  const [reviewPanelOpen, setReviewPanelOpen] = useState(true)
+  const [descripcionesGeneradas, setDescripcionesGeneradas] = useState(0)
 
   // ── Handlers de HomeScreen ───────────────────────────────────────────────
 
@@ -125,6 +128,23 @@ const App: React.FC = () => {
     setAppState('done')
   }
 
+  // Cuando un job de descripciones completa, cargamos el contador para el ReviewPanel.
+  useEffect(() => {
+    if (appState !== 'done' || tipoJob !== 'descripciones' || !jobId) return
+    apiClient
+      .get<{ success: boolean; data: { descripciones_generadas: number } }>(
+        `/jobs/${jobId}`
+      )
+      .then((res) => {
+        const count = res.data.data.descripciones_generadas ?? 0
+        setDescripcionesGeneradas(count)
+        setReviewPanelOpen(count > 0)
+      })
+      .catch(() => {
+        setDescripcionesGeneradas(0)
+      })
+  }, [appState, tipoJob, jobId])
+
   // Cuando el job de marcas completa, cargamos los datos para el panel.
   useEffect(() => {
     if (appState !== 'done' || tipoJob !== 'marcas' || !jobId) return
@@ -154,6 +174,8 @@ const App: React.FC = () => {
     setBrandsData(null)
     setBrandsPanelOpen(true)
     setBrandsLoadError(null)
+    setReviewPanelOpen(true)
+    setDescripcionesGeneradas(0)
   }
 
   /** Callback: desde el historial el usuario abre un job anterior */
@@ -325,6 +347,38 @@ const App: React.FC = () => {
                         </button>
                       ))}
                   </div>
+                </section>
+              )}
+
+            {/* Panel de revisión de descripciones — visible cuando job de descripciones termina */}
+            {appState === 'done' &&
+              tipoJob === 'descripciones' &&
+              jobId !== null &&
+              descripcionesGeneradas > 0 && (
+                <section className="w-full max-w-2xl mx-auto">
+                  <button
+                    type="button"
+                    onClick={() => setReviewPanelOpen((o) => !o)}
+                    className="flex w-full items-center justify-between rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 text-sm font-semibold text-gray-800 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+                    aria-expanded={reviewPanelOpen}
+                  >
+                    <span>Revisar descripciones generadas</span>
+                    <svg
+                      className={`h-4 w-4 text-gray-500 transition-transform duration-200 ${reviewPanelOpen ? 'rotate-180' : ''}`}
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      aria-hidden="true"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </button>
+                  {reviewPanelOpen && (
+                    <div className="mt-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
+                      <ReviewPanel jobId={jobId} onComplete={handleReset} />
+                    </div>
+                  )}
                 </section>
               )}
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -171,3 +171,105 @@ export async function downloadTranslationCsv(jobId: string, lang: string): Promi
   )
   return response.data
 }
+
+// ─── Revisión de descripciones (Fase 7.3) ────────────────────────────────────
+
+/** Acción de revisión aplicada a una descripción. */
+export type ReviewAction = 'approve' | 'reject' | 'edit'
+
+/** Estado de revisión de una descripción. */
+export type ReviewStatus = 'pending' | 'approved' | 'rejected'
+
+/** Body de la petición PATCH para revisar una descripción. */
+export interface DescriptionReviewRequest {
+  action: ReviewAction
+  edited_text?: string
+}
+
+/** Estado de revisión devuelto por el endpoint PATCH. */
+export interface DescriptionReviewState {
+  codigo: string
+  status: ReviewStatus
+  edited_text: string | null
+}
+
+/** Entrada enriquecida devuelta por GET /jobs/{jobId}/descriptions/review. */
+export interface DescriptionReviewEntry extends DescriptionReviewState {
+  nombre: string
+  descripcion_corta: string
+  descripcion_larga: string
+}
+
+/** Respuesta paginada del endpoint GET /jobs/{jobId}/descriptions/review. */
+export interface DescriptionReviewPage {
+  items: DescriptionReviewEntry[]
+  total: number
+  limit: number
+  offset: number
+}
+
+/**
+ * Envía acción de revisión para una descripción individual.
+ *
+ * Llama a `PATCH /api/v1/jobs/{jobId}/descriptions/{codigo}` con la acción
+ * y, opcionalmente, el texto editado (requerido cuando action='edit').
+ *
+ * @author Carlitos6712
+ * @param jobId   - UUID del job.
+ * @param codigo  - Código del producto a revisar.
+ * @param request - Acción y texto editado.
+ * @returns Estado de revisión actualizado.
+ */
+export async function reviewDescription(
+  jobId: string,
+  codigo: string,
+  request: DescriptionReviewRequest,
+): Promise<DescriptionReviewState> {
+  const response = await apiClient.patch<ApiResponse<DescriptionReviewState>>(
+    `/jobs/${jobId}/descriptions/${encodeURIComponent(codigo)}`,
+    request,
+  )
+  return response.data.data
+}
+
+/**
+ * Obtiene estado de revisión de todas las descripciones de un job (paginado).
+ *
+ * Llama a `GET /api/v1/jobs/{jobId}/descriptions/review`.
+ *
+ * @author Carlitos6712
+ * @param jobId  - UUID del job.
+ * @param limit  - Máximo de registros por página (1-100, por defecto 25).
+ * @param offset - Registros a saltar (por defecto 0).
+ * @returns Página de DescriptionReviewEntry.
+ */
+export async function getReviewStatus(
+  jobId: string,
+  limit = 25,
+  offset = 0,
+): Promise<DescriptionReviewPage> {
+  const response = await apiClient.get<ApiResponse<DescriptionReviewPage>>(
+    `/jobs/${jobId}/descriptions/review`,
+    { params: { limit, offset } },
+  )
+  return response.data.data
+}
+
+/**
+ * Descarga CSV con solo las descripciones aprobadas (Fase 7.3).
+ *
+ * Llama a `GET /api/v1/files/{jobId}/csv?only_approved=true`.
+ * Devuelve null si el backend responde 204 (sin aprobadas).
+ *
+ * @author Carlitos6712
+ * @param jobId - UUID del job.
+ * @returns Blob con el CSV filtrado, o null si no hay aprobadas.
+ */
+export async function downloadApprovedCsv(jobId: string): Promise<Blob | null> {
+  const response = await apiClient.get<Blob>(
+    `/files/${jobId}/csv`,
+    { params: { only_approved: true }, responseType: 'blob' },
+  )
+  if (response.status === 204) return null
+  return response.data
+}

--- a/frontend/src/components/ReviewPanel.tsx
+++ b/frontend/src/components/ReviewPanel.tsx
@@ -90,9 +90,11 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({ jobId, onComplete }) =
   const [actionLoading, setActionLoading] = useState<string | null>(null)
   const [editingCodigo, setEditingCodigo] = useState<string | null>(null)
   const [editingText, setEditingText] = useState('')
+  const [actionError, setActionError] = useState<string | null>(null)
   const [exportLoading, setExportLoading] = useState(false)
   const [exportError, setExportError] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const confirmingRef = useRef(false)
 
   // ── Carga de datos ───────────────────────────────────────────────────────────
 
@@ -142,6 +144,7 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({ jobId, onComplete }) =
       editedText?: string
     ): Promise<void> => {
       setActionLoading(codigo)
+      setActionError(null)
       try {
         const body: { action: string; edited_text?: string } = { action }
         if (action === 'edit' && editedText !== undefined) {
@@ -168,7 +171,7 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({ jobId, onComplete }) =
           )
         )
       } catch {
-        // Error silencioso — estado no cambia
+        setActionError('No se pudo guardar la revisión. Inténtalo de nuevo.')
       } finally {
         setActionLoading(null)
       }
@@ -193,11 +196,17 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({ jobId, onComplete }) =
 
   const handleConfirmEdit = useCallback(
     async (codigo: string) => {
-      if (editingText.trim()) {
-        await aplicarAccion(codigo, 'edit', editingText.trim())
+      if (confirmingRef.current) return
+      confirmingRef.current = true
+      try {
+        if (editingText.trim()) {
+          await aplicarAccion(codigo, 'edit', editingText.trim())
+        }
+        setEditingCodigo(null)
+        setEditingText('')
+      } finally {
+        confirmingRef.current = false
       }
-      setEditingCodigo(null)
-      setEditingText('')
     },
     [aplicarAccion, editingText]
   )
@@ -381,6 +390,10 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({ jobId, onComplete }) =
 
       {exportError && (
         <p className="text-xs text-red-600 dark:text-red-400" role="alert">{exportError}</p>
+      )}
+
+      {actionError && (
+        <p className="text-xs text-red-600 dark:text-red-400" role="alert">{actionError}</p>
       )}
 
       {/* ── Tabs de filtro ── */}

--- a/frontend/src/components/ReviewPanel.tsx
+++ b/frontend/src/components/ReviewPanel.tsx
@@ -1,0 +1,599 @@
+/**
+ * Panel de revisión manual de descripciones generadas por IA.
+ *
+ * Permite aprobar, rechazar o editar cada descripción antes de exportar.
+ * Incluye edición inline (blur/Enter confirma, Escape cancela), tabs de filtro,
+ * paginación y aprobación masiva.
+ *
+ * @author Carlitos6712
+ * @param jobId      - Identificador del job a revisar.
+ * @param onComplete - Callback llamado cuando todas las revisiones están hechas.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { apiClient } from '@/api/client'
+
+// ─── Tipos ────────────────────────────────────────────────────────────────────
+
+interface ReviewEntry {
+  codigo: string
+  nombre: string
+  descripcion_corta: string
+  descripcion_larga: string
+  status: 'pending' | 'approved' | 'rejected'
+  edited_text: string | null
+}
+
+interface ReviewPanelProps {
+  jobId: string
+  onComplete: () => void
+}
+
+interface ApiReviewItem {
+  codigo: string
+  nombre: string
+  descripcion_corta: string
+  descripcion_larga: string
+  status: 'pending' | 'approved' | 'rejected'
+  edited_text: string | null
+}
+
+interface ApiReviewResponse {
+  success: boolean
+  data: {
+    items: ApiReviewItem[]
+    total: number
+    limit: number
+    offset: number
+  }
+}
+
+interface ApiPatchResponse {
+  success: boolean
+  data: {
+    codigo: string
+    status: 'pending' | 'approved' | 'rejected'
+    edited_text: string | null
+  }
+}
+
+// ─── Constantes ───────────────────────────────────────────────────────────────
+
+const PAGE_SIZE = 25
+type TabFilter = 'all' | 'pending' | 'approved' | 'rejected'
+
+const STATUS_CONFIG: Record<
+  'pending' | 'approved' | 'rejected',
+  { label: string; classes: string }
+> = {
+  pending: {
+    label: 'Pendiente',
+    classes: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+  },
+  approved: {
+    label: 'Aprobada',
+    classes: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300',
+  },
+  rejected: {
+    label: 'Rechazada',
+    classes: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
+  },
+}
+
+// ─── Componente ───────────────────────────────────────────────────────────────
+
+export const ReviewPanel: React.FC<ReviewPanelProps> = ({ jobId, onComplete }) => {
+  const [entries, setEntries] = useState<ReviewEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [activeTab, setActiveTab] = useState<TabFilter>('all')
+  const [page, setPage] = useState(0)
+  const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [editingCodigo, setEditingCodigo] = useState<string | null>(null)
+  const [editingText, setEditingText] = useState('')
+  const [exportLoading, setExportLoading] = useState(false)
+  const [exportError, setExportError] = useState<string | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // ── Carga de datos ───────────────────────────────────────────────────────────
+
+  const cargarEntradas = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+    try {
+      const allItems: ReviewEntry[] = []
+      let offset = 0
+      const limit = 100
+
+      while (true) {
+        const response = await apiClient.get<ApiReviewResponse>(
+          `/jobs/${jobId}/descriptions/review`,
+          { params: { limit, offset } }
+        )
+        const { items, total } = response.data.data
+        allItems.push(...items)
+        offset += items.length
+        if (allItems.length >= total || items.length === 0) break
+      }
+
+      setEntries(allItems)
+    } catch {
+      setLoadError('No se pudieron cargar las descripciones.')
+    } finally {
+      setLoading(false)
+    }
+  }, [jobId])
+
+  useEffect(() => {
+    cargarEntradas()
+  }, [cargarEntradas])
+
+  useEffect(() => {
+    if (editingCodigo && textareaRef.current) {
+      textareaRef.current.focus()
+    }
+  }, [editingCodigo])
+
+  // ── Acciones de revisión ─────────────────────────────────────────────────────
+
+  const aplicarAccion = useCallback(
+    async (
+      codigo: string,
+      action: 'approve' | 'reject' | 'edit',
+      editedText?: string
+    ): Promise<void> => {
+      setActionLoading(codigo)
+      try {
+        const body: { action: string; edited_text?: string } = { action }
+        if (action === 'edit' && editedText !== undefined) {
+          body.edited_text = editedText
+        }
+
+        const response = await apiClient.patch<ApiPatchResponse>(
+          `/jobs/${jobId}/descriptions/${encodeURIComponent(codigo)}`,
+          body
+        )
+        const { status: newStatus, edited_text: newEditedText } = response.data.data
+
+        setEntries((prev) =>
+          prev.map((e) =>
+            e.codigo === codigo
+              ? {
+                  ...e,
+                  status: newStatus,
+                  edited_text: newEditedText,
+                  descripcion_corta:
+                    action === 'edit' && newEditedText ? newEditedText : e.descripcion_corta,
+                }
+              : e
+          )
+        )
+      } catch {
+        // Error silencioso — estado no cambia
+      } finally {
+        setActionLoading(null)
+      }
+    },
+    [jobId]
+  )
+
+  const handleApprove = useCallback(
+    (codigo: string) => aplicarAccion(codigo, 'approve'),
+    [aplicarAccion]
+  )
+
+  const handleReject = useCallback(
+    (codigo: string) => aplicarAccion(codigo, 'reject'),
+    [aplicarAccion]
+  )
+
+  const handleStartEdit = useCallback((entry: ReviewEntry) => {
+    setEditingCodigo(entry.codigo)
+    setEditingText(entry.descripcion_corta)
+  }, [])
+
+  const handleConfirmEdit = useCallback(
+    async (codigo: string) => {
+      if (editingText.trim()) {
+        await aplicarAccion(codigo, 'edit', editingText.trim())
+      }
+      setEditingCodigo(null)
+      setEditingText('')
+    },
+    [aplicarAccion, editingText]
+  )
+
+  const handleCancelEdit = useCallback(() => {
+    setEditingCodigo(null)
+    setEditingText('')
+  }, [])
+
+  const handleKeyDownEdit = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>, codigo: string) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault()
+        handleConfirmEdit(codigo)
+      } else if (e.key === 'Escape') {
+        handleCancelEdit()
+      }
+    },
+    [handleConfirmEdit, handleCancelEdit]
+  )
+
+  // ── Aprobación masiva ────────────────────────────────────────────────────────
+
+  const handleAprobarTodas = useCallback(async () => {
+    const pendientes = entries.filter((e) => e.status === 'pending')
+    for (const entry of pendientes) {
+      await aplicarAccion(entry.codigo, 'approve')
+    }
+  }, [entries, aplicarAccion])
+
+  // ── Exportar aprobadas ───────────────────────────────────────────────────────
+
+  const handleExportarAprobadas = useCallback(async () => {
+    setExportLoading(true)
+    setExportError(null)
+    try {
+      const response = await apiClient.get<Blob>(
+        `/files/${jobId}/csv`,
+        { params: { only_approved: true }, responseType: 'blob' }
+      )
+      if (response.status === 204) {
+        setExportError('No hay descripciones aprobadas para exportar.')
+        return
+      }
+      const url = URL.createObjectURL(response.data)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `descripciones_aprobadas_${jobId.slice(0, 8)}.csv`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch {
+      setExportError('Error al descargar el CSV de aprobadas.')
+    } finally {
+      setExportLoading(false)
+    }
+  }, [jobId])
+
+  // ── Filtrado y paginación ────────────────────────────────────────────────────
+
+  const entradaFiltradas: ReviewEntry[] = entries.filter((e) => {
+    if (activeTab === 'all') return true
+    return e.status === activeTab
+  })
+
+  const totalPaginas = Math.max(1, Math.ceil(entradaFiltradas.length / PAGE_SIZE))
+  const paginaActual = Math.min(page, totalPaginas - 1)
+  const entradasPagina = entradaFiltradas.slice(
+    paginaActual * PAGE_SIZE,
+    (paginaActual + 1) * PAGE_SIZE
+  )
+
+  const revisadas = entries.filter((e) => e.status !== 'pending').length
+  const aprobadas = entries.filter((e) => e.status === 'approved').length
+  const pendientes = entries.filter((e) => e.status === 'pending').length
+
+  const handleTabChange = useCallback((tab: TabFilter) => {
+    setActiveTab(tab)
+    setPage(0)
+  }, [])
+
+  // ── Render: estados especiales ───────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-sm text-gray-500 dark:text-gray-400">
+        <svg
+          className="mr-2 h-4 w-4 animate-spin"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+        >
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8v8H4z"
+          />
+        </svg>
+        Cargando revisiones…
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950 px-4 py-3 text-sm text-red-700 dark:text-red-400" role="alert">
+        {loadError}
+      </div>
+    )
+  }
+
+  if (entries.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+        Este job no generó descripciones.
+      </p>
+    )
+  }
+
+  // ── Render: panel completo ───────────────────────────────────────────────────
+
+  const TABS: { key: TabFilter; label: string; count: number }[] = [
+    { key: 'all', label: 'Todas', count: entries.length },
+    { key: 'pending', label: 'Pendientes', count: pendientes },
+    { key: 'approved', label: 'Aprobadas', count: aprobadas },
+    { key: 'rejected', label: 'Rechazadas', count: entries.filter((e) => e.status === 'rejected').length },
+  ]
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* ── Barra superior ── */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {revisadas} / {entries.length} revisadas
+        </span>
+
+        <div className="flex items-center gap-2">
+          {pendientes > 0 && (
+            <button
+              type="button"
+              onClick={handleAprobarTodas}
+              disabled={actionLoading !== null}
+              className={
+                "px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors duration-150 " +
+                "bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700 " +
+                "text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/40 " +
+                "disabled:opacity-50 disabled:cursor-not-allowed"
+              }
+            >
+              Aprobar todas ({pendientes})
+            </button>
+          )}
+
+          <button
+            type="button"
+            onClick={handleExportarAprobadas}
+            disabled={aprobadas === 0 || exportLoading}
+            aria-disabled={aprobadas === 0}
+            className={
+              "flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors duration-150 " +
+              (aprobadas > 0
+                ? "bg-green-50 dark:bg-green-900/20 border-green-300 dark:border-green-700 text-green-700 dark:text-green-300 hover:bg-green-100 dark:hover:bg-green-900/40"
+                : "bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-400 cursor-not-allowed") +
+              " disabled:opacity-50 disabled:cursor-not-allowed"
+            }
+          >
+            {exportLoading ? (
+              <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+              </svg>
+            ) : (
+              <svg className="h-3.5 w-3.5" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M8 12l-4.5-4.5 1.06-1.06L7 9.38V2h2v7.38l2.44-2.94 1.06 1.06L8 12zM2 14h12v-2H2v2z" />
+              </svg>
+            )}
+            Exportar aprobadas
+          </button>
+        </div>
+      </div>
+
+      {exportError && (
+        <p className="text-xs text-red-600 dark:text-red-400" role="alert">{exportError}</p>
+      )}
+
+      {/* ── Tabs de filtro ── */}
+      <div className="flex gap-1 border-b border-gray-200 dark:border-gray-700" role="tablist">
+        {TABS.map(({ key, label, count }) => (
+          <button
+            key={key}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === key}
+            onClick={() => handleTabChange(key)}
+            className={
+              "px-3 py-2 text-xs font-medium border-b-2 transition-colors duration-150 " +
+              (activeTab === key
+                ? "border-blue-500 text-blue-600 dark:text-blue-400"
+                : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300")
+            }
+          >
+            {label}
+            <span
+              className={
+                "ml-1.5 rounded-full px-1.5 py-0.5 text-xs " +
+                (activeTab === key
+                  ? "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
+                  : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400")
+              }
+            >
+              {count}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* ── Tabla ── */}
+      {entradasPagina.length === 0 ? (
+        <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">
+          No hay descripciones en esta categoría.
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 dark:bg-gray-800 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+              <tr>
+                <th className="px-3 py-2 text-left w-24">Código</th>
+                <th className="px-3 py-2 text-left w-32">Nombre</th>
+                <th className="px-3 py-2 text-left">Descripción corta</th>
+                <th className="px-3 py-2 text-left hidden lg:table-cell">Descripción larga</th>
+                <th className="px-3 py-2 text-left w-24">Estado</th>
+                <th className="px-3 py-2 text-right w-28">Acciones</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-800 bg-white dark:bg-gray-900">
+              {entradasPagina.map((entry) => {
+                const isEditing = editingCodigo === entry.codigo
+                const isLoading = actionLoading === entry.codigo
+                const statusCfg = STATUS_CONFIG[entry.status]
+
+                return (
+                  <tr
+                    key={entry.codigo}
+                    className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+                  >
+                    <td className="px-3 py-2 font-mono text-xs text-gray-500 dark:text-gray-400 align-top">
+                      {entry.codigo}
+                    </td>
+                    <td className="px-3 py-2 text-gray-800 dark:text-gray-200 align-top">
+                      {entry.nombre}
+                    </td>
+                    <td
+                      className="px-3 py-2 align-top cursor-pointer"
+                      onClick={() => !isEditing && handleStartEdit(entry)}
+                      title="Click para editar"
+                    >
+                      {isEditing ? (
+                        <textarea
+                          ref={textareaRef}
+                          value={editingText}
+                          onChange={(e) => setEditingText(e.target.value)}
+                          onBlur={() => handleConfirmEdit(entry.codigo)}
+                          onKeyDown={(e) => handleKeyDownEdit(e, entry.codigo)}
+                          rows={3}
+                          className={
+                            "w-full rounded border border-blue-400 dark:border-blue-500 bg-white dark:bg-gray-800 " +
+                            "px-2 py-1 text-sm text-gray-800 dark:text-gray-100 " +
+                            "focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                          }
+                          aria-label={`Editar descripción corta de ${entry.codigo}`}
+                        />
+                      ) : (
+                        <span className="text-gray-700 dark:text-gray-300 line-clamp-2 hover:line-clamp-none">
+                          {entry.edited_text ?? entry.descripcion_corta}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-gray-600 dark:text-gray-400 align-top text-xs hidden lg:table-cell">
+                      <span className="line-clamp-3">{entry.descripcion_larga}</span>
+                    </td>
+                    <td className="px-3 py-2 align-top">
+                      <span
+                        className={
+                          "inline-block rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap " +
+                          statusCfg.classes
+                        }
+                      >
+                        {statusCfg.label}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 align-top text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          type="button"
+                          onClick={() => handleApprove(entry.codigo)}
+                          disabled={entry.status === 'approved' || isLoading}
+                          aria-label={`Aprobar descripción de ${entry.codigo}`}
+                          title="Aprobar"
+                          className={
+                            "rounded p-1 transition-colors duration-150 " +
+                            (entry.status === 'approved' || isLoading
+                              ? "text-gray-300 dark:text-gray-600 cursor-not-allowed"
+                              : "text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20")
+                          }
+                        >
+                          <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                            <path
+                              fillRule="evenodd"
+                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                              clipRule="evenodd"
+                            />
+                          </svg>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleReject(entry.codigo)}
+                          disabled={entry.status === 'rejected' || isLoading}
+                          aria-label={`Rechazar descripción de ${entry.codigo}`}
+                          title="Rechazar"
+                          className={
+                            "rounded p-1 transition-colors duration-150 " +
+                            (entry.status === 'rejected' || isLoading
+                              ? "text-gray-300 dark:text-gray-600 cursor-not-allowed"
+                              : "text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20")
+                          }
+                        >
+                          <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                            <path
+                              fillRule="evenodd"
+                              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                              clipRule="evenodd"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* ── Paginación ── */}
+      {totalPaginas > 1 && (
+        <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+          <span>
+            {paginaActual * PAGE_SIZE + 1}–
+            {Math.min((paginaActual + 1) * PAGE_SIZE, entradaFiltradas.length)}{' '}
+            de {entradaFiltradas.length}
+          </span>
+          <div className="flex gap-1">
+            <button
+              type="button"
+              disabled={paginaActual === 0}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              className="rounded px-2 py-1 border border-gray-200 dark:border-gray-700 disabled:opacity-40 hover:bg-gray-50 dark:hover:bg-gray-800"
+              aria-label="Página anterior"
+            >
+              ‹
+            </button>
+            <span className="px-2 py-1">
+              {paginaActual + 1} / {totalPaginas}
+            </span>
+            <button
+              type="button"
+              disabled={paginaActual >= totalPaginas - 1}
+              onClick={() => setPage((p) => Math.min(totalPaginas - 1, p + 1))}
+              className="rounded px-2 py-1 border border-gray-200 dark:border-gray-700 disabled:opacity-40 hover:bg-gray-50 dark:hover:bg-gray-800"
+              aria-label="Página siguiente"
+            >
+              ›
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ── Botón completar ── */}
+      {revisadas === entries.length && entries.length > 0 && (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onComplete}
+            className={
+              "px-4 py-2 rounded-lg text-sm font-semibold text-white " +
+              "bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 " +
+              "transition-colors duration-150"
+            }
+          >
+            Revisión completada
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ReviewPanel

--- a/tests/integration/test_review_panel.py
+++ b/tests/integration/test_review_panel.py
@@ -1,0 +1,715 @@
+"""
+Tests de integración para el panel de revisión manual de descripciones (Fase 7.3).
+
+Cubre:
+  PATCH  /api/v1/jobs/{job_id}/descriptions/{codigo}  — Revisar una descripción
+  GET    /api/v1/jobs/{job_id}/descriptions/review     — Estado paginado de revisiones
+  GET    /api/v1/files/{job_id}/csv?only_approved=true — Exportar solo aprobadas
+
+Redis y Celery se mockean. El storage se simula con archivos temporales (tmp_path).
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+# ── Variables de entorno antes de importar la app ────────────────────────────
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("SECRET_KEY", "clave-de-prueba-super-segura-32c")
+os.environ.setdefault("BROWSER_BINARY_PATH", "/usr/bin/google-chrome")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_BROKER_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_RESULT_BACKEND", "redis://localhost:6379/1")
+
+from api.core.config import get_settings  # noqa: E402
+get_settings.cache_clear()
+
+from api.main import app  # noqa: E402
+from api.v1.schemas.job import (  # noqa: E402
+    DescriptionReviewState,
+    EstadoJob,
+    JobStatus,
+    ReviewStatus,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_CSV_FIELDNAMES = [
+    "codigo", "nombre", "marca", "categoria",
+    "corta", "larga", "keywords", "meta_description", "exitoso", "error",
+]
+
+_SAMPLE_PRODUCTS = [
+    {
+        "codigo": "PROD001",
+        "nombre": "Pienso Gato Adulto",
+        "marca": "Royal Canin",
+        "categoria": "Alimentación",
+        "corta": "Descripción corta generada.",
+        "larga": "Descripción larga generada.",
+        "keywords": "gato,pienso",
+        "meta_description": "Meta descripción.",
+        "exitoso": "True",
+        "error": "",
+    },
+    {
+        "codigo": "PROD002",
+        "nombre": "Cama Perro Grande",
+        "marca": "Ferplast",
+        "categoria": "Descanso",
+        "corta": "Cama cómoda.",
+        "larga": "Cama ortopédica para perros grandes.",
+        "keywords": "cama,perro",
+        "meta_description": "Cama para perros.",
+        "exitoso": "True",
+        "error": "",
+    },
+]
+
+
+def _build_descriptions_csv(products: list[dict] | None = None) -> bytes:
+    """Serializa productos a CSV UTF-8 BOM (mismo formato que el pipeline)."""
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=_CSV_FIELDNAMES)
+    writer.writeheader()
+    for p in (products or _SAMPLE_PRODUCTS):
+        writer.writerow(p)
+    return buf.getvalue().encode("utf-8-sig")
+
+
+def _build_job_status(
+    job_id: str,
+    estado: EstadoJob = EstadoJob.COMPLETADO,
+    descripciones_generadas: int = 2,
+    revisiones_pendientes: int = 2,
+    revisiones_aprobadas: int = 0,
+    revisiones_rechazadas: int = 0,
+) -> JobStatus:
+    """Construye un JobStatus de prueba para un job de descripciones."""
+    return JobStatus(
+        job_id=uuid.UUID(job_id),
+        estado=estado,
+        total_productos=2,
+        productos_procesados=2,
+        descripciones_generadas=descripciones_generadas,
+        revisiones_pendientes=revisiones_pendientes,
+        revisiones_aprobadas=revisiones_aprobadas,
+        revisiones_rechazadas=revisiones_rechazadas,
+        mensaje="Estado de prueba.",
+    )
+
+
+def _build_redis_mock(
+    job_status_json: str | None,
+    review_states: dict[str, str] | None = None,
+    captured_sets: list | None = None,
+) -> AsyncMock:
+    """
+    Construye un mock de aioredis.
+
+    Args:
+        job_status_json: JSON serializado del JobStatus, o None si no existe.
+        review_states:   Mapa de review_key → JSON serializado de DescriptionReviewState.
+        captured_sets:   Lista mutable donde se acumularán las llamadas a redis.set.
+
+    Returns:
+        AsyncMock de la conexión Redis.
+    """
+    if review_states is None:
+        review_states = {}
+    if captured_sets is None:
+        captured_sets = []
+
+    async def get_side_effect(key: str) -> str | None:
+        if ":review:" in key:
+            return review_states.get(key)
+        return job_status_json
+
+    async def set_side_effect(key: str, value: str, ex: int | None = None) -> bool:  # noqa: ARG001
+        captured_sets.append((key, value))
+        return True
+
+    mock = AsyncMock()
+    mock.get = AsyncMock(side_effect=get_side_effect)
+    mock.set = AsyncMock(side_effect=set_side_effect)
+    mock.aclose = AsyncMock()
+    return mock
+
+
+def _build_storage_mock(tmp_path: Path, job_id: str, csv_bytes: bytes | None = None) -> MagicMock:
+    """
+    Mock de StorageService que crea un directorio temporal con descripciones.csv.
+
+    Args:
+        tmp_path:  Directorio temporal de pytest.
+        job_id:    Identificador del job.
+        csv_bytes: Contenido del CSV; si None, no crea el archivo.
+
+    Returns:
+        MagicMock que expone get_job_dir.
+    """
+    job_dir = tmp_path / job_id
+    job_dir.mkdir(parents=True, exist_ok=True)
+
+    if csv_bytes is not None:
+        (job_dir / "descripciones.csv").write_bytes(csv_bytes)
+
+    mock = MagicMock()
+    mock.get_job_dir.return_value = job_dir
+    return mock
+
+
+# ── Fixture ───────────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def async_client() -> AsyncClient:
+    """
+    Cliente HTTPX asíncrono con ASGITransport para llamar a la app sin servidor real.
+
+    Yields:
+        AsyncClient listo para enviar peticiones a la app de test.
+    """
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+
+
+# ── PATCH /api/v1/jobs/{job_id}/descriptions/{codigo} ─────────────────────────
+
+
+class TestRevisarDescripcion:
+    """Suite de tests para PATCH .../descriptions/{codigo}."""
+
+    @pytest.mark.asyncio
+    async def test_404_cuando_job_no_existe(self, async_client: AsyncClient) -> None:
+        """
+        Verifica 404 cuando el job no existe en Redis.
+        """
+        redis = _build_redis_mock(job_status_json=None)
+        with patch("api.v1.endpoints.jobs._get_redis", return_value=redis):
+            response = await async_client.patch(
+                f"/api/v1/jobs/{uuid.uuid4()}/descriptions/PROD001",
+                json={"action": "approve"},
+            )
+        assert response.status_code == 404
+        assert "detail" in response.json()
+
+    @pytest.mark.asyncio
+    async def test_404_cuando_producto_no_existe_en_csv(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica 404 cuando el producto no está en descripciones.csv.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id)
+        redis = _build_redis_mock(status.model_dump_json())
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.patch(
+                f"/api/v1/jobs/{job_id}/descriptions/NO_EXISTE",
+                json={"action": "approve"},
+            )
+        assert response.status_code == 404
+        assert "NO_EXISTE" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_409_cuando_job_no_completado(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica 409 cuando el job está EN_PROCESO y no permite revisión.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id, estado=EstadoJob.EN_PROCESO)
+        redis = _build_redis_mock(status.model_dump_json())
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.patch(
+                f"/api/v1/jobs/{job_id}/descriptions/PROD001",
+                json={"action": "approve"},
+            )
+        assert response.status_code == 409
+        assert "COMPLETADO" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_422_edit_sin_edited_text(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica 422 cuando action='edit' pero edited_text está ausente.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id)
+        redis = _build_redis_mock(status.model_dump_json())
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.patch(
+                f"/api/v1/jobs/{job_id}/descriptions/PROD001",
+                json={"action": "edit"},
+            )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_approve_devuelve_status_approved(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que approve devuelve status='approved' en la respuesta.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id)
+        redis = _build_redis_mock(status.model_dump_json())
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.patch(
+                f"/api/v1/jobs/{job_id}/descriptions/PROD001",
+                json={"action": "approve"},
+            )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"]["status"] == "approved"
+        assert body["data"]["codigo"] == "PROD001"
+
+    @pytest.mark.asyncio
+    async def test_reject_devuelve_status_rejected(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que reject devuelve status='rejected' en la respuesta.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id)
+        redis = _build_redis_mock(status.model_dump_json())
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.patch(
+                f"/api/v1/jobs/{job_id}/descriptions/PROD001",
+                json={"action": "reject"},
+            )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["data"]["status"] == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_edit_guarda_edited_text_y_devuelve_approved(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que edit guarda edited_text y devuelve status='approved'.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id)
+        redis = _build_redis_mock(status.model_dump_json())
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+        texto_editado = "Descripción corta editada por el usuario."
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.patch(
+                f"/api/v1/jobs/{job_id}/descriptions/PROD001",
+                json={"action": "edit", "edited_text": texto_editado},
+            )
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["status"] == "approved"
+        assert data["edited_text"] == texto_editado
+
+    @pytest.mark.asyncio
+    async def test_estado_revisado_persistido_en_redis(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que redis.set es llamado con la clave de revisión correcta
+        y que el estado serializado contiene status=approved.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id)
+        captured_sets: list = []
+        redis = _build_redis_mock(status.model_dump_json(), captured_sets=captured_sets)
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            await async_client.patch(
+                f"/api/v1/jobs/{job_id}/descriptions/PROD001",
+                json={"action": "approve"},
+            )
+
+        review_key = f"job:{job_id}:review:PROD001"
+        keys_written = [k for k, _ in captured_sets]
+        assert review_key in keys_written
+
+        review_value = next(v for k, v in captured_sets if k == review_key)
+        persisted = json.loads(review_value)
+        assert persisted["status"] == "approved"
+
+    @pytest.mark.asyncio
+    async def test_approve_incrementa_contador_revisiones_aprobadas(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que al aprobar, revisiones_aprobadas en JobStatus incrementa en 1.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id, revisiones_pendientes=2, revisiones_aprobadas=0)
+        captured_sets: list = []
+        redis = _build_redis_mock(status.model_dump_json(), captured_sets=captured_sets)
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.patch(
+                f"/api/v1/jobs/{job_id}/descriptions/PROD001",
+                json={"action": "approve"},
+            )
+        assert response.status_code == 200
+
+        job_key = f"job:{job_id}"
+        job_set_value = next((v for k, v in captured_sets if k == job_key), None)
+        assert job_set_value is not None
+        updated_status = json.loads(job_set_value)
+        assert updated_status["revisiones_aprobadas"] == 1
+
+    @pytest.mark.asyncio
+    async def test_reject_incrementa_contador_revisiones_rechazadas(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que al rechazar, revisiones_rechazadas en JobStatus incrementa en 1.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id, revisiones_pendientes=2, revisiones_rechazadas=0)
+        captured_sets: list = []
+        redis = _build_redis_mock(status.model_dump_json(), captured_sets=captured_sets)
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.patch(
+                f"/api/v1/jobs/{job_id}/descriptions/PROD001",
+                json={"action": "reject"},
+            )
+        assert response.status_code == 200
+
+        job_key = f"job:{job_id}"
+        job_set_value = next((v for k, v in captured_sets if k == job_key), None)
+        assert job_set_value is not None
+        updated_status = json.loads(job_set_value)
+        assert updated_status["revisiones_rechazadas"] == 1
+
+
+# ── GET /api/v1/jobs/{job_id}/descriptions/review ─────────────────────────────
+
+
+class TestObtenerEstadoRevisiones:
+    """Suite de tests para GET .../descriptions/review."""
+
+    @pytest.mark.asyncio
+    async def test_retorna_lista_paginada_con_estado_revisiones(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que el endpoint devuelve 200 con items paginados y metadatos de total.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id)
+        redis = _build_redis_mock(status.model_dump_json())
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.get(
+                f"/api/v1/jobs/{job_id}/descriptions/review",
+                params={"limit": 10, "offset": 0},
+            )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        data = body["data"]
+        assert "items" in data
+        assert "total" in data
+        assert data["total"] == len(_SAMPLE_PRODUCTS)
+        assert len(data["items"]) == len(_SAMPLE_PRODUCTS)
+
+    @pytest.mark.asyncio
+    async def test_descripcion_sin_revisar_tiene_status_pending(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que las descripciones sin entrada en Redis se devuelven con status='pending'.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id)
+        # Sin review_states → todas pending
+        redis = _build_redis_mock(status.model_dump_json(), review_states={})
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.get(
+                f"/api/v1/jobs/{job_id}/descriptions/review",
+            )
+        assert response.status_code == 200
+        items = response.json()["data"]["items"]
+        for item in items:
+            assert item["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_descripcion_con_estado_en_redis_devuelve_estado_correcto(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que las descripciones con entrada en Redis devuelven su estado real.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id, revisiones_aprobadas=1)
+        review_key = f"job:{job_id}:review:PROD001"
+        approved_state = DescriptionReviewState(
+            codigo="PROD001", status=ReviewStatus.APPROVED
+        )
+        redis = _build_redis_mock(
+            status.model_dump_json(),
+            review_states={review_key: approved_state.model_dump_json()},
+        )
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.get(
+                f"/api/v1/jobs/{job_id}/descriptions/review",
+            )
+        assert response.status_code == 200
+        items = response.json()["data"]["items"]
+        prod1 = next(i for i in items if i["codigo"] == "PROD001")
+        assert prod1["status"] == "approved"
+
+    @pytest.mark.asyncio
+    async def test_400_cuando_limit_supera_100(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica 400 cuando limit > 100 (fuera del rango permitido).
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id)
+        redis = _build_redis_mock(status.model_dump_json())
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.get(
+                f"/api/v1/jobs/{job_id}/descriptions/review",
+                params={"limit": 200},
+            )
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_404_cuando_no_existe_descripciones_csv_en_get_review(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica 404 cuando el job existe pero no hay descripciones.csv.
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(job_id)
+        redis = _build_redis_mock(status.model_dump_json())
+        # storage sin CSV (csv_bytes=None)
+        storage = _build_storage_mock(tmp_path, job_id, csv_bytes=None)
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.get(
+                f"/api/v1/jobs/{job_id}/descriptions/review",
+            )
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_rerevisar_approved_a_rejected_actualiza_contadores(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que al cambiar una descripción de approved a rejected los
+        contadores se actualizan correctamente (revert approved + increment rejected).
+        """
+        job_id = str(uuid.uuid4())
+        status = _build_job_status(
+            job_id, revisiones_pendientes=0, revisiones_aprobadas=1, revisiones_rechazadas=0
+        )
+        # La descripción ya estaba aprobada en Redis
+        review_key = f"job:{job_id}:review:PROD001"
+        old_approved = DescriptionReviewState(codigo="PROD001", status=ReviewStatus.APPROVED)
+        captured_sets: list = []
+        redis = _build_redis_mock(
+            status.model_dump_json(),
+            review_states={review_key: old_approved.model_dump_json()},
+            captured_sets=captured_sets,
+        )
+        storage = _build_storage_mock(tmp_path, job_id, _build_descriptions_csv())
+
+        with (
+            patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+            patch("api.v1.endpoints.jobs.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.patch(
+                f"/api/v1/jobs/{job_id}/descriptions/PROD001",
+                json={"action": "reject"},
+            )
+        assert response.status_code == 200
+        assert response.json()["data"]["status"] == "rejected"
+
+        job_key = f"job:{job_id}"
+        job_set_value = next((v for k, v in captured_sets if k == job_key), None)
+        assert job_set_value is not None
+        updated = json.loads(job_set_value)
+        assert updated["revisiones_aprobadas"] == 0
+        assert updated["revisiones_rechazadas"] == 1
+
+
+# ── GET /api/v1/files/{job_id}/csv ────────────────────────────────────────────
+
+
+class TestDescargarCsvAprobadas:
+    """Suite de tests para GET /api/v1/files/{job_id}/csv con only_approved."""
+
+    @pytest.mark.asyncio
+    async def test_only_approved_devuelve_solo_filas_aprobadas(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que ?only_approved=true filtra y devuelve solo las filas aprobadas.
+        """
+        job_id = str(uuid.uuid4())
+        csv_bytes = _build_descriptions_csv()
+
+        review_key_prod1 = f"job:{job_id}:review:PROD001"
+        approved_state = DescriptionReviewState(
+            codigo="PROD001", status=ReviewStatus.APPROVED
+        )
+        review_states = {review_key_prod1: approved_state.model_dump_json()}
+
+        async def redis_get(key: str) -> str | None:
+            return review_states.get(key)
+
+        redis_mock = AsyncMock()
+        redis_mock.get = AsyncMock(side_effect=redis_get)
+        redis_mock.aclose = AsyncMock()
+
+        storage = _build_storage_mock(tmp_path, job_id, csv_bytes)
+
+        with (
+            patch("api.v1.endpoints.files.aioredis.from_url", return_value=redis_mock),
+            patch("api.v1.endpoints.files.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.get(
+                f"/api/v1/files/{job_id}/csv",
+                params={"only_approved": "true"},
+            )
+        assert response.status_code == 200
+        content = response.content.decode("utf-8-sig")
+        assert "PROD001" in content
+        assert "PROD002" not in content
+
+    @pytest.mark.asyncio
+    async def test_only_approved_devuelve_204_si_ninguna_aprobada(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que ?only_approved=true devuelve 204 cuando ninguna descripción
+        tiene estado 'approved' en Redis.
+        """
+        job_id = str(uuid.uuid4())
+        csv_bytes = _build_descriptions_csv()
+
+        async def redis_get(key: str) -> None:  # noqa: ARG001
+            return None  # ninguna aprobada
+
+        redis_mock = AsyncMock()
+        redis_mock.get = AsyncMock(side_effect=redis_get)
+        redis_mock.aclose = AsyncMock()
+
+        storage = _build_storage_mock(tmp_path, job_id, csv_bytes)
+
+        with (
+            patch("api.v1.endpoints.files.aioredis.from_url", return_value=redis_mock),
+            patch("api.v1.endpoints.files.get_storage_service", return_value=storage),
+        ):
+            response = await async_client.get(
+                f"/api/v1/files/{job_id}/csv",
+                params={"only_approved": "true"},
+            )
+        assert response.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_sin_only_approved_devuelve_csv_completo(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """
+        Verifica que sin el parámetro only_approved el CSV original se devuelve
+        sin filtrar (comportamiento original).
+        """
+        job_id = str(uuid.uuid4())
+        csv_bytes = _build_descriptions_csv()
+        storage = _build_storage_mock(tmp_path, job_id, csv_bytes)
+
+        with patch("api.v1.endpoints.files.get_storage_service", return_value=storage):
+            response = await async_client.get(f"/api/v1/files/{job_id}/csv")
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8-sig")
+        assert "PROD001" in content
+        assert "PROD002" in content

--- a/workers/tasks.py
+++ b/workers/tasks.py
@@ -354,6 +354,7 @@ def ejecutar_scraping(
         if config.tipo_job == TipoJob.DESCRIPCIONES:
             job_status.total_productos = resumen["total_productos"]
             job_status.descripciones_generadas = resumen.get("descripciones_generadas", 0)
+            job_status.revisiones_pendientes = resumen.get("descripciones_generadas", 0)
             if config.target_languages:
                 job_status.mensaje = (
                     f"Completado: {resumen.get('descripciones_generadas', 0)} descripciones generadas "


### PR DESCRIPTION
## Summary

- **Schemas** (`api/v1/schemas/job.py`): add `ReviewAction`, `ReviewStatus`, `DescriptionReviewRequest`, `DescriptionReviewState`, `DescriptionReviewEntry`; add `revisiones_pendientes/aprobadas/rechazadas` counters to `JobStatus`
- **Endpoints** (`api/v1/endpoints/jobs.py`): `PATCH /jobs/{job_id}/descriptions/{codigo}` (approve/reject/edit) and `GET /jobs/{job_id}/descriptions/review` (paginated review list); review state persisted in Redis with job TTL; counters updated on each action
- **Files endpoint** (`api/v1/endpoints/files.py`): `?only_approved=true` on `GET /files/{job_id}/csv` to export only approved descriptions; returns 204 if none approved
- **Frontend** (`ReviewPanel.tsx` + `client.ts` + `App.tsx`): collapsible review panel in completed descripciones job view; inline editing (blur/Enter confirm, Escape cancel); tabs (all/pending/approved/rejected); bulk approve; export aprobadas button
- **Tests** (`tests/integration/test_review_panel.py`): 19 integration tests covering 404/409/422 error paths, all state transitions, counter management, pagination, and CSV export filter
- **Reviewer fixes**: initialize `revisiones_pendientes` on job completion, surface action errors to UI (no more silent catch), guard blur+Enter double-submit with a ref, move deferred imports to module level

## Test plan

- [ ] `pytest tests/integration/test_review_panel.py -v` → 19 passed
- [ ] `pytest` → 215 passed
- [ ] `npm run type-check` → no errors
- [ ] `npm run build` → build successful
- [ ] files.py coverage: 88% ✓ | jobs.py coverage (excluding WebSocket + cancel/resume pre-existing): review endpoints covered
- [ ] Manual: create a descripciones job, wait for completion, open review panel, approve/reject/edit rows, export aprobadas CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)