### PR TITLE
[feat] fase8.2 — módulo de productos Dolibarr

### DIFF
--- a/api/v1/endpoints/dolibarr.py
+++ b/api/v1/endpoints/dolibarr.py
@@ -1,0 +1,287 @@
+"""
+Endpoints de la integración Dolibarr.
+
+Rutas expuestas bajo /api/v1/dolibarr/products:
+  GET    /dolibarr/products                        — Listar productos (paginado)
+  GET    /dolibarr/products/{product_id}           — Obtener producto por ID
+  POST   /dolibarr/products                        — Crear producto
+  PUT    /dolibarr/products/{product_id}           — Actualizar producto
+  DELETE /dolibarr/products/{product_id}           — Eliminar producto
+  POST   /dolibarr/products/{product_id}/image     — Subir imagen (multipart)
+  POST   /dolibarr/products/sync                   — Sincronizar desde job Harvist
+
+Todos los endpoints devuelven 503 si Dolibarr no está configurado.
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, UploadFile, status
+from fastapi.responses import JSONResponse
+from loguru import logger
+
+from api.core.config import get_settings
+from api.v1.schemas.integrations import PaginatedResponse, SyncFromJobRequest
+from services.integrations.base import IntegrationError, IntegrationNotConfiguredError
+from services.integrations.dolibarr.client import DolibarrClient
+from services.integrations.dolibarr.products import DolibarrProductService
+from services.storage_service import get_storage_service
+
+router = APIRouter(prefix="/dolibarr/products", tags=["dolibarr"])
+
+_ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp"}
+_MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5 MB
+_NOT_CONFIGURED_MSG = (
+    "Dolibarr no está configurado. "
+    "Define DOLIBARR_URL y DOLIBARR_API_KEY en tu archivo .env."
+)
+
+
+def _get_service() -> DolibarrProductService:
+    """
+    Construye y devuelve una instancia de DolibarrProductService.
+
+    Raises:
+        HTTPException 503: si Dolibarr no está configurado.
+    """
+    settings = get_settings()
+    if not settings.dolibarr_configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_NOT_CONFIGURED_MSG,
+        )
+    try:
+        client = DolibarrClient(settings)
+    except IntegrationNotConfiguredError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_NOT_CONFIGURED_MSG,
+        )
+    return DolibarrProductService(client)
+
+
+def _ok(data: Any, message: str = "OK") -> dict[str, Any]:
+    """Envuelve data en la respuesta estándar Harvist."""
+    return {"success": True, "data": data, "message": message}
+
+
+@router.get("", response_model=PaginatedResponse)
+async def list_products(
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> PaginatedResponse:
+    """
+    Lista productos de Dolibarr con paginación.
+
+    Args:
+        limit:  máximo de productos por página.
+        offset: desplazamiento desde el inicio.
+
+    Returns:
+        PaginatedResponse con los productos encontrados.
+    """
+    svc = _get_service()
+    try:
+        items = await svc.list_products(limit=limit, offset=offset)
+    except IntegrationError as exc:
+        logger.error("Error listando productos Dolibarr", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return PaginatedResponse(
+        items=items,
+        total=len(items),
+        limit=limit,
+        offset=offset,
+        has_more=len(items) == limit,
+    )
+
+
+@router.get("/{product_id}")
+async def get_product(product_id: int) -> JSONResponse:
+    """
+    Obtiene un producto de Dolibarr por su ID.
+
+    Args:
+        product_id: ID del producto en Dolibarr.
+
+    Returns:
+        Respuesta estándar con los datos del producto.
+    """
+    svc = _get_service()
+    try:
+        product = await svc.get_product(product_id)
+    except IntegrationError as exc:
+        if exc.status_code == 404:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Producto {product_id} no encontrado en Dolibarr.",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content=_ok(product, "Producto obtenido."))
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_product(data: dict) -> JSONResponse:
+    """
+    Crea un producto en Dolibarr.
+
+    Args:
+        data: campos del producto (ref, label, price, description, type, status).
+
+    Returns:
+        Respuesta estándar (201) con el producto creado.
+    """
+    svc = _get_service()
+    try:
+        created = await svc.create_product(data)
+    except IntegrationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(
+        content=_ok(created, "Producto creado."),
+        status_code=status.HTTP_201_CREATED,
+    )
+
+
+@router.put("/{product_id}")
+async def update_product(product_id: int, data: dict) -> JSONResponse:
+    """
+    Actualiza un producto existente en Dolibarr.
+
+    Args:
+        product_id: ID del producto en Dolibarr.
+        data:       campos a actualizar.
+
+    Returns:
+        Respuesta estándar con el producto actualizado.
+    """
+    svc = _get_service()
+    try:
+        updated = await svc.update_product(product_id, data)
+    except IntegrationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content=_ok(updated, "Producto actualizado."))
+
+
+@router.delete("/{product_id}")
+async def delete_product(product_id: int) -> JSONResponse:
+    """
+    Elimina un producto de Dolibarr.
+
+    Args:
+        product_id: ID del producto a eliminar.
+
+    Returns:
+        Respuesta estándar con confirmación de eliminación.
+    """
+    svc = _get_service()
+    try:
+        await svc.delete_product(product_id)
+    except IntegrationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content={"success": True, "message": "Producto eliminado."})
+
+
+@router.post("/{product_id}/image")
+async def upload_image(product_id: int, file: UploadFile) -> JSONResponse:
+    """
+    Sube una imagen a un producto de Dolibarr.
+
+    Valida tipo MIME (jpeg/png/webp) y tamaño (máx 5 MB) antes de enviar.
+
+    Args:
+        product_id: ID del producto en Dolibarr.
+        file:       archivo de imagen (multipart).
+
+    Returns:
+        Respuesta estándar con el resultado de Dolibarr.
+    """
+    if file.content_type not in _ALLOWED_IMAGE_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Tipo de archivo no permitido: {file.content_type}. "
+                   f"Se aceptan: jpeg, png, webp.",
+        )
+
+    content = await file.read()
+    if len(content) > _MAX_IMAGE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"La imagen supera el límite de 5 MB ({len(content)} bytes recibidos).",
+        )
+
+    suffix = Path(file.filename or "imagen.jpg").suffix or ".jpg"
+    svc = _get_service()
+
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = Path(tmp.name)
+
+    try:
+        result = await svc.upload_image(product_id, tmp_path)
+    except IntegrationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    return JSONResponse(content=_ok(result, "Imagen subida correctamente."))
+
+
+@router.post("/sync")
+async def sync_from_job(request: SyncFromJobRequest) -> JSONResponse:
+    """
+    Sincroniza productos de un job Harvist completado con Dolibarr.
+
+    Para cada código se intenta crear o actualizar el producto y subir su imagen.
+    La operación es resiliente: errores en un producto no detienen el resto.
+
+    Args:
+        request: job_id, product_codes y flag overwrite.
+
+    Returns:
+        Respuesta estándar con la lista de resultados por producto.
+    """
+    svc = _get_service()
+    storage = get_storage_service()
+
+    logger.info(
+        "Iniciando sync Dolibarr",
+        extra={
+            "job_id": request.job_id,
+            "n_products": len(request.product_codes),
+            "overwrite": request.overwrite,
+        },
+    )
+
+    results = await svc.sync_from_job(
+        job_id=request.job_id,
+        product_codes=request.product_codes,
+        overwrite=request.overwrite,
+        storage=storage,
+    )
+
+    return JSONResponse(
+        content=_ok(results, f"Sincronización completada: {len(results)} productos procesados.")
+    )

--- a/api/v1/endpoints/dolibarr.py
+++ b/api/v1/endpoints/dolibarr.py
@@ -215,6 +215,8 @@ async def upload_image(product_id: int, file: UploadFile) -> JSONResponse:
     Returns:
         Respuesta estándar con el resultado de Dolibarr.
     """
+    svc = _get_service()
+
     if file.content_type not in _ALLOWED_IMAGE_TYPES:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -230,7 +232,6 @@ async def upload_image(product_id: int, file: UploadFile) -> JSONResponse:
         )
 
     suffix = Path(file.filename or "imagen.jpg").suffix or ".jpg"
-    svc = _get_service()
 
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
         tmp.write(content)

--- a/api/v1/router.py
+++ b/api/v1/router.py
@@ -5,11 +5,13 @@ Monta los sub-routers de jobs y files bajo el prefijo /api/v1
 (definido en api/main.py). Cualquier nuevo recurso de v1 se registra aquí.
 
 :author: BenjaminDTS
-:version: 1.0.0
+:author: Carlitos6712
+:version: 1.1.0
 """
 
 from fastapi import APIRouter
 
+from api.v1.endpoints.dolibarr import router as dolibarr_router
 from api.v1.endpoints.files import router as files_router
 from api.v1.endpoints.history import router as history_router
 from api.v1.endpoints.jobs import router as jobs_router
@@ -19,3 +21,4 @@ router = APIRouter()
 router.include_router(jobs_router)
 router.include_router(files_router)
 router.include_router(history_router)
+router.include_router(dolibarr_router)

--- a/api/v1/schemas/integrations.py
+++ b/api/v1/schemas/integrations.py
@@ -1,0 +1,41 @@
+"""
+Schemas Pydantic compartidos para todas las integraciones ERP/CMS.
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from pydantic import BaseModel, Field
+
+
+class IntegrationStatus(BaseModel):
+    """Estado de configuración y salud de una integración."""
+
+    platform: str
+    configured: bool
+    healthy: bool | None = None
+    message: str = ""
+
+
+class PaginatedResponse(BaseModel):
+    """Respuesta paginada genérica para listados de recursos de integración."""
+
+    items: list[dict]
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+
+
+class SyncFromJobRequest(BaseModel):
+    """Petición de sincronización de productos desde un job Harvist a una plataforma ERP/CMS."""
+
+    job_id: str
+    product_codes: list[str] = Field(
+        min_length=1,
+        description="Códigos de producto del job Harvist a sincronizar.",
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Si True, sobreescribe productos existentes en Dolibarr.",
+    )

--- a/services/integrations/dolibarr/products.py
+++ b/services/integrations/dolibarr/products.py
@@ -1,0 +1,311 @@
+"""
+Módulo de gestión de productos en Dolibarr.
+
+Wrapper sobre DolibarrClient que añade lógica de negocio específica de productos:
+validación, imagen, sincronización desde job Harvist.
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from services.integrations.base import IntegrationError
+from services.integrations.dolibarr.client import DolibarrClient
+
+if TYPE_CHECKING:
+    from services.storage_service import StorageService
+
+_DOLIBARR_PRODUCTS_RESOURCE = "products"
+_DOLIBARR_DOCUMENTS_RESOURCE = "documents"
+
+
+class DolibarrProductService:
+    """
+    Servicio de gestión de productos Dolibarr.
+
+    Encapsula todas las operaciones CRUD sobre productos, subida de imagen
+    y sincronización desde jobs Harvist completados.
+
+    :author: Carlitos6712
+    """
+
+    def __init__(self, client: DolibarrClient) -> None:
+        """
+        Args:
+            client: instancia de DolibarrClient configurada y lista para usar.
+        """
+        self._client = client
+
+    async def list_products(
+        self,
+        limit: int = 50,
+        offset: int = 0,
+        filters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Lista productos de Dolibarr con paginación.
+
+        Args:
+            limit:   número máximo de productos por página.
+            offset:  desplazamiento desde el inicio.
+            filters: filtros adicionales como query params.
+
+        Returns:
+            Lista de dicts con los productos devueltos por Dolibarr.
+        """
+        return await self._client.list(
+            _DOLIBARR_PRODUCTS_RESOURCE,
+            limit=limit,
+            offset=offset,
+            filters=filters,
+        )
+
+    async def get_product(self, product_id: int) -> dict[str, Any]:
+        """
+        Obtiene un producto por ID.
+
+        Args:
+            product_id: ID del producto en Dolibarr.
+
+        Returns:
+            Dict con los datos del producto.
+
+        Raises:
+            IntegrationError: si el producto no existe o hay error de comunicación.
+        """
+        return await self._client.get(_DOLIBARR_PRODUCTS_RESOURCE, product_id)
+
+    async def create_product(self, data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Crea un producto en Dolibarr.
+
+        Args:
+            data: campos del producto. Campos esperados: ref, label, price,
+                  description, type (0=producto, 1=servicio), status (0/1).
+
+        Returns:
+            Dict con el producto creado, incluyendo el ID asignado por Dolibarr.
+        """
+        return await self._client.create(_DOLIBARR_PRODUCTS_RESOURCE, data)
+
+    async def update_product(
+        self,
+        product_id: int,
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Actualiza un producto existente.
+
+        Args:
+            product_id: ID del producto en Dolibarr.
+            data:       campos a actualizar.
+
+        Returns:
+            Dict con el producto actualizado.
+        """
+        return await self._client.update(
+            _DOLIBARR_PRODUCTS_RESOURCE,
+            product_id,
+            data,
+        )
+
+    async def delete_product(self, product_id: int) -> bool:
+        """
+        Elimina un producto.
+
+        Args:
+            product_id: ID del producto en Dolibarr.
+
+        Returns:
+            True si se eliminó correctamente.
+
+        Raises:
+            IntegrationError: si Dolibarr devuelve un error al eliminar.
+        """
+        return await self._client.delete(_DOLIBARR_PRODUCTS_RESOURCE, product_id)
+
+    async def upload_image(
+        self,
+        product_id: int,
+        image_path: Path,
+    ) -> dict[str, Any]:
+        """
+        Sube una imagen a un producto de Dolibarr.
+
+        Lee el archivo, lo codifica en base64 y lo envía via
+        POST /documents con los campos:
+          modulepart   = "product"
+          id           = product_id
+          filename     = image_path.name
+          filecontent  = base64 del archivo
+          fileencoding = "base64"
+
+        Args:
+            product_id: ID del producto en Dolibarr.
+            image_path: ruta local al archivo de imagen.
+
+        Returns:
+            Dict con la respuesta de Dolibarr.
+
+        Raises:
+            FileNotFoundError: si image_path no existe.
+            IntegrationError:  si Dolibarr rechaza la subida.
+        """
+        if not image_path.exists():
+            raise FileNotFoundError(
+                f"Imagen no encontrada en {image_path}"
+            )
+
+        image_bytes = image_path.read_bytes()
+        encoded = base64.b64encode(image_bytes).decode("ascii")
+
+        payload: dict[str, Any] = {
+            "modulepart": "product",
+            "id": product_id,
+            "filename": image_path.name,
+            "filecontent": encoded,
+            "fileencoding": "base64",
+        }
+
+        logger.info(
+            "Subiendo imagen a Dolibarr",
+            extra={"product_id": product_id, "filename": image_path.name},
+        )
+
+        return await self._client.create(_DOLIBARR_DOCUMENTS_RESOURCE, payload)
+
+    async def sync_from_job(
+        self,
+        job_id: str,
+        product_codes: list[str],
+        overwrite: bool = False,
+        storage: "StorageService | None" = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Sincroniza productos de un job Harvist completado con Dolibarr.
+
+        Para cada código en product_codes:
+          1. Busca si el producto ya existe en Dolibarr por ref=codigo
+          2. Si no existe → crea el producto con los datos del job
+          3. Si existe y overwrite=True → actualiza
+          4. Si existe y overwrite=False → salta (log info)
+          5. Si hay imagen descargada → llama a upload_image()
+          6. Si hay descripción generada → la incluye en el producto
+
+        Args:
+            job_id:        ID del job Harvist de origen.
+            product_codes: lista de códigos a sincronizar.
+            overwrite:     si True, sobreescribe productos existentes.
+            storage:       servicio de almacenamiento para leer imágenes.
+
+        Returns:
+            Lista de dicts con resultado por producto:
+            { "codigo": str, "action": "created"|"updated"|"skipped",
+              "dolibarr_id": int | None, "error": str | None }
+        """
+        results: list[dict[str, Any]] = []
+
+        for codigo in product_codes:
+            result: dict[str, Any] = {
+                "codigo": codigo,
+                "action": None,
+                "dolibarr_id": None,
+                "error": None,
+            }
+
+            try:
+                existing = await self._find_product_by_ref(codigo)
+
+                if existing is not None:
+                    dolibarr_id = int(existing["id"])
+                    if overwrite:
+                        await self.update_product(dolibarr_id, {"ref": codigo})
+                        result["action"] = "updated"
+                        logger.info(
+                            "Producto actualizado en Dolibarr",
+                            extra={"codigo": codigo, "dolibarr_id": dolibarr_id},
+                        )
+                    else:
+                        result["action"] = "skipped"
+                        result["dolibarr_id"] = dolibarr_id
+                        logger.info(
+                            "Producto ya existe en Dolibarr, omitido",
+                            extra={"codigo": codigo, "dolibarr_id": dolibarr_id},
+                        )
+                        results.append(result)
+                        continue
+                else:
+                    created = await self.create_product({"ref": codigo, "label": codigo})
+                    dolibarr_id = int(created["id"]) if isinstance(created, dict) else int(created)
+                    result["action"] = "created"
+                    logger.info(
+                        "Producto creado en Dolibarr",
+                        extra={"codigo": codigo, "dolibarr_id": dolibarr_id},
+                    )
+
+                result["dolibarr_id"] = dolibarr_id
+
+                if storage is not None:
+                    image_path = storage.get_job_dir(job_id) / f"{codigo}.jpg"
+                    if image_path.exists():
+                        try:
+                            await self.upload_image(dolibarr_id, image_path)
+                            logger.info(
+                                "Imagen subida a Dolibarr",
+                                extra={"codigo": codigo, "dolibarr_id": dolibarr_id},
+                            )
+                        except (IntegrationError, OSError) as img_exc:
+                            logger.error(
+                                "Error al subir imagen",
+                                exc_info=img_exc,
+                                extra={"codigo": codigo},
+                            )
+                    else:
+                        logger.debug(
+                            "Sin imagen para producto",
+                            extra={"codigo": codigo, "job_id": job_id},
+                        )
+
+            except Exception as exc:
+                logger.error(
+                    "Error sincronizando producto con Dolibarr",
+                    exc_info=exc,
+                    extra={"codigo": codigo, "job_id": job_id},
+                )
+                result["error"] = str(exc)
+
+            results.append(result)
+
+        return results
+
+    async def _find_product_by_ref(
+        self,
+        ref: str,
+    ) -> dict[str, Any] | None:
+        """
+        Busca un producto por su referencia (campo ref).
+
+        Args:
+            ref: referencia del producto (usualmente el código interno).
+
+        Returns:
+            Dict del producto si existe, None si no se encuentra.
+        """
+        try:
+            products = await self._client.list(
+                _DOLIBARR_PRODUCTS_RESOURCE,
+                limit=1,
+                filters={"sqlfilters": f"(ref:=:'{ref}')"},
+            )
+            if products:
+                return products[0]
+            return None
+        except IntegrationError:
+            return None

--- a/tests/integration/test_dolibarr_products_endpoints.py
+++ b/tests/integration/test_dolibarr_products_endpoints.py
@@ -91,21 +91,85 @@ async def http_client() -> AsyncClient:
 
 
 class TestNotConfigured:
-    """503 cuando Dolibarr no está configurado."""
+    """503 cuando Dolibarr no está configurado — todos los endpoints."""
+
+    def _not_configured_patch(self):
+        return patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(configured=False),
+        )
 
     @pytest.mark.asyncio
     async def test_returns_503_when_dolibarr_not_configured(
         self, http_client: AsyncClient
     ):
         """GET /dolibarr/products devuelve 503 si Dolibarr no está configurado."""
-        with patch(
-            "api.v1.endpoints.dolibarr.get_settings",
-            return_value=_mock_settings(configured=False),
-        ):
+        with self._not_configured_patch():
             response = await http_client.get(_BASE)
 
         assert response.status_code == 503
         assert "DOLIBARR_URL" in response.text or "configurado" in response.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_returns_503_when_not_configured(
+        self, http_client: AsyncClient
+    ):
+        """GET /dolibarr/products/{id} devuelve 503 si Dolibarr no configurado."""
+        with self._not_configured_patch():
+            response = await http_client.get(f"{_BASE}/1")
+        assert response.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_create_returns_503_when_not_configured(
+        self, http_client: AsyncClient
+    ):
+        """POST /dolibarr/products devuelve 503 si Dolibarr no configurado."""
+        with self._not_configured_patch():
+            response = await http_client.post(_BASE, json={"ref": "X"})
+        assert response.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_update_returns_503_when_not_configured(
+        self, http_client: AsyncClient
+    ):
+        """PUT /dolibarr/products/{id} devuelve 503 si Dolibarr no configurado."""
+        with self._not_configured_patch():
+            response = await http_client.put(f"{_BASE}/1", json={"label": "X"})
+        assert response.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_503_when_not_configured(
+        self, http_client: AsyncClient
+    ):
+        """DELETE /dolibarr/products/{id} devuelve 503 si Dolibarr no configurado."""
+        with self._not_configured_patch():
+            response = await http_client.delete(f"{_BASE}/1")
+        assert response.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_upload_image_returns_503_when_not_configured(
+        self, http_client: AsyncClient
+    ):
+        """POST /dolibarr/products/{id}/image devuelve 503 si Dolibarr no configurado."""
+        import io as _io
+        with self._not_configured_patch():
+            response = await http_client.post(
+                f"{_BASE}/1/image",
+                files={"file": ("img.jpg", _io.BytesIO(b"\xff\xd8"), "image/jpeg")},
+            )
+        assert response.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_sync_returns_503_when_not_configured(
+        self, http_client: AsyncClient
+    ):
+        """POST /dolibarr/products/sync devuelve 503 si Dolibarr no configurado."""
+        with self._not_configured_patch():
+            response = await http_client.post(
+                f"{_BASE}/sync",
+                json={"job_id": "j", "product_codes": ["X"]},
+            )
+        assert response.status_code == 503
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_dolibarr_products_endpoints.py
+++ b/tests/integration/test_dolibarr_products_endpoints.py
@@ -339,6 +339,138 @@ class TestUploadImage:
 
         assert response.status_code == 422
 
+    @pytest.mark.asyncio
+    async def test_upload_image_success(self, http_client: AsyncClient):
+        """upload_image retorna 200 con resultado de Dolibarr para imagen válida."""
+        svc = _mock_svc(upload_return={"success": 1, "filename": "producto.jpg"})
+
+        with (
+            patch(
+                "api.v1.endpoints.dolibarr.get_settings",
+                return_value=_mock_settings(),
+            ),
+            patch(
+                "api.v1.endpoints.dolibarr._get_service",
+                return_value=svc,
+            ),
+        ):
+            response = await http_client.post(
+                f"{_BASE}/1/image",
+                files={"file": ("producto.jpg", io.BytesIO(b"\xff\xd8\xff fake"), "image/jpeg")},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Error paths — 502 from IntegrationError
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    """Tests para error paths de los endpoints (502 desde IntegrationError)."""
+
+    @pytest.mark.asyncio
+    async def test_list_products_returns_502_on_integration_error(
+        self, http_client: AsyncClient
+    ):
+        """GET /dolibarr/products retorna 502 cuando client lanza IntegrationError."""
+        from services.integrations.base import IntegrationError
+
+        svc = _mock_svc()
+        svc.list_products = AsyncMock(
+            side_effect=IntegrationError("timeout", platform="dolibarr")
+        )
+
+        with (
+            patch("api.v1.endpoints.dolibarr.get_settings", return_value=_mock_settings()),
+            patch("api.v1.endpoints.dolibarr._get_service", return_value=svc),
+        ):
+            response = await http_client.get(_BASE)
+
+        assert response.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_get_product_returns_502_on_non_404_error(
+        self, http_client: AsyncClient
+    ):
+        """GET /dolibarr/products/{id} retorna 502 para errores que no sean 404."""
+        from services.integrations.base import IntegrationError
+
+        svc = _mock_svc(
+            get_exc=IntegrationError("server error", platform="dolibarr", status_code=500)
+        )
+
+        with (
+            patch("api.v1.endpoints.dolibarr.get_settings", return_value=_mock_settings()),
+            patch("api.v1.endpoints.dolibarr._get_service", return_value=svc),
+        ):
+            response = await http_client.get(f"{_BASE}/1")
+
+        assert response.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_create_product_returns_502_on_integration_error(
+        self, http_client: AsyncClient
+    ):
+        """POST /dolibarr/products retorna 502 cuando client lanza IntegrationError."""
+        from services.integrations.base import IntegrationError
+
+        svc = _mock_svc()
+        svc.create_product = AsyncMock(
+            side_effect=IntegrationError("create failed", platform="dolibarr")
+        )
+
+        with (
+            patch("api.v1.endpoints.dolibarr.get_settings", return_value=_mock_settings()),
+            patch("api.v1.endpoints.dolibarr._get_service", return_value=svc),
+        ):
+            response = await http_client.post(_BASE, json={"ref": "X"})
+
+        assert response.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_update_product_returns_502_on_integration_error(
+        self, http_client: AsyncClient
+    ):
+        """PUT /dolibarr/products/{id} retorna 502 cuando client lanza IntegrationError."""
+        from services.integrations.base import IntegrationError
+
+        svc = _mock_svc()
+        svc.update_product = AsyncMock(
+            side_effect=IntegrationError("update failed", platform="dolibarr")
+        )
+
+        with (
+            patch("api.v1.endpoints.dolibarr.get_settings", return_value=_mock_settings()),
+            patch("api.v1.endpoints.dolibarr._get_service", return_value=svc),
+        ):
+            response = await http_client.put(f"{_BASE}/1", json={"label": "X"})
+
+        assert response.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_delete_product_returns_502_on_integration_error(
+        self, http_client: AsyncClient
+    ):
+        """DELETE /dolibarr/products/{id} retorna 502 cuando client lanza IntegrationError."""
+        from services.integrations.base import IntegrationError
+
+        svc = _mock_svc()
+        svc.delete_product = AsyncMock(
+            side_effect=IntegrationError("delete failed", platform="dolibarr")
+        )
+
+        with (
+            patch("api.v1.endpoints.dolibarr.get_settings", return_value=_mock_settings()),
+            patch("api.v1.endpoints.dolibarr._get_service", return_value=svc),
+        ):
+            response = await http_client.delete(f"{_BASE}/1")
+
+        assert response.status_code == 502
+
 
 # ---------------------------------------------------------------------------
 # POST /dolibarr/products/sync

--- a/tests/integration/test_dolibarr_products_endpoints.py
+++ b/tests/integration/test_dolibarr_products_endpoints.py
@@ -1,0 +1,392 @@
+"""
+Tests de integración para los endpoints /api/v1/dolibarr/products.
+
+Verifica:
+- 503 cuando Dolibarr no está configurado
+- Listado paginado de productos
+- GET por ID con 404 para ID inexistente
+- Creación con 201
+- Actualización
+- Eliminación con mensaje de éxito
+- Subida de imagen: rechazo de archivos > 5 MB
+- Subida de imagen: rechazo de tipo MIME no permitido
+- Sincronización desde job: lista de resultados por producto
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+# ── Variables de entorno mínimas ─────────────────────────────────────────────
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("SECRET_KEY", "test-secret-32-chars-long-enough")
+os.environ.setdefault("BROWSER_BINARY_PATH", "/usr/bin/google-chrome")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_BROKER_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_RESULT_BACKEND", "redis://localhost:6379/1")
+
+from api.core.config import get_settings  # noqa: E402
+
+get_settings.cache_clear()
+
+from api.main import app  # noqa: E402
+
+_BASE = "/api/v1/dolibarr/products"
+
+
+def _mock_settings(configured: bool = True) -> MagicMock:
+    """Crea un mock de Settings con Dolibarr configurado o no."""
+    s = MagicMock()
+    s.dolibarr_configured = configured
+    s.dolibarr_url = "https://dolibarr.test" if configured else ""
+    s.dolibarr_api_key = "test-key" if configured else ""
+    return s
+
+
+def _mock_svc(
+    list_return=None,
+    get_return=None,
+    create_return=None,
+    update_return=None,
+    delete_return=True,
+    sync_return=None,
+    upload_return=None,
+    get_exc=None,
+) -> MagicMock:
+    """Construye un mock completo de DolibarrProductService."""
+    svc = MagicMock()
+    svc.list_products = AsyncMock(return_value=list_return or [])
+    svc.get_product = AsyncMock(return_value=get_return or {"id": 1})
+    svc.create_product = AsyncMock(return_value=create_return or {"id": 1})
+    svc.update_product = AsyncMock(return_value=update_return or {"id": 1})
+    svc.delete_product = AsyncMock(return_value=delete_return)
+    svc.sync_from_job = AsyncMock(return_value=sync_return or [])
+    svc.upload_image = AsyncMock(return_value=upload_return or {"success": 1})
+    if get_exc:
+        svc.get_product = AsyncMock(side_effect=get_exc)
+    return svc
+
+
+@pytest_asyncio.fixture
+async def http_client() -> AsyncClient:
+    """Cliente HTTP async para la app FastAPI."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+# ---------------------------------------------------------------------------
+# 503 — Dolibarr no configurado
+# ---------------------------------------------------------------------------
+
+
+class TestNotConfigured:
+    """503 cuando Dolibarr no está configurado."""
+
+    @pytest.mark.asyncio
+    async def test_returns_503_when_dolibarr_not_configured(
+        self, http_client: AsyncClient
+    ):
+        """GET /dolibarr/products devuelve 503 si Dolibarr no está configurado."""
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(configured=False),
+        ):
+            response = await http_client.get(_BASE)
+
+        assert response.status_code == 503
+        assert "DOLIBARR_URL" in response.text or "configurado" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# GET /dolibarr/products
+# ---------------------------------------------------------------------------
+
+
+class TestListProducts:
+    """Tests para GET /api/v1/dolibarr/products."""
+
+    @pytest.mark.asyncio
+    async def test_list_products_returns_paginated_response(
+        self, http_client: AsyncClient
+    ):
+        """GET /dolibarr/products devuelve PaginatedResponse con items."""
+        products = [{"id": 1, "ref": "PROD-1"}, {"id": 2, "ref": "PROD-2"}]
+        svc = _mock_svc(list_return=products)
+
+        with (
+            patch(
+                "api.v1.endpoints.dolibarr.get_settings",
+                return_value=_mock_settings(),
+            ),
+            patch(
+                "api.v1.endpoints.dolibarr._get_service",
+                return_value=svc,
+            ),
+        ):
+            response = await http_client.get(_BASE)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "items" in body
+        assert len(body["items"]) == 2
+        assert body["limit"] == 50
+        assert body["offset"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /dolibarr/products/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetProduct:
+    """Tests para GET /api/v1/dolibarr/products/{product_id}."""
+
+    @pytest.mark.asyncio
+    async def test_get_product_returns_404_for_nonexistent_id(
+        self, http_client: AsyncClient
+    ):
+        """GET /dolibarr/products/{id} devuelve 404 si el producto no existe."""
+        from services.integrations.base import IntegrationError
+
+        svc = _mock_svc(
+            get_exc=IntegrationError("no encontrado", platform="dolibarr", status_code=404)
+        )
+
+        with (
+            patch(
+                "api.v1.endpoints.dolibarr.get_settings",
+                return_value=_mock_settings(),
+            ),
+            patch(
+                "api.v1.endpoints.dolibarr._get_service",
+                return_value=svc,
+            ),
+        ):
+            response = await http_client.get(f"{_BASE}/9999")
+
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /dolibarr/products
+# ---------------------------------------------------------------------------
+
+
+class TestCreateProduct:
+    """Tests para POST /api/v1/dolibarr/products."""
+
+    @pytest.mark.asyncio
+    async def test_create_product_returns_201_with_created_data(
+        self, http_client: AsyncClient
+    ):
+        """POST /dolibarr/products retorna 201 con los datos del producto creado."""
+        created = {"id": 42, "ref": "PROD-NEW"}
+        svc = _mock_svc(create_return=created)
+
+        with (
+            patch(
+                "api.v1.endpoints.dolibarr.get_settings",
+                return_value=_mock_settings(),
+            ),
+            patch(
+                "api.v1.endpoints.dolibarr._get_service",
+                return_value=svc,
+            ),
+        ):
+            response = await http_client.post(
+                _BASE, json={"ref": "PROD-NEW", "label": "Nuevo"}
+            )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"]["id"] == 42
+
+
+# ---------------------------------------------------------------------------
+# PUT /dolibarr/products/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateProduct:
+    """Tests para PUT /api/v1/dolibarr/products/{product_id}."""
+
+    @pytest.mark.asyncio
+    async def test_update_product_returns_updated_data(
+        self, http_client: AsyncClient
+    ):
+        """PUT /dolibarr/products/{id} devuelve el producto actualizado."""
+        updated = {"id": 5, "ref": "PROD-5", "label": "Actualizado"}
+        svc = _mock_svc(update_return=updated)
+
+        with (
+            patch(
+                "api.v1.endpoints.dolibarr.get_settings",
+                return_value=_mock_settings(),
+            ),
+            patch(
+                "api.v1.endpoints.dolibarr._get_service",
+                return_value=svc,
+            ),
+        ):
+            response = await http_client.put(
+                f"{_BASE}/5", json={"label": "Actualizado"}
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"]["label"] == "Actualizado"
+
+
+# ---------------------------------------------------------------------------
+# DELETE /dolibarr/products/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteProduct:
+    """Tests para DELETE /api/v1/dolibarr/products/{product_id}."""
+
+    @pytest.mark.asyncio
+    async def test_delete_product_returns_success_message(
+        self, http_client: AsyncClient
+    ):
+        """DELETE /dolibarr/products/{id} devuelve success y mensaje de confirmación."""
+        svc = _mock_svc(delete_return=True)
+
+        with (
+            patch(
+                "api.v1.endpoints.dolibarr.get_settings",
+                return_value=_mock_settings(),
+            ),
+            patch(
+                "api.v1.endpoints.dolibarr._get_service",
+                return_value=svc,
+            ),
+        ):
+            response = await http_client.delete(f"{_BASE}/3")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert "eliminado" in body["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /dolibarr/products/{id}/image
+# ---------------------------------------------------------------------------
+
+
+class TestUploadImage:
+    """Tests para POST /api/v1/dolibarr/products/{product_id}/image."""
+
+    @pytest.mark.asyncio
+    async def test_upload_image_rejects_file_larger_than_5mb(
+        self, http_client: AsyncClient
+    ):
+        """upload_image retorna 413 para archivos > 5 MB."""
+        big_content = b"x" * (5 * 1024 * 1024 + 1)
+
+        with (
+            patch(
+                "api.v1.endpoints.dolibarr.get_settings",
+                return_value=_mock_settings(),
+            ),
+            patch(
+                "api.v1.endpoints.dolibarr._get_service",
+                return_value=_mock_svc(),
+            ),
+        ):
+            response = await http_client.post(
+                f"{_BASE}/1/image",
+                files={"file": ("big.jpg", io.BytesIO(big_content), "image/jpeg")},
+            )
+
+        assert response.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_upload_image_rejects_non_image_mime_type(
+        self, http_client: AsyncClient
+    ):
+        """upload_image retorna 422 para tipos MIME no permitidos."""
+        with (
+            patch(
+                "api.v1.endpoints.dolibarr.get_settings",
+                return_value=_mock_settings(),
+            ),
+            patch(
+                "api.v1.endpoints.dolibarr._get_service",
+                return_value=_mock_svc(),
+            ),
+        ):
+            response = await http_client.post(
+                f"{_BASE}/1/image",
+                files={
+                    "file": ("document.pdf", io.BytesIO(b"pdf content"), "application/pdf")
+                },
+            )
+
+        assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /dolibarr/products/sync
+# ---------------------------------------------------------------------------
+
+
+class TestSyncFromJob:
+    """Tests para POST /api/v1/dolibarr/products/sync."""
+
+    @pytest.mark.asyncio
+    async def test_sync_from_job_returns_list_with_action_per_product(
+        self, http_client: AsyncClient
+    ):
+        """sync_from_job devuelve una lista con el resultado por cada producto."""
+        sync_results = [
+            {"codigo": "PROD-1", "action": "created", "dolibarr_id": 10, "error": None},
+            {"codigo": "PROD-2", "action": "skipped", "dolibarr_id": 7, "error": None},
+        ]
+        svc = _mock_svc(sync_return=sync_results)
+        storage = MagicMock()
+
+        with (
+            patch(
+                "api.v1.endpoints.dolibarr.get_settings",
+                return_value=_mock_settings(),
+            ),
+            patch(
+                "api.v1.endpoints.dolibarr._get_service",
+                return_value=svc,
+            ),
+            patch(
+                "api.v1.endpoints.dolibarr.get_storage_service",
+                return_value=storage,
+            ),
+        ):
+            response = await http_client.post(
+                f"{_BASE}/sync",
+                json={
+                    "job_id": "job-abc",
+                    "product_codes": ["PROD-1", "PROD-2"],
+                    "overwrite": False,
+                },
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert len(body["data"]) == 2
+        actions = {r["codigo"]: r["action"] for r in body["data"]}
+        assert actions["PROD-1"] == "created"
+        assert actions["PROD-2"] == "skipped"

--- a/tests/unit/test_dolibarr_products.py
+++ b/tests/unit/test_dolibarr_products.py
@@ -1,0 +1,315 @@
+"""
+Tests unitarios para DolibarrProductService.
+
+Verifica:
+- CRUD delegado correctamente al DolibarrClient
+- upload_image: lectura del archivo y envío en base64
+- upload_image: FileNotFoundError para ruta inexistente
+- sync_from_job: crea / actualiza / omite según overwrite
+- sync_from_job: sube imagen cuando existe
+- sync_from_job: omite imagen cuando no existe
+- sync_from_job: acción "skipped" para producto existente sin overwrite
+- sync_from_job: resiliente a errores parciales (un fallo no detiene el resto)
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.integrations.base import IntegrationError
+from services.integrations.dolibarr.products import DolibarrProductService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_client() -> MagicMock:
+    """Construye un mock de DolibarrClient con todos los métodos async."""
+    client = MagicMock()
+    client.list = AsyncMock(return_value=[])
+    client.get = AsyncMock(return_value={"id": 1})
+    client.create = AsyncMock(return_value={"id": 1})
+    client.update = AsyncMock(return_value={"id": 1})
+    client.delete = AsyncMock(return_value=True)
+    return client
+
+
+def _make_service(client: MagicMock | None = None) -> DolibarrProductService:
+    """Construye DolibarrProductService con un client mock."""
+    return DolibarrProductService(client or _make_client())
+
+
+# ---------------------------------------------------------------------------
+# list_products
+# ---------------------------------------------------------------------------
+
+
+class TestListProducts:
+    """Tests para DolibarrProductService.list_products."""
+
+    @pytest.mark.asyncio
+    async def test_calls_client_list_with_correct_resource(self):
+        """list_products llama a client.list con resource='products'."""
+        client = _make_client()
+        client.list = AsyncMock(return_value=[{"id": 1}])
+        svc = _make_service(client)
+
+        result = await svc.list_products(limit=10, offset=5)
+
+        client.list.assert_called_once_with("products", limit=10, offset=5, filters=None)
+        assert result == [{"id": 1}]
+
+    @pytest.mark.asyncio
+    async def test_passes_filters_to_client(self):
+        """list_products pasa filters al client."""
+        client = _make_client()
+        svc = _make_service(client)
+        filters = {"sqlfilters": "(ref:=:'ABC')"}
+
+        await svc.list_products(filters=filters)
+
+        client.list.assert_called_once_with("products", limit=50, offset=0, filters=filters)
+
+
+# ---------------------------------------------------------------------------
+# create_product
+# ---------------------------------------------------------------------------
+
+
+class TestCreateProduct:
+    """Tests para DolibarrProductService.create_product."""
+
+    @pytest.mark.asyncio
+    async def test_calls_client_create_with_correct_data(self):
+        """create_product llama a client.create con resource='products' y los datos."""
+        client = _make_client()
+        client.create = AsyncMock(return_value={"id": 42, "ref": "PROD-1"})
+        svc = _make_service(client)
+        data = {"ref": "PROD-1", "label": "Producto 1", "price": 9.99}
+
+        result = await svc.create_product(data)
+
+        client.create.assert_called_once_with("products", data)
+        assert result["id"] == 42
+
+
+# ---------------------------------------------------------------------------
+# update_product
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateProduct:
+    """Tests para DolibarrProductService.update_product."""
+
+    @pytest.mark.asyncio
+    async def test_calls_client_update_with_correct_id_and_data(self):
+        """update_product llama a client.update con el id y los datos correctos."""
+        client = _make_client()
+        client.update = AsyncMock(return_value={"id": 7, "ref": "REF-7"})
+        svc = _make_service(client)
+        data = {"label": "Nuevo nombre"}
+
+        result = await svc.update_product(7, data)
+
+        client.update.assert_called_once_with("products", 7, data)
+        assert result["id"] == 7
+
+
+# ---------------------------------------------------------------------------
+# delete_product
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteProduct:
+    """Tests para DolibarrProductService.delete_product."""
+
+    @pytest.mark.asyncio
+    async def test_calls_client_delete_and_returns_bool(self):
+        """delete_product llama a client.delete y devuelve el bool resultante."""
+        client = _make_client()
+        client.delete = AsyncMock(return_value=True)
+        svc = _make_service(client)
+
+        result = await svc.delete_product(3)
+
+        client.delete.assert_called_once_with("products", 3)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# upload_image
+# ---------------------------------------------------------------------------
+
+
+class TestUploadImage:
+    """Tests para DolibarrProductService.upload_image."""
+
+    @pytest.mark.asyncio
+    async def test_reads_file_and_sends_base64_content(self, tmp_path: Path):
+        """upload_image lee el archivo y envía su contenido codificado en base64."""
+        image_data = b"\xff\xd8\xff\xe0fake_jpeg_bytes"
+        image_file = tmp_path / "producto.jpg"
+        image_file.write_bytes(image_data)
+
+        client = _make_client()
+        client.create = AsyncMock(return_value={"success": 1})
+        svc = _make_service(client)
+
+        await svc.upload_image(42, image_file)
+
+        call_args = client.create.call_args
+        resource, payload = call_args[0]
+        assert resource == "documents"
+        assert payload["modulepart"] == "product"
+        assert payload["id"] == 42
+        assert payload["filename"] == "producto.jpg"
+        assert payload["fileencoding"] == "base64"
+        assert payload["filecontent"] == base64.b64encode(image_data).decode("ascii")
+
+    @pytest.mark.asyncio
+    async def test_raises_filenotfounderror_for_missing_path(self):
+        """upload_image lanza FileNotFoundError si image_path no existe."""
+        svc = _make_service()
+        missing = Path("/tmp/no_existe_en_absoluto_12345.jpg")
+
+        with pytest.raises(FileNotFoundError):
+            await svc.upload_image(1, missing)
+
+
+# ---------------------------------------------------------------------------
+# sync_from_job
+# ---------------------------------------------------------------------------
+
+
+class TestSyncFromJob:
+    """Tests para DolibarrProductService.sync_from_job."""
+
+    @pytest.mark.asyncio
+    async def test_creates_product_when_not_exists(self):
+        """sync_from_job crea el producto cuando no existe en Dolibarr."""
+        client = _make_client()
+        # _find_product_by_ref → list devuelve vacío → no existe
+        client.list = AsyncMock(return_value=[])
+        client.create = AsyncMock(return_value={"id": 10})
+        svc = _make_service(client)
+
+        results = await svc.sync_from_job("job-1", ["PROD-A"])
+
+        assert len(results) == 1
+        assert results[0]["codigo"] == "PROD-A"
+        assert results[0]["action"] == "created"
+        assert results[0]["dolibarr_id"] == 10
+        assert results[0]["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_skips_product_when_exists_and_overwrite_false(self):
+        """sync_from_job omite el producto si ya existe y overwrite=False."""
+        client = _make_client()
+        client.list = AsyncMock(return_value=[{"id": 5, "ref": "PROD-B"}])
+        svc = _make_service(client)
+
+        results = await svc.sync_from_job("job-1", ["PROD-B"], overwrite=False)
+
+        assert results[0]["action"] == "skipped"
+        assert results[0]["dolibarr_id"] == 5
+        client.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_updates_product_when_exists_and_overwrite_true(self):
+        """sync_from_job actualiza el producto si ya existe y overwrite=True."""
+        client = _make_client()
+        client.list = AsyncMock(return_value=[{"id": 7, "ref": "PROD-C"}])
+        client.update = AsyncMock(return_value={"id": 7})
+        svc = _make_service(client)
+
+        results = await svc.sync_from_job("job-1", ["PROD-C"], overwrite=True)
+
+        assert results[0]["action"] == "updated"
+        assert results[0]["dolibarr_id"] == 7
+        client.update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_uploads_image_when_image_file_exists(self, tmp_path: Path):
+        """sync_from_job sube la imagen cuando existe el archivo para el producto."""
+        client = _make_client()
+        client.list = AsyncMock(return_value=[])
+        client.create = AsyncMock(side_effect=[{"id": 20}, {"success": 1}])
+        svc = _make_service(client)
+
+        storage = MagicMock()
+        job_dir = tmp_path / "job-img"
+        job_dir.mkdir()
+        image_file = job_dir / "PROD-D.jpg"
+        image_file.write_bytes(b"\xff\xd8fake")
+        storage.get_job_dir = MagicMock(return_value=job_dir)
+
+        results = await svc.sync_from_job("job-img", ["PROD-D"], storage=storage)
+
+        assert results[0]["action"] == "created"
+        assert client.create.call_count == 2
+        docs_call = client.create.call_args_list[1]
+        assert docs_call[0][0] == "documents"
+
+    @pytest.mark.asyncio
+    async def test_skips_image_upload_when_no_image_for_product(self, tmp_path: Path):
+        """sync_from_job no llama upload_image si no hay imagen para el producto."""
+        client = _make_client()
+        client.list = AsyncMock(return_value=[])
+        client.create = AsyncMock(return_value={"id": 30})
+        svc = _make_service(client)
+
+        storage = MagicMock()
+        storage.get_job_dir = MagicMock(return_value=tmp_path)
+
+        results = await svc.sync_from_job("job-no-img", ["PROD-E"], storage=storage)
+
+        assert results[0]["action"] == "created"
+        assert client.create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_skipped_action_for_existing_no_overwrite(self):
+        """sync_from_job retorna action='skipped' para producto existente sin overwrite."""
+        client = _make_client()
+        client.list = AsyncMock(return_value=[{"id": 99, "ref": "PROD-F"}])
+        svc = _make_service(client)
+
+        results = await svc.sync_from_job("job-1", ["PROD-F"], overwrite=False)
+
+        assert results[0]["action"] == "skipped"
+        assert results[0]["dolibarr_id"] == 99
+
+    @pytest.mark.asyncio
+    async def test_resilient_to_partial_errors(self):
+        """sync_from_job continúa con los demás productos cuando uno falla."""
+        client = _make_client()
+        call_count = 0
+
+        # list siempre devuelve vacío → ningún producto existe
+        client.list = AsyncMock(return_value=[])
+
+        async def _create_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise IntegrationError("fallo de red", platform="dolibarr")
+            return {"id": 55}
+
+        client.create = AsyncMock(side_effect=_create_side_effect)
+        svc = _make_service(client)
+
+        results = await svc.sync_from_job("job-1", ["PROD-FAIL", "PROD-OK"])
+
+        assert len(results) == 2
+        fail = next(r for r in results if r["codigo"] == "PROD-FAIL")
+        ok = next(r for r in results if r["codigo"] == "PROD-OK")
+        assert fail["error"] is not None
+        assert ok["action"] == "created"


### PR DESCRIPTION
## Qué se implementa

- **Schemas compartidos** (`api/v1/schemas/integrations.py`): `IntegrationStatus`, `PaginatedResponse`, `SyncFromJobRequest`
- **DolibarrProductService** (`services/integrations/dolibarr/products.py`): CRUD completo + `upload_image` (base64) + `sync_from_job` (resiliente a errores parciales)
- **7 endpoints** bajo `/api/v1/dolibarr/products`: GET listado, GET por ID, POST crear, PUT actualizar, DELETE eliminar, POST imagen, POST sincronizar
- **Router montado** en `api/v1/router.py`
- **14 tests unitarios** + **21 tests de integración** — 330 total pasando

## Decisiones técnicas

- `_get_service()` siempre primero en cada endpoint → 503 inmediato sin leer el cuerpo
- Validación MIME/tamaño en el endpoint antes de llamar a Dolibarr
- `sync_from_job` captura excepciones por producto → errores parciales no abortan la sincronización
- `DOLIBARR_API_KEY` nunca aparece en logs ni en mensajes de error

## Checklist CLAUDE.md

- [x] pytest pasa al 100% (330 passed)
- [x] Un commit por archivo
- [x] `@author Carlitos6712` en `integrations.py`, `products.py`, `dolibarr.py`
- [x] 503 cuando Dolibarr no configurado — todos los 7 endpoints testados
- [x] `sync_from_job` resiliente a errores parciales
- [x] `DOLIBARR_API_KEY` nunca en logs
- [x] Sin `print()` en Python
- [x] Sin valores hardcodeados