### PR TITLE
feat(fase7.4): brand validation panel before writing to brand_cache.json

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,3 +166,10 @@ ROTATING_PROXY_URL=
 BRAND_HTTP_TIMEOUT=10
 # Timeout HTTP para extracción de marca desde Amazon.es (segundos)
 AMAZON_HTTP_TIMEOUT=10
+
+# ==========================================
+# BATERÍA LOCAL DE MARCAS — FASE 7.4
+# ==========================================
+# Ruta al JSON de batería local de prefijos GS1 aprendidos automáticamente.
+# No subir al repositorio (incluido en .gitignore bajo data/).
+BRAND_CACHE_PATH=data/brand_cache.json

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,10 @@ imagenes_descargadas/
 # Logs rotativos de loguru
 logs/
 
+# Batería local de prefijos GS1 (aprendidos en runtime — no subir al repo)
+data/brand_cache.json
+data/gs1_prefixes.db
+
 # Archivos de control del scraper
 registro_miniaturas.txt
 productos_sin_imagen.txt

--- a/api/core/config.py
+++ b/api/core/config.py
@@ -124,6 +124,34 @@ class Settings(BaseSettings):
         ),
     )
 
+    # ── Batería local de marcas — Fase 7.4 ───────────────────────────────────────
+    brand_cache_path: str = Field(
+        default="data/brand_cache.json",
+        description=(
+            "Ruta al JSON de batería local de prefijos GS1 conocidos "
+            "(brand_cache.json). Relativa al directorio raíz del proyecto."
+        ),
+    )
+
+    @field_validator("brand_cache_path")
+    @classmethod
+    def brand_cache_path_not_empty(cls, v: str) -> str:
+        """
+        Valida que la ruta al brand_cache.json no esté vacía.
+
+        Args:
+            v: valor del campo brand_cache_path.
+
+        Returns:
+            Ruta limpia (strip).
+
+        Raises:
+            ValueError: si la ruta está vacía o solo contiene espacios.
+        """
+        if not v or not v.strip():
+            raise ValueError("brand_cache_path no puede estar vacío.")
+        return v.strip()
+
     # ── Scraper — motor de búsqueda ───────────────────────────────────────────
     search_engine: Literal["bing", "google", "duckduckgo"] = Field(
         default="bing",

--- a/api/core/config.py
+++ b/api/core/config.py
@@ -5,6 +5,7 @@ Todas las variables se leen exclusivamente desde variables de entorno o archivo 
 NUNCA hardcodear valores aquí — usar siempre get_settings().
 
 :author: BenjaminDTS
+:author: Carlitos6712
 :version: 1.0.0
 """
 
@@ -24,6 +25,7 @@ class Settings(BaseSettings):
     Pydantic lanzará un ValidationError antes de que la app sirva tráfico.
 
     :author: BenjaminDTS
+    :author: Carlitos6712
     """
 
     model_config = SettingsConfigDict(

--- a/api/v1/endpoints/jobs.py
+++ b/api/v1/endpoints/jobs.py
@@ -5,6 +5,7 @@ Rutas expuestas:
   POST   /api/v1/jobs                                          — Crear un nuevo job con CSV + configuración
   GET    /api/v1/jobs/{job_id}                                 — Consultar el estado de un job
   GET    /api/v1/jobs/{job_id}/brands                          — Obtener marcas resueltas como JSON (Fase 6.4)
+  POST   /api/v1/jobs/{job_id}/brands/validate                 — Validar marcas nuevas (Fase 7.4)
   POST   /api/v1/jobs/{job_id}/cancel                          — Cancelar un job en curso
   POST   /api/v1/jobs/{job_id}/resume                          — Reanudar un job cancelado o fallido
   PATCH  /api/v1/jobs/{job_id}/descriptions/{codigo}           — Revisar (aprobar/rechazar/editar) una descripción (Fase 7.3)
@@ -16,12 +17,13 @@ Ninguna lógica de negocio vive aquí.
 
 :author: BenjaminDTS
 :author: Carlitos6712
-:version: 1.3.0
+:version: 1.4.0
 """
 
 import csv
 import io
 import json
+import threading as _threading
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -45,6 +47,8 @@ from api.core.config import get_settings
 from api.core.security import limiter
 from services.storage_service import get_storage_service
 from api.v1.schemas.job import (
+    BrandValidationAction,
+    BrandValidationRequest,
     ColumnMapping,
     DescriptionReviewEntry,
     DescriptionReviewRequest,
@@ -74,6 +78,10 @@ _JOB_CONFIG_KEY = "job:{job_id}:config"
 _KEY_TTL = settings.file_ttl_seconds
 # Clave Redis donde se almacena el estado de revisión de una descripción individual
 _JOB_REVIEW_KEY = "job:{job_id}:review:{codigo}"
+# Clave Redis donde se almacenan las marcas pendientes de validación (Fase 7.4)
+_BRANDS_PENDING_KEY = "job:{job_id}:brands_pending"
+# Lock a nivel de módulo para proteger escrituras concurrentes en brand_cache.json
+_BRAND_CACHE_WRITE_LOCK: _threading.Lock = _threading.Lock()
 
 
 async def _get_redis() -> aioredis.Redis:
@@ -187,6 +195,15 @@ async def crear_job(
             )
         ),
     ] = None,
+    validate_brands: Annotated[
+        bool,
+        Form(
+            description=(
+                "Si True, el job espera validación manual de marcas nuevas antes de escribirlas "
+                "en brand_cache.json (Fase 7.4). Solo aplica con tipo_job=marcas."
+            )
+        ),
+    ] = False,
 ) -> JSONResponse:
     """
     Recibe un CSV de inventario, encola el trabajo de scraping y devuelve el job_id.
@@ -238,6 +255,7 @@ async def crear_job(
         groq_api_key_usuario=groq_api_key_usuario,
         store_type_usuario=store_type_usuario,
         target_languages=target_languages or [],
+        validate_brands=validate_brands,
         column_mapping=ColumnMapping(
             columna_codigo=columna_codigo,
             columna_ean=columna_ean,
@@ -430,6 +448,182 @@ async def obtener_marcas_job(job_id: str) -> JSONResponse:
             "message": f"{len(brands)} marcas procesadas: {brands_resolved} resueltas, {brands_not_found} sin resolver.",
         }
     )
+
+
+@router.post(
+    "/{job_id}/brands/validate",
+    response_model=JobResponse,
+    summary="Validar marcas nuevas y persistirlas en brand_cache.json (Fase 7.4)",
+)
+async def validar_marcas(
+    job_id: str,
+    body: BrandValidationRequest,
+) -> JSONResponse:
+    """
+    Procesa la decisión del usuario sobre las marcas nuevas detectadas en el job.
+
+    Solo los items con action != 'reject' se escriben en brand_cache.json.
+    Tras la validación, el job pasa a estado COMPLETADO.
+
+    Args:
+        job_id: identificador UUID del job en estado PENDIENTE_VALIDACION_MARCAS.
+        body: lista de marcas con la decisión del usuario por cada una.
+
+    Returns:
+        JSONResponse con el resumen de marcas aceptadas, rechazadas y editadas.
+
+    Raises:
+        HTTPException 404: si el job no existe.
+        HTTPException 409: si el job no está en PENDIENTE_VALIDACION_MARCAS.
+        HTTPException 422: si el body es inválido (validado automáticamente por FastAPI).
+    """
+    redis = await _get_redis()
+    try:
+        job_status = await _get_job_status(redis, job_id)
+
+        if job_status.estado != EstadoJob.PENDIENTE_VALIDACION_MARCAS:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"El job '{job_id}' no está en estado "
+                    f"'{EstadoJob.PENDIENTE_VALIDACION_MARCAS.value}'. "
+                    f"Estado actual: '{job_status.estado.value}'."
+                ),
+            )
+
+        # Leer las marcas pendientes de Redis
+        pending_raw = await redis.get(_BRANDS_PENDING_KEY.format(job_id=job_id))
+        pending: dict[str, str] = json.loads(pending_raw) if pending_raw else {}
+
+        # Procesar las decisiones del usuario
+        accepted = 0
+        rejected = 0
+        edited = 0
+        entries_to_write: dict[str, str] = {}
+
+        for item in body.items:
+            prefijo = item.ean[:7] if len(item.ean) >= 7 else item.ean
+
+            if item.action == BrandValidationAction.REJECT:
+                rejected += 1
+                logger.info(
+                    "Marca rechazada — no se escribe en brand_cache.json",
+                    extra={
+                        "job_id": job_id,
+                        "ean": item.ean,
+                        "prefijo": prefijo,
+                        "brand_name": item.brand_name,
+                        "action": item.action.value,
+                    },
+                )
+            elif item.action == BrandValidationAction.EDIT:
+                nombre_final = item.edited_name or item.brand_name
+                entries_to_write[prefijo] = nombre_final
+                edited += 1
+                logger.info(
+                    "Marca editada — se escribe en brand_cache.json",
+                    extra={
+                        "job_id": job_id,
+                        "ean": item.ean,
+                        "prefijo": prefijo,
+                        "brand_name_original": item.brand_name,
+                        "brand_name_editado": nombre_final,
+                        "action": item.action.value,
+                    },
+                )
+            else:  # ACCEPT
+                entries_to_write[prefijo] = item.brand_name
+                accepted += 1
+                logger.info(
+                    "Marca aceptada — se escribe en brand_cache.json",
+                    extra={
+                        "job_id": job_id,
+                        "ean": item.ean,
+                        "prefijo": prefijo,
+                        "brand_name": item.brand_name,
+                        "action": item.action.value,
+                    },
+                )
+
+        # Persistir las entradas aceptadas/editadas en brand_cache.json
+        merged: dict[str, str] = {}
+        if entries_to_write:
+            brand_cache_path = Path(settings.brand_cache_path)
+
+            with _BRAND_CACHE_WRITE_LOCK:
+                existing: dict[str, str] = {}
+                if brand_cache_path.exists():
+                    try:
+                        existing = json.loads(
+                            brand_cache_path.read_text(encoding="utf-8")
+                        )
+                    except (json.JSONDecodeError, OSError) as exc:
+                        logger.error(
+                            "Error leyendo brand_cache.json; se sobreescribirá",
+                            exc_info=exc,
+                            extra={"job_id": job_id},
+                        )
+
+                merged = {**existing, **entries_to_write}
+                brand_cache_path.parent.mkdir(parents=True, exist_ok=True)
+                brand_cache_path.write_text(
+                    json.dumps(merged, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+
+            logger.info(
+                "brand_cache.json actualizado tras validación",
+                extra={
+                    "job_id": job_id,
+                    "entradas_nuevas": len(entries_to_write),
+                    "total_en_cache": len(merged),
+                },
+            )
+
+        # Eliminar la clave de marcas pendientes de Redis
+        await redis.delete(_BRANDS_PENDING_KEY.format(job_id=job_id))
+
+        # Actualizar estado del job a COMPLETADO
+        job_status.estado = EstadoJob.COMPLETADO
+        job_status.completado_en = datetime.utcnow()
+        job_status.actualizado_en = datetime.utcnow()
+        job_status.marcas_pendientes_validacion = 0
+        job_status.mensaje = (
+            f"Validación de marcas completada: {accepted} aceptadas, "
+            f"{edited} editadas, {rejected} rechazadas."
+        )
+        await redis.set(
+            _JOB_KEY.format(job_id=job_id),
+            job_status.model_dump_json(),
+            ex=_KEY_TTL,
+        )
+
+        logger.info(
+            "Validación de marcas completada",
+            extra={
+                "job_id": job_id,
+                "accepted": accepted,
+                "rejected": rejected,
+                "edited": edited,
+            },
+        )
+
+        return JSONResponse(
+            content={
+                "success": True,
+                "data": {
+                    "accepted": accepted,
+                    "rejected": rejected,
+                    "edited": edited,
+                },
+                "message": (
+                    f"Validación completada: {accepted} marcas guardadas, "
+                    f"{edited} editadas, {rejected} rechazadas."
+                ),
+            }
+        )
+    finally:
+        await redis.aclose()
 
 
 @router.post(
@@ -901,8 +1095,13 @@ async def websocket_progreso(websocket: WebSocket, job_id: str) -> None:
             )
             await websocket.send_json(event.model_dump())
 
-            # Cerrar cuando el job ha terminado
-            if status.estado in (EstadoJob.COMPLETADO, EstadoJob.FALLIDO, EstadoJob.CANCELADO):
+            # Cerrar cuando el job ha terminado o queda en espera de validación manual
+            if status.estado in (
+                EstadoJob.COMPLETADO,
+                EstadoJob.FALLIDO,
+                EstadoJob.CANCELADO,
+                EstadoJob.PENDIENTE_VALIDACION_MARCAS,
+            ):
                 break
 
             await asyncio.sleep(1)

--- a/api/v1/endpoints/jobs.py
+++ b/api/v1/endpoints/jobs.py
@@ -5,6 +5,7 @@ Rutas expuestas:
   POST   /api/v1/jobs                                          — Crear un nuevo job con CSV + configuración
   GET    /api/v1/jobs/{job_id}                                 — Consultar el estado de un job
   GET    /api/v1/jobs/{job_id}/brands                          — Obtener marcas resueltas como JSON (Fase 6.4)
+  GET    /api/v1/jobs/{job_id}/brands/pending                  — Obtener marcas pendientes de validación (Fase 7.4)
   POST   /api/v1/jobs/{job_id}/brands/validate                 — Validar marcas nuevas (Fase 7.4)
   POST   /api/v1/jobs/{job_id}/cancel                          — Cancelar un job en curso
   POST   /api/v1/jobs/{job_id}/resume                          — Reanudar un job cancelado o fallido
@@ -448,6 +449,73 @@ async def obtener_marcas_job(job_id: str) -> JSONResponse:
             "message": f"{len(brands)} marcas procesadas: {brands_resolved} resueltas, {brands_not_found} sin resolver.",
         }
     )
+
+
+@router.get(
+    "/{job_id}/brands/pending",
+    response_model=JobResponse,
+    summary="Obtener marcas pendientes de validación (Fase 7.4)",
+)
+async def obtener_marcas_pendientes(job_id: str) -> JSONResponse:
+    """
+    Devuelve la lista de marcas nuevas pendientes de validación para un job.
+
+    Args:
+        job_id: identificador UUID del job en estado PENDIENTE_VALIDACION_MARCAS.
+
+    Returns:
+        JSONResponse con la lista de marcas pendientes.
+
+    Raises:
+        HTTPException 404: si el job no existe o no tiene marcas pendientes.
+        HTTPException 409: si el job no está en PENDIENTE_VALIDACION_MARCAS.
+    """
+    redis = await _get_redis()
+    try:
+        job_status = await _get_job_status(redis, job_id)
+
+        if job_status.estado != EstadoJob.PENDIENTE_VALIDACION_MARCAS:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"El job '{job_id}' no está en estado "
+                    f"'{EstadoJob.PENDIENTE_VALIDACION_MARCAS.value}'."
+                ),
+            )
+
+        pending_raw = await redis.get(_BRANDS_PENDING_KEY.format(job_id=job_id))
+        if pending_raw is None:
+            return JSONResponse(
+                content={
+                    "success": True,
+                    "data": {"items": []},
+                    "message": "Sin marcas pendientes.",
+                }
+            )
+
+        # brands_pending is dict[str, dict[str, str]] = {prefijo: {brand_name, ean, source, confidence}}
+        pending: dict[str, dict[str, str]] = json.loads(pending_raw)
+
+        items = [
+            {
+                "prefijo": prefijo,
+                "brand_name": entry.get("brand_name", ""),
+                "ean": entry.get("ean", prefijo),
+                "source": entry.get("source", ""),
+                "confidence": entry.get("confidence", "low"),
+            }
+            for prefijo, entry in pending.items()
+        ]
+
+        return JSONResponse(
+            content={
+                "success": True,
+                "data": {"items": items},
+                "message": f"{len(items)} marcas pendientes de validación.",
+            }
+        )
+    finally:
+        await redis.aclose()
 
 
 @router.post(

--- a/api/v1/schemas/job.py
+++ b/api/v1/schemas/job.py
@@ -34,6 +34,7 @@ class EstadoJob(str, Enum):
     COMPLETADO = "completado"
     FALLIDO = "fallido"
     CANCELADO = "cancelado"
+    PENDIENTE_VALIDACION_MARCAS = "pendiente_validacion_marcas"
 
 
 class ModosBusqueda(str, Enum):
@@ -155,6 +156,66 @@ class DescriptionReviewEntry(DescriptionReviewState):
     descripcion_larga: str = Field(default="", description="Descripción larga generada por IA.")
 
 
+# ── Validación de marcas (Fase 7.4) ───────────────────────────────────────────
+
+class BrandValidationAction(str, Enum):
+    """
+    Acción que el usuario aplica sobre una marca pendiente de validación.
+
+    :author: Carlitos6712
+    """
+
+    ACCEPT = "accept"
+    REJECT = "reject"
+    EDIT = "edit"
+
+
+class BrandValidationItem(BaseModel):
+    """
+    Item de validación de una marca nueva antes de persistirla en brand_cache.json.
+
+    :author: Carlitos6712
+    """
+
+    ean: str = Field(description="Código EAN del producto.")
+    brand_name: str = Field(description="Nombre de marca resuelto por el scraper.")
+    action: BrandValidationAction = Field(
+        description="Decisión del usuario: accept, reject o edit."
+    )
+    edited_name: str | None = Field(
+        default=None,
+        description="Nombre editado por el usuario. Requerido si action es 'edit'.",
+    )
+
+    @model_validator(mode="after")
+    def edited_name_required_when_edit(self) -> "BrandValidationItem":
+        """
+        Valida que edited_name esté presente cuando action es 'edit'.
+
+        Returns:
+            La instancia validada.
+
+        Raises:
+            ValueError: si action es 'edit' y edited_name está ausente o vacío.
+        """
+        if self.action == BrandValidationAction.EDIT and not self.edited_name:
+            raise ValueError("edited_name es requerido cuando action es 'edit'")
+        return self
+
+
+class BrandValidationRequest(BaseModel):
+    """
+    Body de la petición POST para validar marcas nuevas de un job.
+
+    :author: Carlitos6712
+    """
+
+    items: list[BrandValidationItem] = Field(
+        min_length=1,
+        description="Lista de marcas con su decisión. Mínimo 1 item.",
+    )
+
+
 # ── Configuración de búsqueda ─────────────────────────────────────────────────
 
 class ColumnMapping(BaseModel):
@@ -252,6 +313,14 @@ class SearchConfig(BaseModel):
         ),
         examples=[["en", "fr"]],
     )
+    validate_brands: bool = Field(
+        default=False,
+        description=(
+            "Si True, el job espera validación manual antes de escribir "
+            "marcas nuevas en brand_cache.json (Fase 7.4). "
+            "Solo aplica cuando tipo_job=MARCAS."
+        ),
+    )
     column_mapping: ColumnMapping = Field(
         default_factory=ColumnMapping,
         description="Mapeo de columnas del CSV del usuario a los campos internos del parser.",
@@ -344,6 +413,11 @@ class JobStatus(BaseModel):
         default=0,
         ge=0,
         description="Contador de marcas procesadas (Fase 6).",
+    )
+    marcas_pendientes_validacion: int = Field(
+        default=0,
+        ge=0,
+        description="Número de marcas nuevas pendientes de validación (Fase 7.4).",
     )
     revisiones_pendientes: int = Field(
         default=0,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@
  *
  * @author BenjaminDTS | Carlos Vico
  */
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { CsvUploader } from '@/components/CsvUploader'
 import { SearchConfig } from '@/components/SearchConfig'
 import { JobProgress } from '@/components/JobProgress'
@@ -18,9 +18,10 @@ import { JobHistory } from '@/components/JobHistory'
 import { HomeScreen } from '@/components/HomeScreen'
 import { BrandsPanel } from '@/components/BrandsPanel'
 import { ReviewPanel } from '@/components/ReviewPanel'
+import BrandValidationPanel from '@/components/BrandValidationPanel'
 import { NsLogo } from '@/components/NsLogo'
-import { apiClient, getBrands, resumeJob, downloadTranslationCsv } from '@/api/client'
-import type { ApiError, BrandEntry } from '@/api/client'
+import { apiClient, getBrands, getBrandsPending, resumeJob, downloadTranslationCsv } from '@/api/client'
+import type { ApiError, BrandEntry, BrandPendingEntry, BrandValidationResult } from '@/api/client'
 import type { SearchConfigValues, TipoJob } from '@/components/SearchConfig'
 
 /** Estados posibles de la pantalla principal */
@@ -44,6 +45,8 @@ const App: React.FC = () => {
   const [targetLanguages, setTargetLanguages] = useState<string[]>([])
   const [reviewPanelOpen, setReviewPanelOpen] = useState(true)
   const [descripcionesGeneradas, setDescripcionesGeneradas] = useState(0)
+  const [pendingBrands, setPendingBrands] = useState<BrandPendingEntry[]>([])
+  const [brandValidationDone, setBrandValidationDone] = useState(false)
 
   // ── Handlers de HomeScreen ───────────────────────────────────────────────
 
@@ -106,6 +109,7 @@ const App: React.FC = () => {
       config.targetLanguages.forEach((lang) =>
         formData.append('target_languages', lang)
       )
+      formData.append('validate_brands', String(config.validateBrands))
 
       const response = await apiClient.post<{
         success: boolean
@@ -124,9 +128,33 @@ const App: React.FC = () => {
   }
 
   /** Callback: el job completó (exitoso o fallido) */
-  const handleJobFinished = (): void => {
+  const handleJobFinished = useCallback(async (): Promise<void> => {
+    if (!jobId || tipoJob !== 'marcas') {
+      setAppState('done')
+      return
+    }
+
+    try {
+      const response = await apiClient.get<{
+        success: boolean
+        data: { estado: string }
+      }>(`/jobs/${jobId}`)
+
+      if (response.data.data.estado === 'pendiente_validacion_marcas') {
+        const brands = await getBrandsPending(jobId)
+        setPendingBrands(brands)
+      }
+    } catch {
+      // Fall through to done regardless
+    }
     setAppState('done')
-  }
+  }, [jobId, tipoJob])
+
+  /** Callback: el usuario completó la validación de marcas */
+  const handleValidationComplete = useCallback((_result: BrandValidationResult): void => {
+    setPendingBrands([])
+    setBrandValidationDone(true)
+  }, [])
 
   // Cuando un job de descripciones completa, cargamos el contador para el ReviewPanel.
   useEffect(() => {
@@ -176,6 +204,8 @@ const App: React.FC = () => {
     setBrandsLoadError(null)
     setReviewPanelOpen(true)
     setDescripcionesGeneradas(0)
+    setPendingBrands([])
+    setBrandValidationDone(false)
   }
 
   /** Callback: desde el historial el usuario abre un job anterior */
@@ -379,6 +409,26 @@ const App: React.FC = () => {
                       <ReviewPanel jobId={jobId} onComplete={handleReset} />
                     </div>
                   )}
+                </section>
+              )}
+
+            {/* Panel de validación de marcas — visible cuando el job espera validación de marcas nuevas */}
+            {appState === 'done' &&
+              tipoJob === 'marcas' &&
+              jobId !== null &&
+              pendingBrands.length > 0 &&
+              !brandValidationDone && (
+                <section className="w-full max-w-2xl mx-auto">
+                  <div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-white dark:bg-gray-900 p-4">
+                    <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-300 mb-4">
+                      Validar marcas nuevas antes de guardar
+                    </h3>
+                    <BrandValidationPanel
+                      jobId={jobId}
+                      pendingBrands={pendingBrands}
+                      onComplete={handleValidationComplete}
+                    />
+                  </div>
                 </section>
               )}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -144,8 +144,9 @@ const App: React.FC = () => {
         const brands = await getBrandsPending(jobId)
         setPendingBrands(brands)
       }
-    } catch {
-      // Fall through to done regardless
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Error al comprobar el estado del job.'
+      setError(msg)
     }
     setAppState('done')
   }, [jobId, tipoJob])
@@ -173,9 +174,9 @@ const App: React.FC = () => {
       })
   }, [appState, tipoJob, jobId])
 
-  // Cuando el job de marcas completa, cargamos los datos para el panel.
+  // Cuando el job de marcas completa (sin validación pendiente), cargamos los datos para el panel.
   useEffect(() => {
-    if (appState !== 'done' || tipoJob !== 'marcas' || !jobId) return
+    if (appState !== 'done' || tipoJob !== 'marcas' || !jobId || pendingBrands.length > 0) return
     setBrandsLoadError(null)
     getBrands(jobId)
       .then((data) => {
@@ -187,7 +188,7 @@ const App: React.FC = () => {
         const msg = (err as ApiError).message ?? 'No se pudieron cargar las marcas.'
         setBrandsLoadError(msg)
       })
-  }, [appState, tipoJob, jobId])
+  }, [appState, tipoJob, jobId, pendingBrands.length])
 
   /** Reinicia el flujo completo a la pantalla de inicio */
   const handleReset = (): void => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -273,3 +273,81 @@ export async function downloadApprovedCsv(jobId: string): Promise<Blob | null> {
   if (response.status === 204) return null
   return response.data
 }
+
+// ─── Validación de marcas (Fase 7.4) ─────────────────────────────────────────
+
+/** Acción del usuario sobre una marca pendiente de validación. */
+export type BrandValidationAction = 'accept' | 'reject' | 'edit'
+
+/** Marca nueva pendiente de validación antes de persistirse en brand_cache.json. */
+export interface BrandPendingEntry {
+  /** Código EAN del producto. */
+  ean: string
+  /** Nombre de marca resuelto por el scraper. */
+  brand_name: string
+  /** Fuente que resolvió el EAN. */
+  source: BrandSource
+  /** Nivel de confianza del resultado. */
+  confidence: 'high' | 'medium' | 'low'
+  /** Primeros 7 dígitos del EAN (prefijo GS1). */
+  prefijo: string
+}
+
+/** Item de validación enviado al backend. */
+export interface BrandValidationItem {
+  ean: string
+  brand_name: string
+  action: BrandValidationAction
+  edited_name?: string
+}
+
+/** Body de POST /jobs/{jobId}/brands/validate. */
+export interface BrandValidationRequest {
+  items: BrandValidationItem[]
+}
+
+/** Respuesta del endpoint de validación. */
+export interface BrandValidationResult {
+  accepted: number
+  rejected: number
+  edited: number
+}
+
+/**
+ * Obtiene las marcas pendientes de validación para un job.
+ *
+ * Llama a `GET /api/v1/jobs/{jobId}/brands/pending`.
+ * Devuelve la lista de marcas nuevas en espera de aprobación.
+ *
+ * @author Carlitos6712
+ * @param jobId - ID del job en PENDIENTE_VALIDACION_MARCAS.
+ * @returns Lista de BrandPendingEntry.
+ */
+export async function getBrandsPending(jobId: string): Promise<BrandPendingEntry[]> {
+  const response = await apiClient.get<ApiResponse<{ items: BrandPendingEntry[] }>>(
+    `/jobs/${jobId}/brands/pending`,
+  )
+  return response.data.data.items
+}
+
+/**
+ * Envía la validación de marcas nuevas para un job.
+ *
+ * Solo los items con action != 'reject' se escriben en brand_cache.json.
+ * Llama a `POST /api/v1/jobs/{jobId}/brands/validate`.
+ *
+ * @author Carlitos6712
+ * @param jobId   - ID del job en PENDIENTE_VALIDACION_MARCAS.
+ * @param request - Lista de marcas con su decisión.
+ * @returns Resumen de marcas aceptadas, rechazadas y editadas.
+ */
+export async function validateBrands(
+  jobId: string,
+  request: BrandValidationRequest,
+): Promise<BrandValidationResult> {
+  const response = await apiClient.post<ApiResponse<BrandValidationResult>>(
+    `/jobs/${jobId}/brands/validate`,
+    request,
+  )
+  return response.data.data
+}

--- a/frontend/src/components/BrandValidationPanel.tsx
+++ b/frontend/src/components/BrandValidationPanel.tsx
@@ -1,0 +1,293 @@
+/**
+ * Panel de validación de marcas nuevas antes de escribirlas
+ * en la batería local (brand_cache.json).
+ *
+ * Solo aparece cuando el job está en PENDIENTE_VALIDACION_MARCAS.
+ * Permite al usuario aceptar, rechazar o editar inline el nombre de
+ * cada marca nueva antes de confirmar la selección.
+ *
+ * @author Carlitos6712
+ * @param jobId      - Identificador del job en validación.
+ * @param onComplete - Callback llamado tras confirmar la selección.
+ */
+import React, { useCallback, useEffect, useState } from 'react'
+import {
+  type BrandPendingEntry,
+  type BrandValidationAction,
+  type BrandValidationResult,
+  validateBrands,
+} from '../api/client'
+
+// ─── Tipos locales ────────────────────────────────────────────────────────────
+
+type BrandDecision = 'accept' | 'reject'
+
+interface RowState {
+  decision: BrandDecision
+  editedName: string
+  isEditing: boolean
+}
+
+interface BrandValidationPanelProps {
+  jobId: string
+  /** Marcas pendientes ya cargadas por el padre (desde el WebSocket payload o por fetch). */
+  pendingBrands: BrandPendingEntry[]
+  onComplete: (result: BrandValidationResult) => void
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function confidenceBadge(confidence: 'high' | 'medium' | 'low'): React.ReactElement {
+  const map: Record<string, string> = {
+    high: 'bg-green-100 text-green-800',
+    medium: 'bg-yellow-100 text-yellow-800',
+    low: 'bg-red-100 text-red-800',
+  }
+  const label: Record<string, string> = {
+    high: 'Alta',
+    medium: 'Media',
+    low: 'Baja',
+  }
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${map[confidence]}`}>
+      {label[confidence]}
+    </span>
+  )
+}
+
+// ─── Componente ───────────────────────────────────────────────────────────────
+
+const BrandValidationPanel: React.FC<BrandValidationPanelProps> = ({
+  jobId,
+  pendingBrands,
+  onComplete,
+}) => {
+  const [rows, setRows] = useState<RowState[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [submitResult, setSubmitResult] = useState<BrandValidationResult | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  // Inicializar rows cuando llegan pendingBrands
+  useEffect(() => {
+    setRows(
+      pendingBrands.map((b) => ({
+        decision: 'accept' as BrandDecision,
+        editedName: b.brand_name,
+        isEditing: false,
+      })),
+    )
+    setSubmitResult(null)
+    setSubmitError(null)
+  }, [pendingBrands])
+
+  const toggleDecision = useCallback((idx: number) => {
+    setRows((prev) =>
+      prev.map((r, i) =>
+        i === idx
+          ? { ...r, decision: r.decision === 'accept' ? 'reject' : 'accept' }
+          : r,
+      ),
+    )
+  }, [])
+
+  const handleNameBlur = useCallback((idx: number, value: string) => {
+    setRows((prev) =>
+      prev.map((r, i) => (i === idx ? { ...r, editedName: value, isEditing: false } : r)),
+    )
+  }, [])
+
+  const acceptAll = useCallback(() => {
+    setRows((prev) => prev.map((r) => ({ ...r, decision: 'accept' as BrandDecision })))
+  }, [])
+
+  const rejectAll = useCallback(() => {
+    setRows((prev) => prev.map((r) => ({ ...r, decision: 'reject' as BrandDecision })))
+  }, [])
+
+  const handleConfirm = useCallback(async () => {
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      const items = pendingBrands.map((brand, idx) => {
+        const row = rows[idx]
+        const nameChanged = row.editedName.trim() !== brand.brand_name.trim()
+        let action: BrandValidationAction
+
+        if (row.decision === 'reject') {
+          action = 'reject'
+        } else if (nameChanged) {
+          action = 'edit'
+        } else {
+          action = 'accept'
+        }
+
+        return {
+          ean: brand.ean,
+          brand_name: brand.brand_name,
+          action,
+          ...(action === 'edit' ? { edited_name: row.editedName.trim() } : {}),
+        }
+      })
+
+      const result = await validateBrands(jobId, { items })
+      setSubmitResult(result)
+      onComplete(result)
+    } catch (err) {
+      const message =
+        err && typeof err === 'object' && 'message' in err
+          ? String((err as { message: string }).message)
+          : 'Error al confirmar la validación.'
+      setSubmitError(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }, [jobId, pendingBrands, rows, onComplete])
+
+  // ── Estado vacío ─────────────────────────────────────────────────────────────
+  if (pendingBrands.length === 0) {
+    return (
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-6 text-center">
+        <p className="text-sm text-amber-700">No se encontraron marcas nuevas en este job.</p>
+      </div>
+    )
+  }
+
+  const acceptedCount = rows.filter((r) => r.decision === 'accept').length
+  const rejectedCount = rows.filter((r) => r.decision === 'reject').length
+  const total = pendingBrands.length
+
+  // ── Resultado post-confirmación ───────────────────────────────────────────────
+  if (submitResult) {
+    return (
+      <div className="rounded-lg border border-green-200 bg-green-50 p-6 text-center">
+        <p className="text-sm font-medium text-green-800">
+          ✓ {submitResult.accepted} marcas guardadas en batería ·{' '}
+          {submitResult.edited} editadas · {submitResult.rejected} rechazadas
+        </p>
+      </div>
+    )
+  }
+
+  // ── Panel principal ───────────────────────────────────────────────────────────
+  return (
+    <div className="space-y-4">
+      {/* Barra superior */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-gray-600">
+          <span className="font-medium text-green-700">{acceptedCount} aceptadas</span>
+          {' · '}
+          <span className="font-medium text-red-700">{rejectedCount} rechazadas</span>
+          {' · '}
+          <span className="text-gray-500">{total} totales</span>
+        </p>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={acceptAll}
+            className="rounded-md border border-green-300 bg-white px-3 py-1.5 text-xs font-medium text-green-700 hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-500"
+          >
+            Aceptar todas
+          </button>
+          <button
+            type="button"
+            onClick={rejectAll}
+            className="rounded-md border border-red-300 bg-white px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500"
+          >
+            Rechazar todas
+          </button>
+        </div>
+      </div>
+
+      {/* Tabla */}
+      <div className="overflow-x-auto rounded-lg border border-gray-200">
+        <table className="min-w-full divide-y divide-gray-200 text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-gray-500">EAN</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-500">Marca</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-500">Fuente</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-500">Confianza</th>
+              <th className="px-4 py-3 text-left font-medium text-gray-500">Decisión</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 bg-white">
+            {pendingBrands.map((brand, idx) => {
+              const row = rows[idx] ?? { decision: 'accept', editedName: brand.brand_name, isEditing: false }
+              const isRejected = row.decision === 'reject'
+              return (
+                <tr key={brand.ean} className={isRejected ? 'opacity-50' : ''}>
+                  <td className="whitespace-nowrap px-4 py-2 font-mono text-xs text-gray-600">
+                    {brand.ean}
+                  </td>
+                  <td className="px-4 py-2">
+                    {/* Edición inline: click para editar, blur para confirmar */}
+                    <input
+                      type="text"
+                      value={row.editedName}
+                      disabled={isRejected}
+                      onChange={(e) =>
+                        setRows((prev) =>
+                          prev.map((r, i) =>
+                            i === idx ? { ...r, editedName: e.target.value } : r,
+                          ),
+                        )
+                      }
+                      onBlur={(e) => handleNameBlur(idx, e.target.value)}
+                      className={`w-full rounded border px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-amber-500 ${
+                        isRejected
+                          ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400'
+                          : 'border-gray-300 bg-white text-gray-900'
+                      }`}
+                    />
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-2 text-xs text-gray-500">
+                    {brand.source}
+                  </td>
+                  <td className="px-4 py-2">{confidenceBadge(brand.confidence)}</td>
+                  <td className="px-4 py-2">
+                    <button
+                      type="button"
+                      onClick={() => toggleDecision(idx)}
+                      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                        isRejected
+                          ? 'bg-red-100 text-red-700 hover:bg-red-200'
+                          : 'bg-green-100 text-green-700 hover:bg-green-200'
+                      }`}
+                    >
+                      {isRejected ? '✗ Rechazar' : '✓ Aceptar'}
+                    </button>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Error */}
+      {submitError && (
+        <p className="text-sm text-red-600">{submitError}</p>
+      )}
+
+      {/* Botón confirmar */}
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={submitting}
+          className="inline-flex items-center gap-2 rounded-md bg-amber-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {submitting && (
+            <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+            </svg>
+          )}
+          {submitting ? 'Confirmando…' : 'Confirmar selección'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default BrandValidationPanel

--- a/frontend/src/components/SearchConfig.tsx
+++ b/frontend/src/components/SearchConfig.tsx
@@ -60,6 +60,11 @@ export interface SearchConfigValues {
   storeType: string;
   /** Idiomas destino para traducción automática (Fase 7.2). Lista vacía = sin traducción. */
   targetLanguages: string[];
+  /**
+   * Si true, el job espera validación manual de marcas nuevas antes de escribirlas
+   * en brand_cache.json (Fase 7.4). Solo aplica cuando tipoJob === 'marcas'.
+   */
+  validateBrands: boolean;
 }
 
 /**
@@ -337,6 +342,7 @@ export const SearchConfig: React.FC<SearchConfigProps> = ({
   const [groqApiKey, setGroqApiKey] = useState<string>("");
   const [storeType, setStoreType] = useState<string>("");
   const [targetLanguages, setTargetLanguages] = useState<string[]>([]);
+  const [validateBrands, setValidateBrands] = useState<boolean>(false);
 
   /** Indica si `onLaunch` está en curso para bloquear el botón y mostrar spinner. */
   const [launching, setLaunching] = useState<boolean>(false);
@@ -380,6 +386,7 @@ export const SearchConfig: React.FC<SearchConfigProps> = ({
         groqApiKey,
         storeType,
         targetLanguages,
+        validateBrands,
       });
     } finally {
       // Siempre desbloquear, incluso si onLaunch lanza una excepción.
@@ -401,6 +408,7 @@ export const SearchConfig: React.FC<SearchConfigProps> = ({
     groqApiKey,
     storeType,
     targetLanguages,
+    validateBrands,
   ]);
 
   // ── Render ───────────────────────────────────────────────────────────────────
@@ -918,6 +926,31 @@ export const SearchConfig: React.FC<SearchConfigProps> = ({
             </div>
           </div>
         </fieldset>
+      )}
+
+      {/* ── Validación de marcas (solo marcas) — Fase 7.4 ── */}
+      {(tipoJobForzado === "marcas" || tipoJob === "marcas") && (
+        <div className="mt-6 p-4 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-lg">
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={validateBrands}
+              onChange={(e) => setValidateBrands(e.target.checked)}
+              className="mt-0.5 h-4 w-4 rounded border-gray-300 text-amber-600 focus:ring-amber-500"
+            />
+            <span className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-amber-900 dark:text-amber-100">
+                Validar marcas nuevas manualmente
+              </span>
+              {validateBrands && (
+                <span className="text-xs text-amber-700 dark:text-amber-200">
+                  Las marcas nuevas encontradas no se guardarán automáticamente.
+                  Podrás revisarlas y aprobarlas cuando termine el job.
+                </span>
+              )}
+            </span>
+          </label>
+        </div>
       )}
 
       {/* ── Imágenes por producto (solo fotos) ── */}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -290,6 +290,113 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/v1/jobs/{job_id}/brands/pending:
+    get:
+      tags:
+        - jobs
+      summary: "(Fase 7.4) Obtener marcas pendientes de validación"
+      description: |
+        Devuelve la lista de marcas nuevas detectadas en el job que aún no
+        han sido validadas manualmente. Solo disponible cuando el job está en
+        estado `pendiente_validacion_marcas`.
+      operationId: getJobBrandsPending
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200':
+          description: Lista de marcas pendientes.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/BrandPendingEntry'
+                  message:
+                    type: string
+        '404':
+          description: El job no existe.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: El job no está en estado pendiente_validacion_marcas.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/jobs/{job_id}/brands/validate:
+    post:
+      tags:
+        - jobs
+      summary: "(Fase 7.4) Validar marcas nuevas y persistirlas en brand_cache.json"
+      description: |
+        Procesa la decisión del usuario sobre las marcas nuevas detectadas en el job.
+        Solo los items con `action != reject` se escriben en `brand_cache.json`.
+        Tras la validación, el job pasa a estado `completado`.
+      operationId: validateJobBrands
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BrandValidationRequest'
+      responses:
+        '200':
+          description: Validación completada correctamente.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      accepted:
+                        type: integer
+                        description: Marcas aceptadas y escritas en brand_cache.json.
+                      rejected:
+                        type: integer
+                        description: Marcas rechazadas (no escritas).
+                      edited:
+                        type: integer
+                        description: Marcas editadas y escritas con el nombre modificado.
+                  message:
+                    type: string
+        '404':
+          description: El job no existe.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: El job no está en estado pendiente_validacion_marcas.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Cuerpo de la petición inválido (p. ej. action=edit sin edited_name).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /api/v1/jobs/{job_id}/ws:
     get:
       tags:
@@ -506,6 +613,7 @@ components:
         - completado
         - fallido
         - cancelado
+        - pendiente_validacion_marcas
       example: en_proceso
 
     ModosBusqueda:
@@ -798,3 +906,86 @@ components:
             - production
           description: Entorno activo en el que está corriendo el servicio.
           example: development
+
+    # ── Fase 7.4 — Validación de marcas ───────────────────────────────────────
+
+    BrandPendingEntry:
+      type: object
+      description: Marca nueva detectada durante el scraping, pendiente de validación manual.
+      required:
+        - prefijo
+        - brand_name
+        - ean
+        - source
+        - confidence
+      properties:
+        prefijo:
+          type: string
+          description: Prefijo GS1 de 7 dígitos que identifica al fabricante.
+          example: "8410076"
+        brand_name:
+          type: string
+          description: Nombre de la marca resuelto automáticamente.
+          example: "Royal Canin"
+        ean:
+          type: string
+          description: EAN del producto que originó el aprendizaje de este prefijo.
+          example: "8410076472093"
+        source:
+          type: string
+          description: Fuente de resolución (amazon, open_pet_food_facts, open_food_facts, etc.).
+          example: "amazon"
+        confidence:
+          type: string
+          description: Nivel de confianza de la resolución.
+          enum:
+            - high
+            - medium
+            - low
+          example: "high"
+
+    BrandValidationAction:
+      type: string
+      description: Acción a realizar sobre una marca pendiente de validación.
+      enum:
+        - accept
+        - reject
+        - edit
+      example: accept
+
+    BrandValidationItem:
+      type: object
+      description: Decisión del usuario sobre una marca pendiente de validación.
+      required:
+        - ean
+        - brand_name
+        - action
+      properties:
+        ean:
+          type: string
+          description: EAN del producto asociado a la marca.
+          example: "8410076472093"
+        brand_name:
+          type: string
+          description: Nombre de la marca (original o editado).
+          example: "Royal Canin"
+        action:
+          $ref: '#/components/schemas/BrandValidationAction'
+        edited_name:
+          type: string
+          nullable: true
+          description: Nombre editado por el usuario. Requerido cuando `action` es `edit`.
+          example: "Royal Canin ES"
+
+    BrandValidationRequest:
+      type: object
+      description: Cuerpo de la petición para validar marcas pendientes de un job.
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          minItems: 1
+          description: Lista de decisiones de validación, una por marca pendiente.
+          items:
+            $ref: '#/components/schemas/BrandValidationItem'

--- a/services/scraper/brand_cache.py
+++ b/services/scraper/brand_cache.py
@@ -15,7 +15,8 @@ Relación con el resto del pipeline:
     instantáneas desde caché.
 
 :author: BenjaminDTS
-:version: 1.0.0
+:author: Carlitos6712
+:version: 1.1.0
 """
 from __future__ import annotations
 
@@ -55,6 +56,7 @@ class GS1PrefixCache:
         disco desde el worker o la tarea Celery.
 
     :author: BenjaminDTS
+    :author: Carlitos6712
     """
 
     def __init__(self, seed_path: str | None = None) -> None:
@@ -220,3 +222,33 @@ class GS1PrefixCache:
             "Prefijo GS1 registrado en caché",
             extra={"prefix": prefix, "company_name": company_name, "country_code": country_code},
         )
+
+    def current_prefix_keys(self) -> set[str]:
+        """
+        Devuelve el conjunto de prefijos actualmente en la caché.
+
+        Returns:
+            Set de strings con todos los prefijos cargados en memoria.
+        """
+        return set(self._prefixes.keys())
+
+    def get_learned_prefixes(self, seed_prefixes: set[str]) -> dict[str, str]:
+        """
+        Devuelve los prefijos aprendidos durante la ejecución actual que no
+        estaban en el semillero original.
+
+        Útil para persistir solo las entradas nuevas a brand_cache.json
+        sin incluir las del semillero estático.
+
+        Args:
+            seed_prefixes: conjunto de prefijos que ya existían antes de
+                iniciar la resolución (obtenidos antes de procesar el lote).
+
+        Returns:
+            Dict {prefijo: company_name} con solo los prefijos nuevos.
+        """
+        return {
+            prefijo: datos["company_name"]
+            for prefijo, datos in self._prefixes.items()
+            if prefijo not in seed_prefixes
+        }

--- a/services/scraper/brand_cache.py
+++ b/services/scraper/brand_cache.py
@@ -189,7 +189,15 @@ class GS1PrefixCache:
             confidence="high",
         )
 
-    def register(self, prefix: str, company_name: str, country_code: str) -> None:
+    def register(
+        self,
+        prefix: str,
+        company_name: str,
+        country_code: str,
+        source: str = "",
+        confidence: str = "",
+        ean: str = "",
+    ) -> None:
         """
         Registra un nuevo prefijo GS1 en la caché en memoria.
 
@@ -202,6 +210,9 @@ class GS1PrefixCache:
             prefix: prefijo GS1 (entre 6 y 10 dígitos) del nuevo fabricante.
             company_name: nombre de la empresa o fabricante asociado al prefijo.
             country_code: código de país ISO 3166-1 alpha-2 (p. ej. ``"ES"``).
+            source: fuente que resolvió el EAN (ej: ``"amazon"``, ``"open_data_api"``).
+            confidence: nivel de confianza del resultado (``"high"``, ``"medium"``, ``"low"``).
+            ean: código EAN completo del producto que originó el aprendizaje.
 
         Raises:
             No lanza excepciones. Si el prefijo ya existe, su entrada se
@@ -216,6 +227,9 @@ class GS1PrefixCache:
         self._prefixes[prefix] = {
             "company_name": company_name,
             "country_code": country_code,
+            "source": source,
+            "confidence": confidence,
+            "ean": ean,
         }
 
         logger.debug(
@@ -232,10 +246,10 @@ class GS1PrefixCache:
         """
         return set(self._prefixes.keys())
 
-    def get_learned_prefixes(self, seed_prefixes: set[str]) -> dict[str, str]:
+    def get_learned_prefixes(self, seed_prefixes: set[str]) -> dict[str, dict[str, str]]:
         """
         Devuelve los prefijos aprendidos durante la ejecución actual que no
-        estaban en el semillero original.
+        estaban en el semillero original, con sus metadatos completos.
 
         Útil para persistir solo las entradas nuevas a brand_cache.json
         sin incluir las del semillero estático.
@@ -245,10 +259,16 @@ class GS1PrefixCache:
                 iniciar la resolución (obtenidos antes de procesar el lote).
 
         Returns:
-            Dict {prefijo: company_name} con solo los prefijos nuevos.
+            Dict {prefijo: {brand_name, ean, source, confidence}} con solo
+            los prefijos nuevos.
         """
         return {
-            prefijo: datos["company_name"]
+            prefijo: {
+                "brand_name": datos["company_name"],
+                "ean": datos.get("ean", ""),
+                "source": datos.get("source", ""),
+                "confidence": datos.get("confidence", ""),
+            }
             for prefijo, datos in self._prefixes.items()
             if prefijo not in seed_prefixes
         }

--- a/services/scraper/brand_pipeline.py
+++ b/services/scraper/brand_pipeline.py
@@ -15,13 +15,17 @@ ningún WebDriver. Toda la resolución se realiza mediante HTTP síncrono
 (httpx.Client) a través de los clientes de ean_http_clients.py.
 
 :author: BenjaminDTS
-:version: 3.0.0
+:author: Carlitos6712
+:version: 3.1.0
 """
 
 from __future__ import annotations
 
 import csv
 import io
+import json
+import threading
+from pathlib import Path
 from typing import Callable
 
 from loguru import logger
@@ -35,6 +39,9 @@ from services.storage_service import StorageService, get_storage_service
 # Firma: (job_id, procesados, total, exitosos) -> None
 BrandProgressCallback = Callable[[str, int, int, int], None]
 
+# Protege las escrituras concurrentes a brand_cache.json
+_BRAND_CACHE_LOCK: threading.Lock = threading.Lock()
+
 
 class BrandPipeline:
     """
@@ -46,6 +53,7 @@ class BrandPipeline:
     resolvió cada EAN) y ``confidence`` para filtrar resultados poco fiables.
 
     :author: BenjaminDTS
+    :author: Carlitos6712
     """
 
     def __init__(
@@ -54,6 +62,7 @@ class BrandPipeline:
         config: SearchConfig,
         storage: StorageService | None = None,
         carpeta_job_id: str | None = None,
+        write_cache: bool = True,
     ) -> None:
         """
         Inicializa el pipeline de resolución de marcas.
@@ -64,11 +73,15 @@ class BrandPipeline:
             storage: servicio de almacenamiento. Si None usa el factory.
             carpeta_job_id: carpeta de almacenamiento a reutilizar (para resume).
                 Si None se usa job_id.
+            write_cache: si True (por defecto), persiste los prefijos aprendidos
+                en brand_cache.json al finalizar. Si False, devuelve los prefijos
+                nuevos en el resumen para que el endpoint de validación los persista.
         """
         self._job_id = job_id
         self._carpeta_id = carpeta_job_id or job_id
         self._config = config
         self._storage = storage or get_storage_service()
+        self._write_cache = write_cache
 
     def ejecutar(
         self,
@@ -140,6 +153,9 @@ class BrandPipeline:
         # registra el prefijo para acelerar resoluciones posteriores del mismo
         # fabricante.
         resolver = EanBrandResolver()
+        # Capturar prefijos ya existentes ANTES de procesar cualquier producto
+        # para poder detectar cuáles son nuevos al finalizar.
+        seed_keys = resolver._cache.current_prefix_keys()
         resultados: list[BrandResult] = []
         exitosos = 0
 
@@ -196,11 +212,33 @@ class BrandPipeline:
         ))
         self._guardar_csv(productos_resultados)
 
+        # ── Paso 4: Persistencia de brand_cache.json ──────────────────────────
+        # Detectar los prefijos GS1 aprendidos durante el procesamiento.
+        new_entries = resolver._cache.get_learned_prefixes(seed_keys)
+
+        from api.core.config import get_settings  # noqa: PLC0415 — import diferido para evitar ciclos
+        settings = get_settings()
+        brand_cache_path = Path(settings.brand_cache_path)
+
+        if self._write_cache:
+            self._persist_brand_cache(new_entries, brand_cache_path)
+            new_cache_entries_out: dict[str, str] = {}
+        else:
+            logger.info(
+                "write_cache=False: prefijos nuevos diferidos para validación manual",
+                extra={
+                    "job_id": self._job_id,
+                    "prefijos_nuevos": len(new_entries),
+                },
+            )
+            new_cache_entries_out = new_entries
+
         resumen = {
             "total_productos": total,
             "marcas_exitosas": exitosos,
             "marcas_fallidas": total - exitosos,
             "errores_csv": resultado_csv.errores,
+            "new_cache_entries": new_cache_entries_out,
         }
 
         logger.info(
@@ -213,6 +251,64 @@ class BrandPipeline:
             },
         )
         return resumen
+
+    def _persist_brand_cache(
+        self,
+        new_entries: dict[str, str],
+        brand_cache_path: Path,
+    ) -> None:
+        """
+        Persiste las entradas nuevas de marca en brand_cache.json con lock.
+
+        Usa threading.Lock a nivel de proceso para evitar corrupción por
+        escrituras concurrentes entre workers Celery del mismo proceso.
+        El archivo se crea si no existe.
+
+        Args:
+            new_entries: dict {prefijo_7_digits: company_name} con las
+                marcas nuevas a persistir.
+            brand_cache_path: ruta absoluta al archivo brand_cache.json.
+
+        Raises:
+            OSError: si no se puede leer o escribir el archivo (log + raise).
+        """
+        if not new_entries:
+            logger.debug(
+                "Sin prefijos nuevos que persistir en brand_cache.json",
+                extra={"job_id": self._job_id},
+            )
+            return
+
+        with _BRAND_CACHE_LOCK:
+            existing: dict[str, str] = {}
+            if brand_cache_path.exists():
+                try:
+                    existing = json.loads(
+                        brand_cache_path.read_text(encoding="utf-8")
+                    )
+                except (json.JSONDecodeError, OSError) as exc:
+                    logger.error(
+                        "Error leyendo brand_cache.json; se sobreescribirá",
+                        exc_info=exc,
+                        extra={"job_id": self._job_id, "path": str(brand_cache_path)},
+                    )
+
+            merged = {**existing, **new_entries}
+            brand_cache_path.parent.mkdir(parents=True, exist_ok=True)
+            brand_cache_path.write_text(
+                json.dumps(merged, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
+        for prefijo, nombre in new_entries.items():
+            logger.info(
+                "Prefijo GS1 persistido en brand_cache.json",
+                extra={
+                    "job_id": self._job_id,
+                    "prefijo": prefijo,
+                    "brand_name": nombre,
+                },
+            )
 
     def _guardar_csv(
         self,

--- a/services/scraper/brand_pipeline.py
+++ b/services/scraper/brand_pipeline.py
@@ -222,7 +222,7 @@ class BrandPipeline:
 
         if self._write_cache:
             self._persist_brand_cache(new_entries, brand_cache_path)
-            new_cache_entries_out: dict[str, str] = {}
+            new_cache_entries_out: dict[str, dict[str, str]] = {}
         else:
             logger.info(
                 "write_cache=False: prefijos nuevos diferidos para validación manual",
@@ -254,7 +254,7 @@ class BrandPipeline:
 
     def _persist_brand_cache(
         self,
-        new_entries: dict[str, str],
+        new_entries: dict[str, dict[str, str]],
         brand_cache_path: Path,
     ) -> None:
         """
@@ -265,8 +265,8 @@ class BrandPipeline:
         El archivo se crea si no existe.
 
         Args:
-            new_entries: dict {prefijo_7_digits: company_name} con las
-                marcas nuevas a persistir.
+            new_entries: dict {prefijo_7_digits: {brand_name, ean, source, confidence}}
+                con las marcas nuevas a persistir.
             brand_cache_path: ruta absoluta al archivo brand_cache.json.
 
         Raises:
@@ -278,6 +278,12 @@ class BrandPipeline:
                 extra={"job_id": self._job_id},
             )
             return
+
+        # Build flat {prefijo: brand_name} dict for persistence
+        flat_entries: dict[str, str] = {
+            prefijo: entry["brand_name"]
+            for prefijo, entry in new_entries.items()
+        }
 
         with _BRAND_CACHE_LOCK:
             existing: dict[str, str] = {}
@@ -293,20 +299,20 @@ class BrandPipeline:
                         extra={"job_id": self._job_id, "path": str(brand_cache_path)},
                     )
 
-            merged = {**existing, **new_entries}
+            merged = {**existing, **flat_entries}
             brand_cache_path.parent.mkdir(parents=True, exist_ok=True)
             brand_cache_path.write_text(
                 json.dumps(merged, ensure_ascii=False, indent=2),
                 encoding="utf-8",
             )
 
-        for prefijo, nombre in new_entries.items():
+        for prefijo, entry in new_entries.items():
             logger.info(
                 "Prefijo GS1 persistido en brand_cache.json",
                 extra={
                     "job_id": self._job_id,
                     "prefijo": prefijo,
-                    "brand_name": nombre,
+                    "brand_name": entry["brand_name"],
                 },
             )
 

--- a/services/scraper/brand_scraper.py
+++ b/services/scraper/brand_scraper.py
@@ -268,4 +268,7 @@ class EanBrandResolver:
             prefix=prefijo,
             company_name=company_name,
             country_code="",  # Desconocido al aprender desde web/API
+            source=resultado.source,
+            confidence=resultado.confidence,
+            ean=ean,
         )

--- a/tests/integration/test_brand_validation.py
+++ b/tests/integration/test_brand_validation.py
@@ -1,0 +1,474 @@
+"""
+Tests de integración para la validación de marcas nuevas (Fase 7.4).
+
+Cubre:
+  POST /api/v1/jobs/{job_id}/brands/validate  — Confirmar marcas pendientes
+  GET  /api/v1/jobs/{job_id}/brands/pending   — Obtener marcas pendientes
+
+Redis y Celery se mockean. brand_cache.json se aísla con tmp_path.
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("SECRET_KEY", "clave-de-prueba-super-segura-32c")
+os.environ.setdefault("BROWSER_BINARY_PATH", "/usr/bin/google-chrome")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_BROKER_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_RESULT_BACKEND", "redis://localhost:6379/1")
+
+from api.core.config import get_settings  # noqa: E402
+get_settings.cache_clear()
+
+from api.main import app  # noqa: E402
+from api.v1.schemas.job import EstadoJob, JobStatus  # noqa: E402
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_PREFIJO_A = "1234567"
+_PREFIJO_B = "9876543"
+_EAN_A     = "1234567890123"
+_EAN_B     = "9876543210987"
+
+
+def _job_status(
+    job_id: str,
+    estado: EstadoJob = EstadoJob.PENDIENTE_VALIDACION_MARCAS,
+    marcas_pendientes_validacion: int = 2,
+) -> JobStatus:
+    """
+    Construye un JobStatus de prueba para un job de validación de marcas.
+
+    Args:
+        job_id: UUID del job como string.
+        estado: estado del job (por defecto PENDIENTE_VALIDACION_MARCAS).
+        marcas_pendientes_validacion: número de marcas pendientes de validar.
+
+    Returns:
+        JobStatus listo para serializar y cargar en el mock de Redis.
+    """
+    return JobStatus(
+        job_id=uuid.UUID(job_id),
+        estado=estado,
+        total_productos=5,
+        productos_procesados=5,
+        marcas_procesadas=5,
+        marcas_pendientes_validacion=marcas_pendientes_validacion,
+        mensaje="Esperando validación de marcas.",
+    )
+
+
+def _brands_pending_payload(
+    prefijos: dict[str, tuple[str, str, str]] | None = None,
+) -> str:
+    """
+    Serializa un dict de marcas pendientes al formato Redis brands_pending.
+
+    Args:
+        prefijos: dict con forma {prefijo: (brand_name, ean, source)}.
+            Si None, usa dos marcas de ejemplo con _PREFIJO_A y _PREFIJO_B.
+
+    Returns:
+        JSON serializado listo para devolver desde redis.get().
+    """
+    if prefijos is None:
+        prefijos = {
+            _PREFIJO_A: ("BrandA", _EAN_A, "amazon"),
+            _PREFIJO_B: ("BrandB", _EAN_B, "cache_gs1"),
+        }
+    data = {
+        pref: {"brand_name": bn, "ean": ean, "source": src, "confidence": "high"}
+        for pref, (bn, ean, src) in prefijos.items()
+    }
+    return json.dumps(data)
+
+
+def _redis_mock(
+    job_id: str,
+    job_status: JobStatus,
+    brands_pending_json: str | None = None,
+    captured_sets: list | None = None,
+    captured_deletes: list | None = None,
+) -> AsyncMock:
+    """
+    Construye un mock de aioredis para los endpoints de validación.
+
+    Args:
+        job_id: UUID del job como string.
+        job_status: estado del job a devolver desde redis.get().
+        brands_pending_json: JSON de marcas pendientes o None si no hay.
+        captured_sets: lista mutable donde se acumulan las llamadas a redis.set().
+        captured_deletes: lista mutable donde se acumulan las llamadas a redis.delete().
+
+    Returns:
+        AsyncMock que implementa get / set / delete / ping / aclose.
+    """
+    if captured_sets is None:
+        captured_sets = []
+    if captured_deletes is None:
+        captured_deletes = []
+
+    job_key = f"job:{job_id}"
+    brands_key = f"job:{job_id}:brands_pending"
+    job_json = job_status.model_dump_json()
+
+    async def get_side(key: str) -> str | None:
+        if key == job_key:
+            return job_json
+        if key == brands_key:
+            return brands_pending_json
+        return None
+
+    async def set_side(key: str, value: str, ex: int | None = None) -> bool:  # noqa: ARG001
+        captured_sets.append((key, value))
+        return True
+
+    async def delete_side(*keys: str) -> int:
+        captured_deletes.extend(keys)
+        return len(keys)
+
+    mock = AsyncMock()
+    mock.get = AsyncMock(side_effect=get_side)
+    mock.set = AsyncMock(side_effect=set_side)
+    mock.delete = AsyncMock(side_effect=delete_side)
+    mock.ping = AsyncMock(return_value=True)
+    mock.aclose = AsyncMock()
+    return mock
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncClient:
+    """
+    Cliente HTTPX asíncrono con ASGITransport para llamar a la app sin servidor real.
+
+    Yields:
+        AsyncClient listo para enviar peticiones a la app de test.
+    """
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ── Tests POST /brands/validate ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_validate_returns_404_for_nonexistent_job(client: AsyncClient) -> None:
+    """Devuelve 404 si el job no existe en Redis."""
+    job_id = str(uuid.uuid4())
+
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=None)
+    redis.ping = AsyncMock(return_value=True)
+    redis.aclose = AsyncMock()
+
+    with patch("api.v1.endpoints.jobs._get_redis", return_value=redis):
+        resp = await client.post(
+            f"/api/v1/jobs/{job_id}/brands/validate",
+            json={"items": [{"ean": _EAN_A, "brand_name": "BrandA", "action": "accept"}]},
+        )
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_validate_returns_409_if_job_not_pending_validation(client: AsyncClient) -> None:
+    """Devuelve 409 si el job no está en PENDIENTE_VALIDACION_MARCAS."""
+    job_id = str(uuid.uuid4())
+    status = _job_status(job_id, estado=EstadoJob.COMPLETADO)
+    redis = _redis_mock(job_id, status)
+
+    with patch("api.v1.endpoints.jobs._get_redis", return_value=redis):
+        resp = await client.post(
+            f"/api/v1/jobs/{job_id}/brands/validate",
+            json={"items": [{"ean": _EAN_A, "brand_name": "BrandA", "action": "accept"}]},
+        )
+
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_validate_returns_422_when_edit_action_missing_edited_name(client: AsyncClient) -> None:
+    """Devuelve 422 cuando action=edit pero edited_name no está presente."""
+    job_id = str(uuid.uuid4())
+    status = _job_status(job_id)
+    redis = _redis_mock(job_id, status, _brands_pending_payload())
+
+    with patch("api.v1.endpoints.jobs._get_redis", return_value=redis):
+        resp = await client.post(
+            f"/api/v1/jobs/{job_id}/brands/validate",
+            json={"items": [{"ean": _EAN_A, "brand_name": "BrandA", "action": "edit"}]},
+        )
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_validate_accept_writes_to_brand_cache_json(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """action=accept escribe el prefijo y brand_name en brand_cache.json."""
+    job_id = str(uuid.uuid4())
+    brand_cache = tmp_path / "brand_cache.json"
+    status = _job_status(job_id)
+    pending = _brands_pending_payload({_PREFIJO_A: ("BrandA", _EAN_A, "amazon")})
+    redis = _redis_mock(job_id, status, pending)
+
+    with (
+        patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+        patch("api.v1.endpoints.jobs.settings") as mock_settings,
+    ):
+        mock_settings.brand_cache_path = str(brand_cache)
+        mock_settings.file_ttl_seconds = 86400
+
+        resp = await client.post(
+            f"/api/v1/jobs/{job_id}/brands/validate",
+            json={"items": [{"ean": _EAN_A, "brand_name": "BrandA", "action": "accept"}]},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["accepted"] == 1
+    assert data["rejected"] == 0
+    assert brand_cache.exists()
+    cache_contents = json.loads(brand_cache.read_text())
+    assert cache_contents.get(_PREFIJO_A) == "BrandA"
+
+
+@pytest.mark.asyncio
+async def test_validate_edit_writes_edited_name_to_brand_cache_json(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """action=edit escribe el edited_name (no el brand_name original) en brand_cache.json."""
+    job_id = str(uuid.uuid4())
+    brand_cache = tmp_path / "brand_cache.json"
+    status = _job_status(job_id)
+    pending = _brands_pending_payload({_PREFIJO_A: ("BrandA", _EAN_A, "amazon")})
+    redis = _redis_mock(job_id, status, pending)
+
+    with (
+        patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+        patch("api.v1.endpoints.jobs.settings") as mock_settings,
+    ):
+        mock_settings.brand_cache_path = str(brand_cache)
+        mock_settings.file_ttl_seconds = 86400
+
+        resp = await client.post(
+            f"/api/v1/jobs/{job_id}/brands/validate",
+            json={"items": [{"ean": _EAN_A, "brand_name": "BrandA", "action": "edit", "edited_name": "BrandA Edited"}]},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["edited"] == 1
+    cache_contents = json.loads(brand_cache.read_text())
+    assert cache_contents.get(_PREFIJO_A) == "BrandA Edited"
+
+
+@pytest.mark.asyncio
+async def test_validate_reject_does_not_write_to_brand_cache_json(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """action=reject no escribe ningún prefijo en brand_cache.json."""
+    job_id = str(uuid.uuid4())
+    brand_cache = tmp_path / "brand_cache.json"
+    status = _job_status(job_id)
+    pending = _brands_pending_payload({_PREFIJO_A: ("BrandA", _EAN_A, "amazon")})
+    redis = _redis_mock(job_id, status, pending)
+
+    with (
+        patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+        patch("api.v1.endpoints.jobs.settings") as mock_settings,
+    ):
+        mock_settings.brand_cache_path = str(brand_cache)
+        mock_settings.file_ttl_seconds = 86400
+
+        resp = await client.post(
+            f"/api/v1/jobs/{job_id}/brands/validate",
+            json={"items": [{"ean": _EAN_A, "brand_name": "BrandA", "action": "reject"}]},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["rejected"] == 1
+    assert data["accepted"] == 0
+    # brand_cache.json should not exist (no writes happened)
+    assert not brand_cache.exists()
+
+
+@pytest.mark.asyncio
+async def test_validate_mixed_actions_write_only_accepted_and_edited(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """Solo los items con action accept/edit se escriben; reject no."""
+    job_id = str(uuid.uuid4())
+    brand_cache = tmp_path / "brand_cache.json"
+    status = _job_status(job_id)
+    pending = _brands_pending_payload({
+        _PREFIJO_A: ("BrandA", _EAN_A, "amazon"),
+        _PREFIJO_B: ("BrandB", _EAN_B, "cache_gs1"),
+    })
+    redis = _redis_mock(job_id, status, pending)
+
+    with (
+        patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+        patch("api.v1.endpoints.jobs.settings") as mock_settings,
+    ):
+        mock_settings.brand_cache_path = str(brand_cache)
+        mock_settings.file_ttl_seconds = 86400
+
+        resp = await client.post(
+            f"/api/v1/jobs/{job_id}/brands/validate",
+            json={"items": [
+                {"ean": _EAN_A, "brand_name": "BrandA", "action": "accept"},
+                {"ean": _EAN_B, "brand_name": "BrandB", "action": "reject"},
+            ]},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["accepted"] == 1
+    assert data["rejected"] == 1
+    cache = json.loads(brand_cache.read_text())
+    assert _PREFIJO_A in cache
+    assert _PREFIJO_B not in cache
+
+
+@pytest.mark.asyncio
+async def test_validate_job_status_changes_to_completado(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """Tras validar, el job pasa a estado COMPLETADO en Redis."""
+    job_id = str(uuid.uuid4())
+    brand_cache = tmp_path / "brand_cache.json"
+    status = _job_status(job_id)
+    pending = _brands_pending_payload({_PREFIJO_A: ("BrandA", _EAN_A, "amazon")})
+    captured_sets: list = []
+    redis = _redis_mock(job_id, status, pending, captured_sets=captured_sets)
+
+    with (
+        patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+        patch("api.v1.endpoints.jobs.settings") as mock_settings,
+    ):
+        mock_settings.brand_cache_path = str(brand_cache)
+        mock_settings.file_ttl_seconds = 86400
+
+        await client.post(
+            f"/api/v1/jobs/{job_id}/brands/validate",
+            json={"items": [{"ean": _EAN_A, "brand_name": "BrandA", "action": "accept"}]},
+        )
+
+    # Find the job status update in captured_sets
+    job_key = f"job:{job_id}"
+    job_updates = [json.loads(v) for k, v in captured_sets if k == job_key]
+    assert job_updates, "Job status was not updated in Redis"
+    assert job_updates[-1]["estado"] == EstadoJob.COMPLETADO.value
+
+
+@pytest.mark.asyncio
+async def test_validate_brands_pending_key_removed_from_redis(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """Después de validar, la clave brands_pending se elimina de Redis."""
+    job_id = str(uuid.uuid4())
+    brand_cache = tmp_path / "brand_cache.json"
+    status = _job_status(job_id)
+    pending = _brands_pending_payload({_PREFIJO_A: ("BrandA", _EAN_A, "amazon")})
+    captured_deletes: list = []
+    redis = _redis_mock(job_id, status, pending, captured_deletes=captured_deletes)
+
+    with (
+        patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+        patch("api.v1.endpoints.jobs.settings") as mock_settings,
+    ):
+        mock_settings.brand_cache_path = str(brand_cache)
+        mock_settings.file_ttl_seconds = 86400
+
+        await client.post(
+            f"/api/v1/jobs/{job_id}/brands/validate",
+            json={"items": [{"ean": _EAN_A, "brand_name": "BrandA", "action": "accept"}]},
+        )
+
+    brands_pending_key = f"job:{job_id}:brands_pending"
+    assert brands_pending_key in captured_deletes
+
+
+@pytest.mark.asyncio
+async def test_validate_returns_correct_counts(client: AsyncClient, tmp_path: Path) -> None:
+    """El endpoint devuelve los contadores correctos de accepted/rejected/edited."""
+    job_id = str(uuid.uuid4())
+    brand_cache = tmp_path / "brand_cache.json"
+    status = _job_status(job_id, marcas_pendientes_validacion=3)
+    prefijos = {
+        "1111111": ("BrandX", "1111111000001", "amazon"),
+        "2222222": ("BrandY", "2222222000002", "cache_gs1"),
+        "3333333": ("BrandZ", "3333333000003", "bing_search"),
+    }
+    pending = _brands_pending_payload(prefijos)
+    redis = _redis_mock(job_id, status, pending)
+
+    with (
+        patch("api.v1.endpoints.jobs._get_redis", return_value=redis),
+        patch("api.v1.endpoints.jobs.settings") as mock_settings,
+    ):
+        mock_settings.brand_cache_path = str(brand_cache)
+        mock_settings.file_ttl_seconds = 86400
+
+        resp = await client.post(
+            f"/api/v1/jobs/{job_id}/brands/validate",
+            json={"items": [
+                {"ean": "1111111000001", "brand_name": "BrandX", "action": "accept"},
+                {"ean": "2222222000002", "brand_name": "BrandY", "action": "reject"},
+                {"ean": "3333333000003", "brand_name": "BrandZ", "action": "edit", "edited_name": "BrandZ Fixed"},
+            ]},
+        )
+
+    data = resp.json()["data"]
+    assert data["accepted"] == 1
+    assert data["rejected"] == 1
+    assert data["edited"] == 1
+
+
+# ── Tests GET /brands/pending ─────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_get_brands_pending_returns_409_if_wrong_state(client: AsyncClient) -> None:
+    """GET /brands/pending devuelve 409 si el job no está en PENDIENTE_VALIDACION_MARCAS."""
+    job_id = str(uuid.uuid4())
+    status = _job_status(job_id, estado=EstadoJob.COMPLETADO)
+    redis = _redis_mock(job_id, status)
+
+    with patch("api.v1.endpoints.jobs._get_redis", return_value=redis):
+        resp = await client.get(f"/api/v1/jobs/{job_id}/brands/pending")
+
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_get_brands_pending_returns_items(client: AsyncClient) -> None:
+    """GET /brands/pending devuelve la lista de marcas pendientes."""
+    job_id = str(uuid.uuid4())
+    status = _job_status(job_id)
+    pending = _brands_pending_payload({_PREFIJO_A: ("BrandA", _EAN_A, "amazon")})
+    redis = _redis_mock(job_id, status, pending)
+
+    with patch("api.v1.endpoints.jobs._get_redis", return_value=redis):
+        resp = await client.get(f"/api/v1/jobs/{job_id}/brands/pending")
+
+    assert resp.status_code == 200
+    items = resp.json()["data"]["items"]
+    assert len(items) == 1
+    assert items[0]["prefijo"] == _PREFIJO_A
+    assert items[0]["brand_name"] == "BrandA"

--- a/tests/unit/test_brand_scraper_cache.py
+++ b/tests/unit/test_brand_scraper_cache.py
@@ -1,0 +1,108 @@
+"""
+Tests unitarios para la separación resolución/escritura en brand_scraper (Fase 7.4).
+
+Verifica que GS1PrefixCache registra correctamente prefijos nuevos, que
+get_learned_prefixes excluye los prefijos ya presentes en el semillero, y que
+BrandPipeline._persist_brand_cache escribe en brand_cache.json únicamente cuando
+write_cache=True.
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("SECRET_KEY", "clave-de-prueba-super-segura-32c")
+os.environ.setdefault("BROWSER_BINARY_PATH", "/usr/bin/google-chrome")
+
+from api.core.config import get_settings  # noqa: E402
+get_settings.cache_clear()
+
+from services.scraper.brand_cache import GS1PrefixCache  # noqa: E402
+
+
+# ── Tests GS1PrefixCache ──────────────────────────────────────────────────────
+
+def test_current_prefix_keys_empty_on_init(tmp_path: Path) -> None:
+    """Una caché inicializada sin semilla no tiene prefijos."""
+    cache = GS1PrefixCache(seed_path=str(tmp_path / "empty_seed.json"))
+    assert cache.current_prefix_keys() == set()
+
+
+def test_register_and_current_prefix_keys(tmp_path: Path) -> None:
+    """Tras register(), current_prefix_keys() incluye el nuevo prefijo."""
+    cache = GS1PrefixCache(seed_path=str(tmp_path / "empty_seed.json"))
+    cache.register("1234567", "TestBrand", "ES", source="amazon", confidence="high", ean="1234567000000")
+    assert "1234567" in cache.current_prefix_keys()
+
+
+def test_get_learned_prefixes_returns_only_new_ones(tmp_path: Path) -> None:
+    """get_learned_prefixes devuelve solo prefijos no presentes en seed_keys."""
+    cache = GS1PrefixCache(seed_path=str(tmp_path / "empty_seed.json"))
+    seed_keys = cache.current_prefix_keys()  # vacío
+
+    cache.register("1111111", "BrandA", "ES", source="amazon", confidence="high", ean="1111111000001")
+    cache.register("2222222", "BrandB", "ES", source="cache_gs1", confidence="high", ean="2222222000002")
+
+    learned = cache.get_learned_prefixes(seed_keys)
+    assert "1111111" in learned
+    assert "2222222" in learned
+    assert learned["1111111"]["brand_name"] == "BrandA"
+    assert learned["1111111"]["ean"] == "1111111000001"
+    assert learned["1111111"]["source"] == "amazon"
+
+
+def test_get_learned_prefixes_excludes_seed_prefixes(tmp_path: Path) -> None:
+    """Un prefijo que ya estaba en seed no aparece en get_learned_prefixes."""
+    cache = GS1PrefixCache(seed_path=str(tmp_path / "empty_seed.json"))
+    cache.register("9999999", "OldBrand", "ES")
+    seed_keys = cache.current_prefix_keys()  # ahora contiene "9999999"
+
+    cache.register("1111111", "NewBrand", "ES", source="bing_search", confidence="medium", ean="1111111000001")
+
+    learned = cache.get_learned_prefixes(seed_keys)
+    assert "9999999" not in learned
+    assert "1111111" in learned
+
+
+def test_brand_pipeline_persist_brand_cache_writes_file(tmp_path: Path) -> None:
+    """
+    _persist_brand_cache crea brand_cache.json con los prefijos proporcionados
+    cuando write_cache=True.
+    """
+    from api.v1.schemas.job import ModosBusqueda, SearchConfig, TipoJob
+    from services.scraper.brand_pipeline import BrandPipeline
+
+    brand_cache = tmp_path / "brand_cache.json"
+    config = SearchConfig(tipo_job=TipoJob.MARCAS, modo=ModosBusqueda.EAN)
+
+    mock_storage = MagicMock()
+    pipeline = BrandPipeline(
+        job_id="test-job",
+        config=config,
+        storage=mock_storage,
+        write_cache=True,
+    )
+
+    new_entries: dict[str, dict[str, str]] = {
+        "1234567": {
+            "brand_name": "TestBrand",
+            "ean": "1234567000000",
+            "source": "amazon",
+            "confidence": "high",
+        },
+    }
+
+    pipeline._persist_brand_cache(new_entries, brand_cache)
+
+    assert brand_cache.exists()
+    cache = json.loads(brand_cache.read_text())
+    assert cache.get("1234567") == "TestBrand"

--- a/workers/tasks.py
+++ b/workers/tasks.py
@@ -6,6 +6,7 @@ No contiene lógica de dominio — solo integración con Celery y actualización
 del estado del job en Redis.
 
 :author: BenjaminDTS
+:author: Carlitos6712
 :version: 1.0.0
 """
 
@@ -27,6 +28,7 @@ from workers.celery_app import celery_app
 task_logger = get_task_logger(__name__)
 
 _JOB_KEY = "job:{job_id}"
+_BRANDS_PENDING_KEY = "job:{job_id}:brands_pending"
 
 
 class JobCancelledError(Exception):
@@ -333,7 +335,12 @@ def ejecutar_scraping(
             )
         elif config.tipo_job == TipoJob.MARCAS:
             from services.scraper.brand_pipeline import BrandPipeline  # noqa: PLC0415
-            pipeline_marcas = BrandPipeline(job_id=job_id, config=config, carpeta_job_id=carpeta_job_id)
+            pipeline_marcas = BrandPipeline(
+                job_id=job_id,
+                config=config,
+                carpeta_job_id=carpeta_job_id,
+                write_cache=not config.validate_brands,
+            )
             resumen = pipeline_marcas.ejecutar(
                 contenido_csv=contenido_csv,
                 callback=_callback_marcas,
@@ -379,10 +386,48 @@ def ejecutar_scraping(
             job_status.total_productos = resumen["total_productos"]
             job_status.productos_procesados = resumen["total_productos"]
             job_status.marcas_procesadas = resumen.get("marcas_exitosas", 0)
-            job_status.mensaje = (
-                f"Completado: {resumen.get('marcas_exitosas', 0)} marcas procesadas "
-                f"de {resumen['total_productos']}."
-            )
+
+            new_entries: dict[str, str] = resumen.get("new_cache_entries", {})
+
+            if config.validate_brands and new_entries:
+                # Hay marcas nuevas pendientes de validación: guardar en Redis y
+                # dejar el job en estado intermedio (no COMPLETADO todavía).
+                redis_client.set(
+                    _BRANDS_PENDING_KEY.format(job_id=job_id),
+                    json.dumps(new_entries, ensure_ascii=False),
+                    ex=settings.file_ttl_seconds,
+                )
+                job_status.estado = EstadoJob.PENDIENTE_VALIDACION_MARCAS
+                job_status.completado_en = None  # No completado aún
+                job_status.marcas_pendientes_validacion = len(new_entries)
+                job_status.mensaje = (
+                    f"Marcas procesadas: {resumen.get('marcas_exitosas', 0)} de "
+                    f"{resumen['total_productos']}. "
+                    f"{len(new_entries)} marcas nuevas pendientes de validación."
+                )
+                logger.info(
+                    "Job en espera de validación de marcas",
+                    extra={
+                        "job_id": job_id,
+                        "marcas_nuevas": len(new_entries),
+                    },
+                )
+            elif config.validate_brands and not new_entries:
+                # validate_brands=True pero no hay marcas nuevas: completar directamente
+                job_status.estado = EstadoJob.COMPLETADO
+                job_status.completado_en = datetime.utcnow()
+                job_status.mensaje = (
+                    f"Completado: {resumen.get('marcas_exitosas', 0)} marcas procesadas "
+                    f"de {resumen['total_productos']}. Sin marcas nuevas para validar."
+                )
+            else:
+                # validate_brands=False (comportamiento por defecto)
+                job_status.estado = EstadoJob.COMPLETADO
+                job_status.completado_en = datetime.utcnow()
+                job_status.mensaje = (
+                    f"Completado: {resumen.get('marcas_exitosas', 0)} marcas procesadas "
+                    f"de {resumen['total_productos']}."
+                )
         else:
             job_status.total_productos = resumen["total_productos"]
             job_status.imagenes_descargadas = resumen.get("imagenes_descargadas", 0)


### PR DESCRIPTION
## Summary

- Separa la resolución de EAN→marca de la escritura en `brand_cache.json`: cuando `validate_brands=True` en el job, los prefijos nuevos se retienen en Redis (`job:{job_id}:brands_pending`) y el job queda en estado `PENDIENTE_VALIDACION_MARCAS`
- Nuevo endpoint `GET /api/v1/jobs/{job_id}/brands/pending` expone las marcas retenidas con ean/source/confidence
- Nuevo endpoint `POST /api/v1/jobs/{job_id}/brands/validate` procesa accept/reject/edit por marca y escribe solo las aceptadas en `brand_cache.json` con file lock
- `BrandValidationPanel` aparece automáticamente en el frontend cuando el job está en `PENDIENTE_VALIDACION_MARCAS`, con edición inline, acciones bulk y badge de confianza por fila
- `GS1PrefixCache.register()` extendido para rastrear ean/source/confidence por prefijo (necesario para mostrar datos completos en el panel)
- `data/brand_cache.json` y `data/gs1_prefixes.db` añadidos a `.gitignore`
- 19 tests nuevos (12 integración + 7 unitarios); suite completa: 232 passing

## Test plan

- [ ] Crear job con `validate_brands=false` → job completa directamente, `brand_cache.json` se escribe automáticamente
- [ ] Crear job con `validate_brands=true` → job queda en `pendiente_validacion_marcas`, panel aparece en UI
- [ ] `GET /brands/pending` devuelve lista con prefijo/brand_name/ean/source/confidence
- [ ] `POST /brands/validate` con mix accept/reject/edit → solo aceptadas y editadas se escriben en `brand_cache.json`
- [ ] `POST /brands/validate` con action=edit sin edited_name → 422
- [ ] `POST /brands/validate` en job que no está en `pendiente_validacion_marcas` → 409
- [ ] Después de validar → job pasa a `completado`, panel desaparece, BrandsPanel visible
- [ ] `npm run type-check` sin errores
- [ ] `pytest tests/ -q` → 232 passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)