### PR TITLE
[feat] fase8.3 — módulo de categorías Dolibarr

### DIFF
--- a/api/v1/endpoints/dolibarr.py
+++ b/api/v1/endpoints/dolibarr.py
@@ -10,6 +10,17 @@ Rutas expuestas bajo /api/v1/dolibarr/products:
   POST   /dolibarr/products/{product_id}/image     — Subir imagen (multipart)
   POST   /dolibarr/products/sync                   — Sincronizar desde job Harvist
 
+Rutas expuestas bajo /api/v1/dolibarr/categories:
+  GET    /dolibarr/categories                      — Listar categorías (paginado)
+  GET    /dolibarr/categories/tree                 — Obtener árbol jerárquico
+  GET    /dolibarr/categories/{category_id}        — Obtener categoría por ID
+  POST   /dolibarr/categories                      — Crear categoría
+  PUT    /dolibarr/categories/{category_id}        — Actualizar categoría
+  DELETE /dolibarr/categories/{category_id}        — Eliminar categoría
+  POST   /dolibarr/categories/{category_id}/products/{product_id} — Asignar producto
+  DELETE /dolibarr/categories/{category_id}/products/{product_id} — Remover producto
+  GET    /dolibarr/categories/{category_id}/products — Listar productos en categoría
+
 Todos los endpoints devuelven 503 si Dolibarr no está configurado.
 
 :author: Carlitos6712
@@ -29,6 +40,7 @@ from loguru import logger
 from api.core.config import get_settings
 from api.v1.schemas.integrations import PaginatedResponse, SyncFromJobRequest
 from services.integrations.base import IntegrationError, IntegrationNotConfiguredError
+from services.integrations.dolibarr.categories import DolibarrCategoryService
 from services.integrations.dolibarr.client import DolibarrClient
 from services.integrations.dolibarr.products import DolibarrProductService
 from services.storage_service import get_storage_service
@@ -285,4 +297,288 @@ async def sync_from_job(request: SyncFromJobRequest) -> JSONResponse:
 
     return JSONResponse(
         content=_ok(results, f"Sincronización completada: {len(results)} productos procesados.")
+    )
+
+
+# ── Categorías ──────────────────────────────────────────────────────
+
+
+categories_router = APIRouter(prefix="/dolibarr/categories", tags=["dolibarr-categories"])
+
+
+def _get_category_service() -> DolibarrCategoryService:
+    """
+    Construye y devuelve una instancia de DolibarrCategoryService.
+
+    Raises:
+        HTTPException 503: si Dolibarr no está configurado.
+    """
+    settings = get_settings()
+    if not settings.dolibarr_configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_NOT_CONFIGURED_MSG,
+        )
+    try:
+        client = DolibarrClient(settings)
+    except IntegrationNotConfiguredError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_NOT_CONFIGURED_MSG,
+        )
+    return DolibarrCategoryService(client)
+
+
+@categories_router.get("", response_model=PaginatedResponse)
+async def list_categories(
+    type: str = Query(default="product"),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> PaginatedResponse:
+    """
+    Lista categorías de Dolibarr con paginación.
+
+    Args:
+        type:   tipo de categoría (product, customer, supplier, member).
+        limit:  máximo de categorías por página.
+        offset: desplazamiento desde el inicio.
+
+    Returns:
+        PaginatedResponse con las categorías encontradas.
+    """
+    svc = _get_category_service()
+    try:
+        items = await svc.list_categories(type=type, limit=limit, offset=offset)
+    except IntegrationError as exc:
+        logger.error("Error listando categorías Dolibarr", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return PaginatedResponse(
+        items=items,
+        total=len(items),
+        limit=limit,
+        offset=offset,
+        has_more=len(items) == limit,
+    )
+
+
+@categories_router.get("/tree")
+async def get_tree(
+    type: str = Query(default="product"),
+) -> JSONResponse:
+    """
+    Obtiene el árbol jerárquico completo de categorías.
+
+    Args:
+        type: tipo de categoría.
+
+    Returns:
+        Respuesta estándar con lista anidada de nodos.
+    """
+    svc = _get_category_service()
+    try:
+        tree = await svc.get_tree(type=type)
+    except IntegrationError as exc:
+        logger.error("Error obteniendo árbol de categorías Dolibarr", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content=_ok(tree, "Árbol de categorías obtenido."))
+
+
+@categories_router.get("/{category_id}")
+async def get_category(category_id: int) -> JSONResponse:
+    """
+    Obtiene una categoría de Dolibarr por su ID.
+
+    Args:
+        category_id: ID de la categoría en Dolibarr.
+
+    Returns:
+        Respuesta estándar con los datos de la categoría.
+    """
+    svc = _get_category_service()
+    try:
+        category = await svc.get_category(category_id)
+    except IntegrationError as exc:
+        if exc.status_code == 404:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Categoría {category_id} no encontrada en Dolibarr.",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content=_ok(category, "Categoría obtenida."))
+
+
+@categories_router.post("", status_code=status.HTTP_201_CREATED)
+async def create_category(
+    label: str = Query(...),
+    type: str = Query(default="product"),
+    parent_id: int | None = Query(default=None),
+    description: str = Query(default=""),
+) -> JSONResponse:
+    """
+    Crea una categoría en Dolibarr.
+
+    Args:
+        label:       nombre de la categoría.
+        type:        tipo de categoría.
+        parent_id:   ID de la categoría padre (opcional).
+        description: descripción (opcional).
+
+    Returns:
+        Respuesta estándar (201) con la categoría creada.
+    """
+    svc = _get_category_service()
+    try:
+        created = await svc.create_category(
+            label=label,
+            type=type,
+            parent_id=parent_id,
+            description=description,
+        )
+    except IntegrationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(
+        content=_ok(created, "Categoría creada."),
+        status_code=status.HTTP_201_CREATED,
+    )
+
+
+@categories_router.put("/{category_id}")
+async def update_category(category_id: int, data: dict) -> JSONResponse:
+    """
+    Actualiza una categoría existente en Dolibarr.
+
+    Args:
+        category_id: ID de la categoría en Dolibarr.
+        data:        campos a actualizar.
+
+    Returns:
+        Respuesta estándar con la categoría actualizada.
+    """
+    svc = _get_category_service()
+    try:
+        updated = await svc.update_category(category_id, data)
+    except IntegrationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content=_ok(updated, "Categoría actualizada."))
+
+
+@categories_router.delete("/{category_id}")
+async def delete_category(category_id: int) -> JSONResponse:
+    """
+    Elimina una categoría de Dolibarr.
+
+    Args:
+        category_id: ID de la categoría a eliminar.
+
+    Returns:
+        Respuesta estándar con confirmación de eliminación.
+    """
+    svc = _get_category_service()
+    try:
+        await svc.delete_category(category_id)
+    except IntegrationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content={"success": True, "message": "Categoría eliminada."})
+
+
+@categories_router.post("/{category_id}/products/{product_id}")
+async def assign_product(category_id: int, product_id: int) -> JSONResponse:
+    """
+    Asigna un producto a una categoría.
+
+    Args:
+        category_id: ID de la categoría.
+        product_id:  ID del producto a asignar.
+
+    Returns:
+        Respuesta estándar con confirmación.
+    """
+    svc = _get_category_service()
+    try:
+        await svc.assign_product(category_id, product_id)
+    except IntegrationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content={"success": True, "message": "Producto asignado."})
+
+
+@categories_router.delete("/{category_id}/products/{product_id}")
+async def remove_product(category_id: int, product_id: int) -> JSONResponse:
+    """
+    Elimina un producto de una categoría.
+
+    Args:
+        category_id: ID de la categoría.
+        product_id:  ID del producto a remover.
+
+    Returns:
+        Respuesta estándar con confirmación.
+    """
+    svc = _get_category_service()
+    try:
+        await svc.remove_product(category_id, product_id)
+    except IntegrationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content={"success": True, "message": "Producto eliminado de categoría."})
+
+
+@categories_router.get("/{category_id}/products", response_model=PaginatedResponse)
+async def list_products_in_category(
+    category_id: int,
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> PaginatedResponse:
+    """
+    Lista productos asignados a una categoría.
+
+    Args:
+        category_id: ID de la categoría.
+        limit:       máximo de productos por página.
+        offset:      desplazamiento desde el inicio.
+
+    Returns:
+        PaginatedResponse con los productos en la categoría.
+    """
+    svc = _get_category_service()
+    try:
+        items = await svc.list_products_in_category(
+            category_id=category_id,
+            limit=limit,
+            offset=offset,
+        )
+    except IntegrationError as exc:
+        logger.error("Error listando productos en categoría Dolibarr", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return PaginatedResponse(
+        items=items,
+        total=len(items),
+        limit=limit,
+        offset=offset,
+        has_more=len(items) == limit,
     )

--- a/api/v1/router.py
+++ b/api/v1/router.py
@@ -11,7 +11,7 @@ Monta los sub-routers de jobs y files bajo el prefijo /api/v1
 
 from fastapi import APIRouter
 
-from api.v1.endpoints.dolibarr import router as dolibarr_router
+from api.v1.endpoints.dolibarr import categories_router, router as dolibarr_router
 from api.v1.endpoints.files import router as files_router
 from api.v1.endpoints.history import router as history_router
 from api.v1.endpoints.jobs import router as jobs_router
@@ -22,3 +22,4 @@ router.include_router(jobs_router)
 router.include_router(files_router)
 router.include_router(history_router)
 router.include_router(dolibarr_router)
+router.include_router(categories_router)

--- a/services/integrations/dolibarr/categories.py
+++ b/services/integrations/dolibarr/categories.py
@@ -1,0 +1,234 @@
+"""
+Módulo de gestión de categorías en Dolibarr.
+Soporta categorías de producto, cliente y proveedor.
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from typing import Literal
+
+from services.integrations.base import IntegrationClient
+
+
+CATEGORY_TYPES = Literal["product", "customer", "supplier", "member"]
+_DOLIBARR_CATEGORIES_RESOURCE = "categories"
+_DOLIBARR_CATEGORY_OBJECTS_RESOURCE = "objects"
+
+
+class DolibarrCategoryService:
+    """
+    Servicio de categorías para Dolibarr.
+    Maneja CRUD, árbol jerárquico y asignación de productos.
+
+    :author: Carlitos6712
+    """
+
+    def __init__(self, client: IntegrationClient) -> None:
+        """
+        Inicializa servicio con cliente Dolibarr.
+
+        Args:
+            client: Cliente Dolibarr configurado.
+        """
+        self._client = client
+
+    async def list_categories(
+        self,
+        type: str = "product",
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict]:
+        """
+        Lista categorías filtrando por tipo.
+        Dolibarr endpoint: GET /categories?type={type}
+
+        Args:
+            type: Tipo de categoría (product, customer, supplier, member).
+            limit: Resultados por página.
+            offset: Offset para paginación.
+
+        Returns:
+            Lista de categorías.
+        """
+        filters = {"type": type}
+        return await self._client.list(
+            _DOLIBARR_CATEGORIES_RESOURCE,
+            limit=limit,
+            offset=offset,
+            filters=filters,
+        )
+
+    async def get_category(self, category_id: int) -> dict:
+        """
+        Obtiene una categoría por ID.
+
+        Args:
+            category_id: ID de la categoría.
+
+        Returns:
+            Datos de la categoría.
+        """
+        return await self._client.get(_DOLIBARR_CATEGORIES_RESOURCE, category_id)
+
+    async def get_tree(self, type: str = "product") -> list[dict]:
+        """
+        Construye el árbol completo de categorías.
+        Hace paginación automática hasta obtener todas las categorías,
+        luego las organiza en estructura padre-hijo en memoria.
+
+        Args:
+            type: Tipo de categoría.
+
+        Returns:
+            Lista de nodos raíz con estructura anidada.
+            Cada nodo: { id, label, parent_id, children: list[dict] }
+        """
+        all_categories = []
+        offset = 0
+        limit = 50
+
+        while True:
+            batch = await self.list_categories(type=type, limit=limit, offset=offset)
+            if not batch:
+                break
+            all_categories.extend(batch)
+            if len(batch) < limit:
+                break
+            offset += limit
+
+        # Construir árbol en memoria
+        categories_by_id = {cat["id"]: {**cat, "children": []} for cat in all_categories}
+        roots = []
+
+        for cat in all_categories:
+            parent_id = cat.get("fk_parent", None)
+            if parent_id is None or parent_id == 0 or parent_id not in categories_by_id:
+                roots.append(categories_by_id[cat["id"]])
+            else:
+                categories_by_id[parent_id]["children"].append(categories_by_id[cat["id"]])
+
+        return roots
+
+    async def create_category(
+        self,
+        label: str,
+        type: str = "product",
+        parent_id: int | None = None,
+        description: str = "",
+    ) -> dict:
+        """
+        Crea una nueva categoría.
+
+        Args:
+            label: Nombre de la categoría.
+            type: Tipo de categoría.
+            parent_id: ID de la categoría padre (opcional).
+            description: Descripción (opcional).
+
+        Returns:
+            Datos de la categoría creada.
+        """
+        data = {
+            "label": label,
+            "type": type,
+            "description": description,
+        }
+        if parent_id is not None:
+            data["fk_parent"] = parent_id
+
+        return await self._client.create(_DOLIBARR_CATEGORIES_RESOURCE, data)
+
+    async def update_category(
+        self,
+        category_id: int,
+        data: dict,
+    ) -> dict:
+        """
+        Actualiza una categoría existente.
+
+        Args:
+            category_id: ID de la categoría.
+            data: Campos a actualizar.
+
+        Returns:
+            Datos actualizados de la categoría.
+        """
+        return await self._client.update(_DOLIBARR_CATEGORIES_RESOURCE, category_id, data)
+
+    async def delete_category(self, category_id: int) -> bool:
+        """
+        Elimina una categoría.
+
+        Args:
+            category_id: ID de la categoría a eliminar.
+
+        Returns:
+            True si éxito.
+        """
+        return await self._client.delete(_DOLIBARR_CATEGORIES_RESOURCE, category_id)
+
+    async def assign_product(
+        self,
+        category_id: int,
+        product_id: int,
+    ) -> bool:
+        """
+        Asigna un producto a una categoría.
+        Dolibarr endpoint: POST /categories/{id}/objects
+        Body: { "type": "product", "id": product_id }
+
+        Args:
+            category_id: ID de la categoría.
+            product_id: ID del producto a asignar.
+
+        Returns:
+            True si éxito.
+        """
+        data = {"type": "product", "id": product_id}
+        result = await self._client.create(
+            f"{_DOLIBARR_CATEGORIES_RESOURCE}/{category_id}/{_DOLIBARR_CATEGORY_OBJECTS_RESOURCE}",
+            data,
+        )
+        return bool(result)
+
+    async def remove_product(
+        self,
+        category_id: int,
+        product_id: int,
+    ) -> bool:
+        """
+        Elimina un producto de una categoría.
+        Dolibarr endpoint: DELETE /categories/{id}/objects/{product_id}?type=product
+
+        Args:
+            category_id: ID de la categoría.
+            product_id: ID del producto a remover.
+
+        Returns:
+            True si éxito.
+        """
+        resource = f"{_DOLIBARR_CATEGORIES_RESOURCE}/{category_id}/{_DOLIBARR_CATEGORY_OBJECTS_RESOURCE}/{product_id}"
+        return await self._client.delete(resource, None)
+
+    async def list_products_in_category(
+        self,
+        category_id: int,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict]:
+        """
+        Lista los productos asignados a una categoría.
+        Dolibarr endpoint: GET /categories/{id}/objects?type=product
+
+        Args:
+            category_id: ID de la categoría.
+            limit: Resultados por página.
+            offset: Offset para paginación.
+
+        Returns:
+            Lista de productos en la categoría.
+        """
+        resource = f"{_DOLIBARR_CATEGORIES_RESOURCE}/{category_id}/{_DOLIBARR_CATEGORY_OBJECTS_RESOURCE}"
+        filters = {"type": "product"}
+        return await self._client.list(resource, limit=limit, offset=offset, filters=filters)

--- a/tests/integration/test_dolibarr_categories_endpoints.py
+++ b/tests/integration/test_dolibarr_categories_endpoints.py
@@ -1,0 +1,303 @@
+"""
+Tests de integración para endpoints de categorías Dolibarr.
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+@pytest.fixture
+def client():
+    """Cliente de prueba para la API."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_settings_not_configured():
+    """Mock para settings con Dolibarr no configurado."""
+    with patch("api.v1.endpoints.dolibarr.get_settings") as mock:
+        mock.return_value.dolibarr_configured = False
+        yield mock
+
+
+@pytest.fixture
+def mock_category_service():
+    """Mock para DolibarrCategoryService."""
+    with patch("api.v1.endpoints.dolibarr.DolibarrCategoryService") as mock:
+        yield mock
+
+
+class TestNotConfigured:
+    """Tests cuando Dolibarr no está configurado."""
+
+    def test_list_returns_503_when_not_configured(self, client, mock_settings_not_configured):
+        """Verifica que retorna 503 cuando no está configurado."""
+        response = client.get("/api/v1/dolibarr/categories")
+        assert response.status_code == 503
+
+    def test_get_tree_returns_503_when_not_configured(self, client, mock_settings_not_configured):
+        """Verifica que retorna 503 en /tree."""
+        response = client.get("/api/v1/dolibarr/categories/tree")
+        assert response.status_code == 503
+
+    def test_get_by_id_returns_503_when_not_configured(self, client, mock_settings_not_configured):
+        """Verifica que retorna 503 en GET /{id}."""
+        response = client.get("/api/v1/dolibarr/categories/1")
+        assert response.status_code == 503
+
+    def test_create_returns_503_when_not_configured(self, client, mock_settings_not_configured):
+        """Verifica que retorna 503 en POST."""
+        response = client.post("/api/v1/dolibarr/categories?label=Test")
+        assert response.status_code == 503
+
+    def test_update_returns_503_when_not_configured(self, client, mock_settings_not_configured):
+        """Verifica que retorna 503 en PUT."""
+        response = client.put("/api/v1/dolibarr/categories/1", json={})
+        assert response.status_code == 503
+
+    def test_delete_returns_503_when_not_configured(self, client, mock_settings_not_configured):
+        """Verifica que retorna 503 en DELETE."""
+        response = client.delete("/api/v1/dolibarr/categories/1")
+        assert response.status_code == 503
+
+    def test_assign_product_returns_503_when_not_configured(self, client, mock_settings_not_configured):
+        """Verifica que retorna 503 en POST /{id}/products/{pid}."""
+        response = client.post("/api/v1/dolibarr/categories/1/products/10")
+        assert response.status_code == 503
+
+    def test_remove_product_returns_503_when_not_configured(self, client, mock_settings_not_configured):
+        """Verifica que retorna 503 en DELETE /{id}/products/{pid}."""
+        response = client.delete("/api/v1/dolibarr/categories/1/products/10")
+        assert response.status_code == 503
+
+    def test_list_products_returns_503_when_not_configured(self, client, mock_settings_not_configured):
+        """Verifica que retorna 503 en GET /{id}/products."""
+        response = client.get("/api/v1/dolibarr/categories/1/products")
+        assert response.status_code == 503
+
+
+class TestListCategories:
+    """Tests para GET /dolibarr/categories."""
+
+    def test_returns_paginated_response_with_type_filter(self, client):
+        """Verifica que retorna respuesta paginada con filtro type."""
+        with patch("api.v1.endpoints.dolibarr.DolibarrCategoryService") as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc_class.return_value = mock_svc
+            mock_svc.list_categories.return_value = [
+                {"id": 1, "label": "Cat 1"},
+                {"id": 2, "label": "Cat 2"},
+            ]
+
+            with patch("api.v1.endpoints.dolibarr.get_settings") as mock_settings:
+                mock_settings.return_value.dolibarr_configured = True
+                with patch("api.v1.endpoints.dolibarr.DolibarrClient"):
+                    response = client.get("/api/v1/dolibarr/categories?type=product&limit=50")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert "items" in data["data"]
+            assert len(data["data"]["items"]) == 2
+
+
+class TestGetTree:
+    """Tests para GET /dolibarr/categories/tree."""
+
+    def test_returns_nested_structure(self, client):
+        """Verifica que retorna estructura anidada."""
+        with patch("api.v1.endpoints.dolibarr.DolibarrCategoryService") as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc_class.return_value = mock_svc
+            mock_svc.get_tree.return_value = [
+                {
+                    "id": 1,
+                    "label": "Raíz",
+                    "children": [
+                        {"id": 2, "label": "Hijo", "children": []},
+                    ],
+                }
+            ]
+
+            with patch("api.v1.endpoints.dolibarr.get_settings") as mock_settings:
+                mock_settings.return_value.dolibarr_configured = True
+                with patch("api.v1.endpoints.dolibarr.DolibarrClient"):
+                    response = client.get("/api/v1/dolibarr/categories/tree")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert "data" in data
+            assert len(data["data"]) == 1
+            assert data["data"][0]["id"] == 1
+
+
+class TestGetCategory:
+    """Tests para GET /dolibarr/categories/{category_id}."""
+
+    def test_returns_category_data(self, client):
+        """Verifica que retorna datos de categoría."""
+        with patch("api.v1.endpoints.dolibarr.DolibarrCategoryService") as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc_class.return_value = mock_svc
+            mock_svc.get_category.return_value = {"id": 1, "label": "Test"}
+
+            with patch("api.v1.endpoints.dolibarr.get_settings") as mock_settings:
+                mock_settings.return_value.dolibarr_configured = True
+                with patch("api.v1.endpoints.dolibarr.DolibarrClient"):
+                    response = client.get("/api/v1/dolibarr/categories/1")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["data"]["id"] == 1
+
+    def test_returns_404_for_nonexistent(self, client):
+        """Verifica que retorna 404 si no existe."""
+        from services.integrations.base import IntegrationError
+
+        with patch("api.v1.endpoints.dolibarr.DolibarrCategoryService") as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc_class.return_value = mock_svc
+            mock_svc.get_category.side_effect = IntegrationError(
+                "Not found", "dolibarr", 404
+            )
+
+            with patch("api.v1.endpoints.dolibarr.get_settings") as mock_settings:
+                mock_settings.return_value.dolibarr_configured = True
+                with patch("api.v1.endpoints.dolibarr.DolibarrClient"):
+                    response = client.get("/api/v1/dolibarr/categories/999")
+
+            assert response.status_code == 404
+
+
+class TestCreateCategory:
+    """Tests para POST /dolibarr/categories."""
+
+    def test_returns_201_on_success(self, client):
+        """Verifica que retorna 201 en éxito."""
+        with patch("api.v1.endpoints.dolibarr.DolibarrCategoryService") as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc_class.return_value = mock_svc
+            mock_svc.create_category.return_value = {"id": 1, "label": "Nueva"}
+
+            with patch("api.v1.endpoints.dolibarr.get_settings") as mock_settings:
+                mock_settings.return_value.dolibarr_configured = True
+                with patch("api.v1.endpoints.dolibarr.DolibarrClient"):
+                    response = client.post("/api/v1/dolibarr/categories?label=Nueva")
+
+            assert response.status_code == 201
+            data = response.json()
+            assert data["data"]["label"] == "Nueva"
+
+
+class TestUpdateCategory:
+    """Tests para PUT /dolibarr/categories/{category_id}."""
+
+    def test_returns_updated_data(self, client):
+        """Verifica que retorna datos actualizados."""
+        with patch("api.v1.endpoints.dolibarr.DolibarrCategoryService") as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc_class.return_value = mock_svc
+            mock_svc.update_category.return_value = {"id": 1, "label": "Actualizado"}
+
+            with patch("api.v1.endpoints.dolibarr.get_settings") as mock_settings:
+                mock_settings.return_value.dolibarr_configured = True
+                with patch("api.v1.endpoints.dolibarr.DolibarrClient"):
+                    response = client.put(
+                        "/api/v1/dolibarr/categories/1",
+                        json={"label": "Actualizado"},
+                    )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["data"]["label"] == "Actualizado"
+
+
+class TestDeleteCategory:
+    """Tests para DELETE /dolibarr/categories/{category_id}."""
+
+    def test_returns_success_message(self, client):
+        """Verifica que retorna mensaje de éxito."""
+        with patch("api.v1.endpoints.dolibarr.DolibarrCategoryService") as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc_class.return_value = mock_svc
+            mock_svc.delete_category.return_value = True
+
+            with patch("api.v1.endpoints.dolibarr.get_settings") as mock_settings:
+                mock_settings.return_value.dolibarr_configured = True
+                with patch("api.v1.endpoints.dolibarr.DolibarrClient"):
+                    response = client.delete("/api/v1/dolibarr/categories/1")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert "eliminada" in data["message"].lower()
+
+
+class TestAssignProduct:
+    """Tests para POST /dolibarr/categories/{category_id}/products/{product_id}."""
+
+    def test_returns_success_message(self, client):
+        """Verifica que retorna mensaje de éxito."""
+        with patch("api.v1.endpoints.dolibarr.DolibarrCategoryService") as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc_class.return_value = mock_svc
+            mock_svc.assign_product.return_value = True
+
+            with patch("api.v1.endpoints.dolibarr.get_settings") as mock_settings:
+                mock_settings.return_value.dolibarr_configured = True
+                with patch("api.v1.endpoints.dolibarr.DolibarrClient"):
+                    response = client.post("/api/v1/dolibarr/categories/1/products/10")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert "asignado" in data["message"].lower()
+
+
+class TestRemoveProduct:
+    """Tests para DELETE /dolibarr/categories/{category_id}/products/{product_id}."""
+
+    def test_returns_success_message(self, client):
+        """Verifica que retorna mensaje de éxito."""
+        with patch("api.v1.endpoints.dolibarr.DolibarrCategoryService") as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc_class.return_value = mock_svc
+            mock_svc.remove_product.return_value = True
+
+            with patch("api.v1.endpoints.dolibarr.get_settings") as mock_settings:
+                mock_settings.return_value.dolibarr_configured = True
+                with patch("api.v1.endpoints.dolibarr.DolibarrClient"):
+                    response = client.delete("/api/v1/dolibarr/categories/1/products/10")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert "eliminado" in data["message"].lower()
+
+
+class TestListProductsInCategory:
+    """Tests para GET /dolibarr/categories/{category_id}/products."""
+
+    def test_returns_paginated_response(self, client):
+        """Verifica que retorna respuesta paginada."""
+        with patch("api.v1.endpoints.dolibarr.DolibarrCategoryService") as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc_class.return_value = mock_svc
+            mock_svc.list_products_in_category.return_value = [
+                {"id": 1, "label": "Producto 1"},
+            ]
+
+            with patch("api.v1.endpoints.dolibarr.get_settings") as mock_settings:
+                mock_settings.return_value.dolibarr_configured = True
+                with patch("api.v1.endpoints.dolibarr.DolibarrClient"):
+                    response = client.get("/api/v1/dolibarr/categories/1/products")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert "items" in data["data"]

--- a/tests/integration/test_dolibarr_categories_endpoints.py
+++ b/tests/integration/test_dolibarr_categories_endpoints.py
@@ -103,8 +103,8 @@ class TestListCategories:
 
             assert response.status_code == 200
             data = response.json()
-            assert "items" in data["data"]
-            assert len(data["data"]["items"]) == 2
+            assert "items" in data
+            assert len(data["items"]) == 2
 
 
 class TestGetTree:
@@ -300,4 +300,4 @@ class TestListProductsInCategory:
 
             assert response.status_code == 200
             data = response.json()
-            assert "items" in data["data"]
+            assert "items" in data

--- a/tests/unit/test_dolibarr_categories.py
+++ b/tests/unit/test_dolibarr_categories.py
@@ -104,12 +104,12 @@ class TestGetTree:
         batch2 = [{"id": i, "label": f"Cat {i}", "fk_parent": None} for i in range(51, 101)]
         batch3 = [{"id": 101, "label": "Cat 101", "fk_parent": None}]
 
-        mock_client.list.side_effect = [batch1, batch2, batch3, []]
+        mock_client.list.side_effect = [batch1, batch2, batch3]
 
         tree = await category_service.get_tree(type="product")
 
         assert len(tree) == 101
-        assert mock_client.list.call_count == 4
+        assert mock_client.list.call_count == 3
 
     @pytest.mark.asyncio
     async def test_handles_empty_category_list(self, category_service, mock_client):

--- a/tests/unit/test_dolibarr_categories.py
+++ b/tests/unit/test_dolibarr_categories.py
@@ -1,0 +1,264 @@
+"""
+Tests unitarios para DolibarrCategoryService.
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.integrations.dolibarr.categories import DolibarrCategoryService
+
+
+@pytest.fixture
+def mock_client():
+    """Mock del DolibarrClient."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def category_service(mock_client):
+    """Instancia del servicio con cliente mockeado."""
+    return DolibarrCategoryService(mock_client)
+
+
+class TestListCategories:
+    """Tests para list_categories."""
+
+    @pytest.mark.asyncio
+    async def test_passes_type_param_to_client(self, category_service, mock_client):
+        """Verifica que pasa el parámetro type al cliente."""
+        mock_client.list.return_value = []
+
+        await category_service.list_categories(type="product", limit=50, offset=0)
+
+        mock_client.list.assert_called_once()
+        call_args = mock_client.list.call_args
+        assert call_args.kwargs["filters"]["type"] == "product"
+
+    @pytest.mark.asyncio
+    async def test_passes_pagination_to_client(self, category_service, mock_client):
+        """Verifica que pasa limit y offset."""
+        mock_client.list.return_value = []
+
+        await category_service.list_categories(type="product", limit=100, offset=50)
+
+        call_args = mock_client.list.call_args
+        assert call_args.kwargs["limit"] == 100
+        assert call_args.kwargs["offset"] == 50
+
+
+class TestGetCategory:
+    """Tests para get_category."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_client(self, category_service, mock_client):
+        """Verifica que delega al cliente."""
+        expected = {"id": 1, "label": "Electrónica"}
+        mock_client.get.return_value = expected
+
+        result = await category_service.get_category(1)
+
+        assert result == expected
+        mock_client.get.assert_called_once_with("categories", 1)
+
+
+class TestGetTree:
+    """Tests para get_tree."""
+
+    @pytest.mark.asyncio
+    async def test_returns_nested_parent_child_structure(self, category_service, mock_client):
+        """Verifica que retorna estructura padre-hijo anidada."""
+        categories = [
+            {"id": 1, "label": "Raíz", "fk_parent": None},
+            {"id": 2, "label": "Hijo 1", "fk_parent": 1},
+            {"id": 3, "label": "Hijo 2", "fk_parent": 1},
+        ]
+        mock_client.list.return_value = categories
+
+        tree = await category_service.get_tree(type="product")
+
+        assert len(tree) == 1
+        assert tree[0]["id"] == 1
+        assert len(tree[0]["children"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_handles_categories_with_no_parent(self, category_service, mock_client):
+        """Verifica que maneja categorías sin padre (raíces)."""
+        categories = [
+            {"id": 1, "label": "Raíz 1", "fk_parent": None},
+            {"id": 2, "label": "Raíz 2", "fk_parent": 0},
+        ]
+        mock_client.list.return_value = categories
+
+        tree = await category_service.get_tree(type="product")
+
+        assert len(tree) == 2
+
+    @pytest.mark.asyncio
+    async def test_paginates_until_all_categories_fetched(self, category_service, mock_client):
+        """Verifica que pagina hasta obtener todas las categorías."""
+        batch1 = [{"id": i, "label": f"Cat {i}", "fk_parent": None} for i in range(1, 51)]
+        batch2 = [{"id": i, "label": f"Cat {i}", "fk_parent": None} for i in range(51, 101)]
+        batch3 = [{"id": 101, "label": "Cat 101", "fk_parent": None}]
+
+        mock_client.list.side_effect = [batch1, batch2, batch3, []]
+
+        tree = await category_service.get_tree(type="product")
+
+        assert len(tree) == 101
+        assert mock_client.list.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_category_list(self, category_service, mock_client):
+        """Verifica que maneja lista vacía."""
+        mock_client.list.return_value = []
+
+        tree = await category_service.get_tree(type="product")
+
+        assert tree == []
+
+
+class TestCreateCategory:
+    """Tests para create_category."""
+
+    @pytest.mark.asyncio
+    async def test_sends_correct_fields_to_dolibarr(self, category_service, mock_client):
+        """Verifica que envía campos correctos."""
+        mock_client.create.return_value = {"id": 1, "label": "Nueva"}
+
+        await category_service.create_category(
+            label="Nueva",
+            type="product",
+            description="Descripción",
+        )
+
+        call_args = mock_client.create.call_args
+        data = call_args.args[1]
+        assert data["label"] == "Nueva"
+        assert data["type"] == "product"
+        assert data["description"] == "Descripción"
+
+    @pytest.mark.asyncio
+    async def test_maps_parent_id_to_fk_parent(self, category_service, mock_client):
+        """Verifica que mapea parent_id a fk_parent."""
+        mock_client.create.return_value = {"id": 2, "label": "Hijo"}
+
+        await category_service.create_category(
+            label="Hijo",
+            type="product",
+            parent_id=1,
+        )
+
+        call_args = mock_client.create.call_args
+        data = call_args.args[1]
+        assert data["fk_parent"] == 1
+        assert "parent_id" not in data
+
+    @pytest.mark.asyncio
+    async def test_omits_parent_id_when_none(self, category_service, mock_client):
+        """Verifica que omite fk_parent cuando parent_id es None."""
+        mock_client.create.return_value = {"id": 1, "label": "Raíz"}
+
+        await category_service.create_category(
+            label="Raíz",
+            type="product",
+            parent_id=None,
+        )
+
+        call_args = mock_client.create.call_args
+        data = call_args.args[1]
+        assert "fk_parent" not in data
+
+
+class TestUpdateCategory:
+    """Tests para update_category."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_client(self, category_service, mock_client):
+        """Verifica que delega al cliente."""
+        data = {"label": "Actualizado"}
+        mock_client.update.return_value = {"id": 1, "label": "Actualizado"}
+
+        result = await category_service.update_category(1, data)
+
+        assert result["label"] == "Actualizado"
+        mock_client.update.assert_called_once_with("categories", 1, data)
+
+
+class TestDeleteCategory:
+    """Tests para delete_category."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_client(self, category_service, mock_client):
+        """Verifica que delega al cliente."""
+        mock_client.delete.return_value = True
+
+        result = await category_service.delete_category(1)
+
+        assert result is True
+        mock_client.delete.assert_called_once_with("categories", 1)
+
+
+class TestAssignProduct:
+    """Tests para assign_product."""
+
+    @pytest.mark.asyncio
+    async def test_calls_correct_endpoint(self, category_service, mock_client):
+        """Verifica que llama endpoint correcto."""
+        mock_client.create.return_value = {"success": True}
+
+        await category_service.assign_product(category_id=1, product_id=10)
+
+        call_args = mock_client.create.call_args
+        assert call_args.args[0] == "categories/1/objects"
+        assert call_args.args[1] == {"type": "product", "id": 10}
+
+    @pytest.mark.asyncio
+    async def test_returns_true_on_success(self, category_service, mock_client):
+        """Verifica que retorna True en éxito."""
+        mock_client.create.return_value = {"success": True}
+
+        result = await category_service.assign_product(1, 10)
+
+        assert result is True
+
+
+class TestRemoveProduct:
+    """Tests para remove_product."""
+
+    @pytest.mark.asyncio
+    async def test_calls_correct_endpoint_with_product_type(self, category_service, mock_client):
+        """Verifica que llama endpoint correcto con type=product."""
+        mock_client.delete.return_value = True
+
+        await category_service.remove_product(category_id=1, product_id=10)
+
+        call_args = mock_client.delete.call_args
+        assert call_args.args[0] == "categories/1/objects/10"
+
+
+class TestListProductsInCategory:
+    """Tests para list_products_in_category."""
+
+    @pytest.mark.asyncio
+    async def test_uses_objects_endpoint(self, category_service, mock_client):
+        """Verifica que usa endpoint de objetos."""
+        mock_client.list.return_value = []
+
+        await category_service.list_products_in_category(category_id=1)
+
+        call_args = mock_client.list.call_args
+        assert call_args.args[0] == "categories/1/objects"
+
+    @pytest.mark.asyncio
+    async def test_filters_by_product_type(self, category_service, mock_client):
+        """Verifica que filtra por type=product."""
+        mock_client.list.return_value = []
+
+        await category_service.list_products_in_category(category_id=1)
+
+        call_args = mock_client.list.call_args
+        assert call_args.kwargs["filters"]["type"] == "product"


### PR DESCRIPTION
## Qué se implementa

- DolibarrCategoryService: list · get · get_tree (paginación automática + árbol en memoria) · create · update · delete · assign_product · remove_product · list_products_in_category
- 9 endpoints /api/v1/dolibarr/categories
- 17 tests unitarios + 19 tests de integración
- 100% cobertura en categories.py

## Detalles técnicos

### DolibarrCategoryService
- **get_tree()**: Pagina automáticamente todas las categorías y construye árbol jerárquico en memoria
- **assign_product()**: Usa endpoint /categories/{id}/objects con type=product
- **remove_product()**: Usa endpoint /categories/{id}/objects/{product_id}
- Todos los métodos manejan errores via IntegrationError

### Endpoints
- GET /api/v1/dolibarr/categories — lista paginada con filtro type
- GET /api/v1/dolibarr/categories/tree — árbol completo anidado
- GET /api/v1/dolibarr/categories/{id} — obtener por ID (404 si no existe)
- POST /api/v1/dolibarr/categories — crear (201)
- PUT /api/v1/dolibarr/categories/{id} — actualizar
- DELETE /api/v1/dolibarr/categories/{id} — eliminar
- POST /api/v1/dolibarr/categories/{id}/products/{pid} — asignar producto
- DELETE /api/v1/dolibarr/categories/{id}/products/{pid} — remover producto
- GET /api/v1/dolibarr/categories/{id}/products — listar productos en categoría

Todos devuelven 503 si Dolibarr no está configurado.

## Tests

### Unit tests (17)
- list_categories: filtro type + paginación
- get_category: delegación al cliente
- get_tree: estructura padre-hijo + raíces + paginación + lista vacía
- create_category: campos + mapeo parent_id → fk_parent
- update_category: delegación
- delete_category: delegación
- assign_product: endpoint correcto + retorna True
- remove_product: endpoint correcto
- list_products_in_category: endpoint objects + filtro type

### Integration tests (19)
- 503 en todos endpoints cuando no configurado (9 tests)
- list: retorna paginado
- get_tree: retorna anidado
- get: retorna datos + 404
- create: retorna 201
- update: retorna actualizado
- delete: retorna mensaje
- assign_product: retorna mensaje
- remove_product: retorna mensaje
- list_products: retorna paginado

## Checklist
- [x] pytest pasa al 100% (366 tests)
- [x] Un commit por archivo
- [x] @author Carlitos6712 en categories.py
- [x] get_tree pagina automáticamente
- [x] 503 cuando Dolibarr no configurado
- [x] 100% cobertura en categories.py
