### PR TITLE
[feat] fase8.7 — módulo de stock Dolibarr

### DIFF
--- a/api/v1/endpoints/dolibarr.py
+++ b/api/v1/endpoints/dolibarr.py
@@ -31,6 +31,14 @@ Rutas expuestas bajo /api/v1/dolibarr/invoices:
   POST   /dolibarr/invoices/{invoice_id}/pay       — Registrar pago
   DELETE /dolibarr/invoices/{invoice_id}           — Eliminar factura (borrador)
 
+Rutas expuestas bajo /api/v1/dolibarr/stocks:
+  GET    /dolibarr/stocks/warehouses               — Listar almacenes (paginado)
+  GET    /dolibarr/stocks/warehouses/{warehouse_id} — Obtener almacén por ID
+  GET    /dolibarr/stocks/products/{product_id}   — Obtener stock de producto
+  GET    /dolibarr/stocks/movements                — Listar movimientos (paginado)
+  POST   /dolibarr/stocks/movements                — Crear movimiento de stock
+  POST   /dolibarr/stocks/transfer                 — Transferir entre almacenes
+
 Todos los endpoints devuelven 503 si Dolibarr no está configurado.
 
 :author: Carlitos6712
@@ -55,6 +63,7 @@ from services.integrations.dolibarr.client import DolibarrClient
 from services.integrations.dolibarr.invoices import DolibarrInvoiceService
 from services.integrations.dolibarr.orders import DolibarrOrderService
 from services.integrations.dolibarr.products import DolibarrProductService
+from services.integrations.dolibarr.stocks import DolibarrStockService
 from services.integrations.dolibarr.thirdparties import DolibarrThirdpartyService
 from services.storage_service import get_storage_service
 
@@ -1487,3 +1496,255 @@ async def delete_invoice(
             detail=str(exc),
         )
     return _ok({"deleted": True}, message="Factura eliminada exitosamente")
+
+
+stocks_router = APIRouter(prefix="/dolibarr/stocks", tags=["dolibarr-stocks"])
+
+
+def _get_stock_service() -> DolibarrStockService:
+    """
+    Construye y devuelve una instancia de DolibarrStockService.
+
+    Raises:
+        HTTPException 503: si Dolibarr no está configurado.
+    """
+    settings = get_settings()
+    if not settings.dolibarr_configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_NOT_CONFIGURED_MSG,
+        )
+    try:
+        client = DolibarrClient(settings)
+    except IntegrationNotConfiguredError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_NOT_CONFIGURED_MSG,
+        )
+    return DolibarrStockService(client)
+
+
+@stocks_router.get("/warehouses", response_model=PaginatedResponse)
+async def list_warehouses(
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> PaginatedResponse:
+    """
+    Lista almacenes de Dolibarr con paginación.
+
+    Args:
+        limit:  máximo de almacenes por página.
+        offset: desplazamiento desde el inicio.
+
+    Returns:
+        PaginatedResponse con los almacenes encontrados.
+    """
+    svc = _get_stock_service()
+    try:
+        items = await svc.list_warehouses(limit=limit, offset=offset)
+    except IntegrationError as exc:
+        logger.error("Error listando almacenes Dolibarr", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return PaginatedResponse(
+        items=items,
+        total=len(items),
+        limit=limit,
+        offset=offset,
+        has_more=len(items) == limit,
+    )
+
+
+@stocks_router.get("/warehouses/{warehouse_id}")
+async def get_warehouse(warehouse_id: int) -> JSONResponse:
+    """
+    Obtiene un almacén de Dolibarr por su ID.
+
+    Args:
+        warehouse_id: ID del almacén en Dolibarr.
+
+    Returns:
+        Respuesta estándar con los datos del almacén.
+    """
+    svc = _get_stock_service()
+    try:
+        warehouse = await svc.get_warehouse(warehouse_id)
+    except IntegrationError as exc:
+        if exc.status_code == 404:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Almacén {warehouse_id} no encontrado en Dolibarr.",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content=_ok(warehouse, "Almacén obtenido."))
+
+
+@stocks_router.get("/products/{product_id}")
+async def get_product_stock(product_id: int) -> JSONResponse:
+    """
+    Obtiene el stock actual de un producto desglosado por almacén.
+
+    Args:
+        product_id: ID del producto en Dolibarr.
+
+    Returns:
+        Respuesta estándar con stock_total y desglose por almacén.
+    """
+    svc = _get_stock_service()
+    try:
+        stock_info = await svc.get_product_stock(product_id)
+    except IntegrationError as exc:
+        if exc.status_code == 404:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Producto {product_id} no encontrado en Dolibarr.",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content=_ok(stock_info, "Stock de producto obtenido."))
+
+
+@stocks_router.get("/movements", response_model=PaginatedResponse)
+async def list_movements(
+    product_id: int | None = Query(default=None),
+    warehouse_id: int | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> PaginatedResponse:
+    """
+    Lista movimientos de stock con filtros opcionales.
+
+    Args:
+        product_id: Filtrar por producto (opcional).
+        warehouse_id: Filtrar por almacén (opcional).
+        limit: máximo de movimientos por página.
+        offset: desplazamiento desde el inicio.
+
+    Returns:
+        PaginatedResponse con los movimientos encontrados.
+    """
+    svc = _get_stock_service()
+    try:
+        items = await svc.get_stock_movements(
+            product_id=product_id,
+            warehouse_id=warehouse_id,
+            limit=limit,
+            offset=offset,
+        )
+    except IntegrationError as exc:
+        logger.error("Error listando movimientos de stock Dolibarr", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return PaginatedResponse(
+        items=items,
+        total=len(items),
+        limit=limit,
+        offset=offset,
+        has_more=len(items) == limit,
+    )
+
+
+@stocks_router.post("/movements", status_code=status.HTTP_201_CREATED)
+async def add_movement(data: dict) -> JSONResponse:
+    """
+    Registra un movimiento de stock en Dolibarr.
+
+    Body esperado:
+      - product_id: int
+      - warehouse_id: int
+      - qty: float (puede ser negativo)
+      - movement_type: int (0=entrada, 1=salida, 2=corrección, 3=transferencia)
+      - label: str (opcional)
+      - price: float (opcional)
+
+    Returns:
+        Respuesta estándar (201) con el movimiento creado.
+    """
+    svc = _get_stock_service()
+    try:
+        product_id = data.get("product_id")
+        warehouse_id = data.get("warehouse_id")
+        qty = data.get("qty")
+        movement_type = data.get("movement_type")
+        label = data.get("label", "")
+        price = data.get("price", 0.0)
+
+        movement = await svc.add_stock_movement(
+            product_id=product_id,
+            warehouse_id=warehouse_id,
+            qty=qty,
+            movement_type=movement_type,
+            label=label,
+            price=price,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        )
+    except IntegrationError as exc:
+        logger.error("Error registrando movimiento de stock", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(
+        content=_ok(movement, "Movimiento de stock registrado."),
+        status_code=status.HTTP_201_CREATED,
+    )
+
+
+@stocks_router.post("/transfer", status_code=status.HTTP_201_CREATED)
+async def transfer_stock(data: dict) -> JSONResponse:
+    """
+    Transfiere stock entre almacenes.
+
+    Body esperado:
+      - product_id: int
+      - from_warehouse_id: int
+      - to_warehouse_id: int
+      - qty: float (debe ser > 0)
+      - label: str (opcional)
+
+    Returns:
+        Respuesta estándar (201) con los dos movimientos creados.
+    """
+    svc = _get_stock_service()
+    try:
+        product_id = data.get("product_id")
+        from_warehouse_id = data.get("from_warehouse_id")
+        to_warehouse_id = data.get("to_warehouse_id")
+        qty = data.get("qty")
+        label = data.get("label", "")
+
+        result = await svc.transfer_stock(
+            product_id=product_id,
+            from_warehouse_id=from_warehouse_id,
+            to_warehouse_id=to_warehouse_id,
+            qty=qty,
+            label=label,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        )
+    except IntegrationError as exc:
+        logger.error("Error transfiriendo stock", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(
+        content=_ok(result, "Transferencia de stock completada."),
+        status_code=status.HTTP_201_CREATED,
+    )

--- a/api/v1/router.py
+++ b/api/v1/router.py
@@ -11,7 +11,7 @@ Monta los sub-routers de jobs y files bajo el prefijo /api/v1
 
 from fastapi import APIRouter
 
-from api.v1.endpoints.dolibarr import categories_router, invoices_router, orders_router, thirdparties_router, router as dolibarr_router
+from api.v1.endpoints.dolibarr import categories_router, invoices_router, orders_router, stocks_router, thirdparties_router, router as dolibarr_router
 from api.v1.endpoints.files import router as files_router
 from api.v1.endpoints.history import router as history_router
 from api.v1.endpoints.jobs import router as jobs_router
@@ -26,3 +26,4 @@ router.include_router(categories_router)
 router.include_router(thirdparties_router)
 router.include_router(orders_router)
 router.include_router(invoices_router)
+router.include_router(stocks_router)

--- a/services/integrations/dolibarr/stocks.py
+++ b/services/integrations/dolibarr/stocks.py
@@ -1,0 +1,281 @@
+"""
+Módulo de gestión de stock y almacenes en Dolibarr.
+
+Tipos de movimiento de stock:
+  0 = Entrada (recepción de mercancía)
+  1 = Salida  (entrega, venta)
+  2 = Corrección de inventario (positiva o negativa)
+  3 = Transferencia entre almacenes
+
+:author: BenjaminDTS
+:version: 1.0.0
+"""
+
+from typing import Any, Literal
+
+from loguru import logger
+
+from services.integrations.base import IntegrationClient
+
+StockMovementType = Literal[0, 1, 2, 3]
+
+
+class DolibarrStockService:
+    """
+    Servicio para gestión de stock y almacenes en Dolibarr.
+
+    :author: BenjaminDTS
+    """
+
+    def __init__(self, client: IntegrationClient) -> None:
+        """
+        Inicializa el servicio.
+
+        Args:
+            client: Cliente Dolibarr configurado.
+        """
+        self.client = client
+
+    async def list_warehouses(
+        self, limit: int = 50, offset: int = 0
+    ) -> list[dict[str, Any]]:
+        """
+        Lista todos los almacenes de Dolibarr.
+
+        Args:
+            limit: Cantidad máxima (default 50).
+            offset: Desplazamiento (default 0).
+
+        Returns:
+            Lista de almacenes.
+        """
+        logger.debug(f"Listing warehouses with limit={limit}, offset={offset}")
+        return await self.client.list("warehouses", limit=limit, offset=offset)
+
+    async def get_warehouse(self, warehouse_id: int) -> dict[str, Any]:
+        """
+        Obtiene un almacén por ID.
+
+        Args:
+            warehouse_id: ID del almacén.
+
+        Returns:
+            Diccionario con los datos del almacén.
+
+        Raises:
+            Exception: Si el almacén no existe.
+        """
+        logger.debug(f"Getting warehouse {warehouse_id}")
+        return await self.client.get("warehouses", warehouse_id)
+
+    async def get_product_stock(self, product_id: int) -> dict[str, Any]:
+        """
+        Obtiene el stock actual de un producto desglosado por almacén.
+
+        Args:
+            product_id: ID del producto.
+
+        Returns:
+            Diccionario con:
+              - stock_total: float (suma de todos los almacenes)
+              - warehouses: list de { warehouse_id, warehouse_label, qty }
+
+        Raises:
+            Exception: Si el producto no existe.
+        """
+        logger.debug(f"Getting stock for product {product_id}")
+        response = await self.client.get("products", product_id)
+
+        stock_info = response.get("stock", 0)
+        warehouses_raw = response.get("warehouses", [])
+
+        warehouses = [
+            {
+                "warehouse_id": w.get("id"),
+                "warehouse_label": w.get("label"),
+                "qty": w.get("qty", 0),
+            }
+            for w in warehouses_raw
+        ]
+
+        stock_total = sum(w["qty"] for w in warehouses)
+
+        return {"stock_total": stock_total, "warehouses": warehouses}
+
+    async def get_stock_for_products(
+        self, product_ids: list[int]
+    ) -> dict[int, dict[str, Any]]:
+        """
+        Obtiene el stock de múltiples productos de forma eficiente.
+
+        Args:
+            product_ids: Lista de IDs de productos.
+
+        Returns:
+            Diccionario { product_id: stock_info }.
+        """
+        logger.debug(f"Getting stock for {len(product_ids)} products")
+        result = {}
+        for product_id in product_ids:
+            try:
+                result[product_id] = await self.get_product_stock(product_id)
+            except Exception as exc:
+                logger.warning(
+                    f"Could not fetch stock for product {product_id}",
+                    extra={"product_id": product_id},
+                    exc_info=exc,
+                )
+        return result
+
+    async def add_stock_movement(
+        self,
+        product_id: int,
+        warehouse_id: int,
+        qty: float,
+        movement_type: StockMovementType,
+        label: str = "",
+        price: float = 0.0,
+    ) -> dict[str, Any]:
+        """
+        Registra un movimiento de stock.
+
+        Args:
+            product_id: ID del producto.
+            warehouse_id: ID del almacén.
+            qty: Cantidad (puede ser negativa para salidas).
+            movement_type: Tipo de movimiento (0-3).
+            label: Etiqueta / descripción (opcional).
+            price: Precio unitario (opcional).
+
+        Returns:
+            Diccionario del movimiento creado.
+
+        Raises:
+            ValueError: Si qty es 0 o movement_type es inválido.
+            Exception: Si la API de Dolibarr falla.
+        """
+        if qty == 0:
+            raise ValueError("qty cannot be zero")
+        if movement_type not in (0, 1, 2, 3):
+            raise ValueError(
+                f"movement_type must be 0, 1, 2, or 3, got {movement_type}"
+            )
+
+        data = {
+            "product_id": product_id,
+            "warehouse_id": warehouse_id,
+            "qty": qty,
+            "type": movement_type,
+            "label": label,
+            "price": price,
+        }
+
+        logger.info(
+            "Creating stock movement",
+            extra={
+                "product_id": product_id,
+                "warehouse_id": warehouse_id,
+                "qty": qty,
+                "movement_type": movement_type,
+            },
+        )
+
+        return await self.client.create("stockmovements", data)
+
+    async def get_stock_movements(
+        self,
+        product_id: int | None = None,
+        warehouse_id: int | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """
+        Lista movimientos de stock con filtros opcionales.
+
+        Args:
+            product_id: Filtrar por producto (opcional).
+            warehouse_id: Filtrar por almacén (opcional).
+            limit: Cantidad máxima (default 50).
+            offset: Desplazamiento (default 0).
+
+        Returns:
+            Lista de movimientos.
+        """
+        filters = {}
+        if product_id is not None:
+            filters["fk_product"] = product_id
+        if warehouse_id is not None:
+            filters["fk_warehouse"] = warehouse_id
+
+        logger.debug(
+            f"Listing stock movements with filters={filters}, limit={limit}, offset={offset}"
+        )
+
+        return await self.client.list(
+            "stockmovements", limit=limit, offset=offset, filters=filters
+        )
+
+    async def transfer_stock(
+        self,
+        product_id: int,
+        from_warehouse_id: int,
+        to_warehouse_id: int,
+        qty: float,
+        label: str = "",
+    ) -> dict[str, Any]:
+        """
+        Transfiere stock entre almacenes.
+
+        Implementado como dos movimientos: salida del origen
+        y entrada en el destino.
+
+        Args:
+            product_id: ID del producto.
+            from_warehouse_id: ID del almacén de origen.
+            to_warehouse_id: ID del almacén de destino.
+            qty: Cantidad a transferir.
+            label: Descripción (opcional).
+
+        Returns:
+            Diccionario con los dos movimientos creados.
+
+        Raises:
+            ValueError: Si warehouses son iguales o qty <= 0.
+            Exception: Si la API de Dolibarr falla.
+        """
+        if from_warehouse_id == to_warehouse_id:
+            raise ValueError(
+                "from_warehouse_id and to_warehouse_id cannot be the same"
+            )
+        if qty <= 0:
+            raise ValueError("qty must be greater than 0 for transfers")
+
+        logger.info(
+            "Transferring stock between warehouses",
+            extra={
+                "product_id": product_id,
+                "from": from_warehouse_id,
+                "to": to_warehouse_id,
+                "qty": qty,
+            },
+        )
+
+        # Salida del almacén origen (type=1: salida)
+        out_movement = await self.add_stock_movement(
+            product_id=product_id,
+            warehouse_id=from_warehouse_id,
+            qty=-qty,
+            movement_type=1,
+            label=f"Transfer out to warehouse {to_warehouse_id}: {label}",
+        )
+
+        # Entrada al almacén destino (type=0: entrada)
+        in_movement = await self.add_stock_movement(
+            product_id=product_id,
+            warehouse_id=to_warehouse_id,
+            qty=qty,
+            movement_type=0,
+            label=f"Transfer in from warehouse {from_warehouse_id}: {label}",
+        )
+
+        return {"out_movement": out_movement, "in_movement": in_movement}

--- a/tests/integration/test_dolibarr_stocks_endpoints.py
+++ b/tests/integration/test_dolibarr_stocks_endpoints.py
@@ -1,0 +1,419 @@
+"""
+Tests de integración para los endpoints /api/v1/dolibarr/stocks.
+
+Verifica:
+- 503 cuando Dolibarr no está configurado
+- Listado paginado de almacenes
+- GET almacén por ID con 404 para ID inexistente
+- GET stock de producto con desglose
+- Listado de movimientos con filtros
+- POST movimiento: validación qty=0 → 422
+- POST movimiento: validación movement_type inválido → 422
+- POST movimiento: creación exitosa
+- POST transferencia: validación warehouses iguales → 422
+- POST transferencia: validación qty <= 0 → 422
+- POST transferencia: creación exitosa con dos movimientos
+
+:author: BenjaminDTS
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("APP_ENV", "development")
+os.environ.setdefault("SECRET_KEY", "test-secret-32-chars-long-enough")
+os.environ.setdefault("BROWSER_BINARY_PATH", "/usr/bin/google-chrome")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_BROKER_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_RESULT_BACKEND", "redis://localhost:6379/1")
+
+from api.core.config import get_settings  # noqa: E402
+
+get_settings.cache_clear()
+
+from api.main import app  # noqa: E402
+from services.integrations.base import IntegrationError  # noqa: E402
+
+_BASE = "/api/v1/dolibarr/stocks"
+
+
+def _mock_settings(configured: bool = True) -> MagicMock:
+    """Crea un mock de Settings con Dolibarr configurado o no."""
+    s = MagicMock()
+    s.dolibarr_configured = configured
+    s.dolibarr_url = "https://dolibarr.test" if configured else ""
+    s.dolibarr_api_key = "test-key" if configured else ""
+    return s
+
+
+def _mock_stock_svc(
+    list_warehouses_return=None,
+    get_warehouse_return=None,
+    get_stock_return=None,
+    get_movements_return=None,
+    add_movement_return=None,
+    transfer_return=None,
+    add_movement_exc=None,
+    transfer_exc=None,
+) -> MagicMock:
+    """Construye un mock completo de DolibarrStockService."""
+    svc = MagicMock()
+    svc.list_warehouses = AsyncMock(return_value=list_warehouses_return or [])
+    svc.get_warehouse = AsyncMock(return_value=get_warehouse_return or {"id": 1})
+    svc.get_product_stock = AsyncMock(
+        return_value=get_stock_return or {"stock_total": 100.0, "warehouses": []}
+    )
+    svc.get_stock_movements = AsyncMock(return_value=get_movements_return or [])
+    svc.add_stock_movement = AsyncMock(return_value=add_movement_return or {"id": 1})
+    svc.transfer_stock = AsyncMock(return_value=transfer_return or {})
+
+    if add_movement_exc:
+        svc.add_stock_movement = AsyncMock(side_effect=add_movement_exc)
+    if transfer_exc:
+        svc.transfer_stock = AsyncMock(side_effect=transfer_exc)
+
+    return svc
+
+
+@pytest_asyncio.fixture
+async def http_client() -> AsyncClient:
+    """Cliente HTTP async para la app FastAPI."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+class TestNotConfigured:
+    """503 cuando Dolibarr no está configurado."""
+
+    def _not_configured_patch(self):
+        return patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(configured=False),
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_warehouses_503(self, http_client: AsyncClient):
+        """GET /warehouses retorna 503 cuando no configurado."""
+        with self._not_configured_patch():
+            resp = await http_client.get(f"{_BASE}/warehouses")
+            assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_get_product_stock_503(self, http_client: AsyncClient):
+        """GET /products/{id} retorna 503 cuando no configurado."""
+        with self._not_configured_patch():
+            resp = await http_client.get(f"{_BASE}/products/1")
+            assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_list_movements_503(self, http_client: AsyncClient):
+        """GET /movements retorna 503 cuando no configurado."""
+        with self._not_configured_patch():
+            resp = await http_client.get(f"{_BASE}/movements")
+            assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_add_movement_503(self, http_client: AsyncClient):
+        """POST /movements retorna 503 cuando no configurado."""
+        with self._not_configured_patch():
+            resp = await http_client.post(
+                f"{_BASE}/movements",
+                json={
+                    "product_id": 1,
+                    "warehouse_id": 1,
+                    "qty": 10,
+                    "movement_type": 0,
+                },
+            )
+            assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_transfer_503(self, http_client: AsyncClient):
+        """POST /transfer retorna 503 cuando no configurado."""
+        with self._not_configured_patch():
+            resp = await http_client.post(
+                f"{_BASE}/transfer",
+                json={
+                    "product_id": 1,
+                    "from_warehouse_id": 1,
+                    "to_warehouse_id": 2,
+                    "qty": 10,
+                },
+            )
+            assert resp.status_code == 503
+
+
+class TestListWarehouses:
+    """Tests para GET /warehouses."""
+
+    @pytest.mark.asyncio
+    async def test_list_warehouses_success(self, http_client: AsyncClient):
+        """GET /warehouses retorna lista paginada."""
+        svc = _mock_stock_svc(
+            list_warehouses_return=[{"id": 1, "label": "Main"}]
+        )
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(),
+        ), patch(
+            "api.v1.endpoints.dolibarr._get_stock_service", return_value=svc
+        ):
+            resp = await http_client.get(f"{_BASE}/warehouses")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["success"] is True
+            assert len(data["data"]["items"]) == 1
+
+
+class TestGetWarehouse:
+    """Tests para GET /warehouses/{warehouse_id}."""
+
+    @pytest.mark.asyncio
+    async def test_get_warehouse_success(self, http_client: AsyncClient):
+        """GET /warehouses/{id} retorna almacén."""
+        svc = _mock_stock_svc(get_warehouse_return={"id": 5, "label": "Storage"})
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(),
+        ), patch(
+            "api.v1.endpoints.dolibarr._get_stock_service", return_value=svc
+        ):
+            resp = await http_client.get(f"{_BASE}/warehouses/5")
+            assert resp.status_code == 200
+            assert resp.json()["data"]["id"] == 5
+
+    @pytest.mark.asyncio
+    async def test_get_warehouse_404(self, http_client: AsyncClient):
+        """GET /warehouses/{id} retorna 404 si no existe."""
+        exc = IntegrationError("Not found", status_code=404)
+        svc = _mock_stock_svc()
+        svc.get_warehouse = AsyncMock(side_effect=exc)
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(),
+        ), patch(
+            "api.v1.endpoints.dolibarr._get_stock_service", return_value=svc
+        ):
+            resp = await http_client.get(f"{_BASE}/warehouses/999")
+            assert resp.status_code == 404
+
+
+class TestGetProductStock:
+    """Tests para GET /products/{product_id}."""
+
+    @pytest.mark.asyncio
+    async def test_get_product_stock_success(self, http_client: AsyncClient):
+        """GET /products/{id} retorna stock con desglose."""
+        svc = _mock_stock_svc(
+            get_stock_return={
+                "stock_total": 100.0,
+                "warehouses": [
+                    {"warehouse_id": 1, "warehouse_label": "Main", "qty": 100.0},
+                ],
+            }
+        )
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(),
+        ), patch(
+            "api.v1.endpoints.dolibarr._get_stock_service", return_value=svc
+        ):
+            resp = await http_client.get(f"{_BASE}/products/10")
+            assert resp.status_code == 200
+            assert resp.json()["data"]["stock_total"] == 100.0
+
+
+class TestListMovements:
+    """Tests para GET /movements."""
+
+    @pytest.mark.asyncio
+    async def test_list_movements_success(self, http_client: AsyncClient):
+        """GET /movements retorna lista paginada."""
+        svc = _mock_stock_svc(
+            get_movements_return=[{"id": 1, "qty": 10.0}]
+        )
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(),
+        ), patch(
+            "api.v1.endpoints.dolibarr._get_stock_service", return_value=svc
+        ):
+            resp = await http_client.get(f"{_BASE}/movements")
+            assert resp.status_code == 200
+            assert len(resp.json()["data"]["items"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_list_movements_with_filters(self, http_client: AsyncClient):
+        """GET /movements pasa filtros al servicio."""
+        svc = _mock_stock_svc(get_movements_return=[])
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(),
+        ), patch(
+            "api.v1.endpoints.dolibarr._get_stock_service", return_value=svc
+        ):
+            resp = await http_client.get(
+                f"{_BASE}/movements?product_id=5&warehouse_id=2"
+            )
+            assert resp.status_code == 200
+            svc.get_stock_movements.assert_called_once()
+            call_args = svc.get_stock_movements.call_args
+            assert call_args[1]["product_id"] == 5
+            assert call_args[1]["warehouse_id"] == 2
+
+
+class TestAddMovement:
+    """Tests para POST /movements."""
+
+    @pytest.mark.asyncio
+    async def test_add_movement_success(self, http_client: AsyncClient):
+        """POST /movements crea movimiento exitosamente."""
+        svc = _mock_stock_svc(
+            add_movement_return={"id": 100, "qty": 10.0}
+        )
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(),
+        ), patch(
+            "api.v1.endpoints.dolibarr._get_stock_service", return_value=svc
+        ):
+            resp = await http_client.post(
+                f"{_BASE}/movements",
+                json={
+                    "product_id": 1,
+                    "warehouse_id": 1,
+                    "qty": 10.0,
+                    "movement_type": 0,
+                },
+            )
+            assert resp.status_code == 201
+            assert resp.json()["data"]["id"] == 100
+
+    @pytest.mark.asyncio
+    async def test_add_movement_qty_zero_422(self, http_client: AsyncClient):
+        """POST /movements retorna 422 si qty == 0."""
+        exc = ValueError("qty cannot be zero")
+        svc = _mock_stock_svc(add_movement_exc=exc)
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(),
+        ), patch(
+            "api.v1.endpoints.dolibarr._get_stock_service", return_value=svc
+        ):
+            resp = await http_client.post(
+                f"{_BASE}/movements",
+                json={
+                    "product_id": 1,
+                    "warehouse_id": 1,
+                    "qty": 0,
+                    "movement_type": 0,
+                },
+            )
+            assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_add_movement_invalid_type_422(self, http_client: AsyncClient):
+        """POST /movements retorna 422 para movement_type inválido."""
+        exc = ValueError("movement_type must be 0, 1, 2, or 3")
+        svc = _mock_stock_svc(add_movement_exc=exc)
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(),
+        ), patch(
+            "api.v1.endpoints.dolibarr._get_stock_service", return_value=svc
+        ):
+            resp = await http_client.post(
+                f"{_BASE}/movements",
+                json={
+                    "product_id": 1,
+                    "warehouse_id": 1,
+                    "qty": 10.0,
+                    "movement_type": 99,
+                },
+            )
+            assert resp.status_code == 422
+
+
+class TestTransferStock:
+    """Tests para POST /transfer."""
+
+    @pytest.mark.asyncio
+    async def test_transfer_success(self, http_client: AsyncClient):
+        """POST /transfer transfiere stock exitosamente."""
+        svc = _mock_stock_svc(
+            transfer_return={
+                "out_movement": {"id": 101},
+                "in_movement": {"id": 102},
+            }
+        )
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(),
+        ), patch(
+            "api.v1.endpoints.dolibarr._get_stock_service", return_value=svc
+        ):
+            resp = await http_client.post(
+                f"{_BASE}/transfer",
+                json={
+                    "product_id": 1,
+                    "from_warehouse_id": 1,
+                    "to_warehouse_id": 2,
+                    "qty": 10.0,
+                },
+            )
+            assert resp.status_code == 201
+            assert "out_movement" in resp.json()["data"]
+            assert "in_movement" in resp.json()["data"]
+
+    @pytest.mark.asyncio
+    async def test_transfer_same_warehouse_422(self, http_client: AsyncClient):
+        """POST /transfer retorna 422 si from == to."""
+        exc = ValueError("from_warehouse_id and to_warehouse_id cannot be the same")
+        svc = _mock_stock_svc(transfer_exc=exc)
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(),
+        ), patch(
+            "api.v1.endpoints.dolibarr._get_stock_service", return_value=svc
+        ):
+            resp = await http_client.post(
+                f"{_BASE}/transfer",
+                json={
+                    "product_id": 1,
+                    "from_warehouse_id": 1,
+                    "to_warehouse_id": 1,
+                    "qty": 10.0,
+                },
+            )
+            assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_transfer_invalid_qty_422(self, http_client: AsyncClient):
+        """POST /transfer retorna 422 si qty <= 0."""
+        exc = ValueError("qty must be greater than 0 for transfers")
+        svc = _mock_stock_svc(transfer_exc=exc)
+        with patch(
+            "api.v1.endpoints.dolibarr.get_settings",
+            return_value=_mock_settings(),
+        ), patch(
+            "api.v1.endpoints.dolibarr._get_stock_service", return_value=svc
+        ):
+            resp = await http_client.post(
+                f"{_BASE}/transfer",
+                json={
+                    "product_id": 1,
+                    "from_warehouse_id": 1,
+                    "to_warehouse_id": 2,
+                    "qty": 0,
+                },
+            )
+            assert resp.status_code == 422

--- a/tests/integration/test_dolibarr_stocks_endpoints.py
+++ b/tests/integration/test_dolibarr_stocks_endpoints.py
@@ -170,8 +170,8 @@ class TestListWarehouses:
             resp = await http_client.get(f"{_BASE}/warehouses")
             assert resp.status_code == 200
             data = resp.json()
-            assert data["success"] is True
-            assert len(data["data"]["items"]) == 1
+            assert len(data["items"]) == 1
+            assert data["limit"] == 50
 
 
 class TestGetWarehouse:
@@ -249,7 +249,7 @@ class TestListMovements:
         ):
             resp = await http_client.get(f"{_BASE}/movements")
             assert resp.status_code == 200
-            assert len(resp.json()["data"]["items"]) == 1
+            assert len(resp.json()["items"]) == 1
 
     @pytest.mark.asyncio
     async def test_list_movements_with_filters(self, http_client: AsyncClient):

--- a/tests/unit/test_dolibarr_stocks.py
+++ b/tests/unit/test_dolibarr_stocks.py
@@ -1,0 +1,254 @@
+"""
+Tests unitarios para DolibarrStockService.
+
+Verifica:
+- list_warehouses: delegación correcta a client.list
+- get_warehouse: obtiene almacén por ID
+- get_product_stock: desglose de stock por almacén
+- get_stock_for_products: itera sobre IDs llamando get_product_stock
+- add_stock_movement: validación qty != 0 antes de API
+- add_stock_movement: validación movement_type en 0-3
+- get_stock_movements: filtros product_id y warehouse_id
+- transfer_stock: dos movimientos (salida + entrada)
+- transfer_stock: validación from == to
+- transfer_stock: validación qty > 0
+
+:author: BenjaminDTS
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.integrations.dolibarr.stocks import DolibarrStockService
+
+
+def _make_client() -> MagicMock:
+    """Construye un mock de DolibarrClient con métodos async."""
+    client = MagicMock()
+    client.list = AsyncMock(return_value=[])
+    client.get = AsyncMock(return_value={"id": 1})
+    client.create = AsyncMock(return_value={"id": 1})
+    return client
+
+
+def _make_service(client: MagicMock | None = None) -> DolibarrStockService:
+    """Construye DolibarrStockService con un client mock."""
+    return DolibarrStockService(client or _make_client())
+
+
+class TestListWarehouses:
+    """Tests para list_warehouses."""
+
+    @pytest.mark.asyncio
+    async def test_calls_client_list_warehouses(self):
+        """list_warehouses llama a client.list con resource='warehouses'."""
+        client = _make_client()
+        client.list = AsyncMock(return_value=[{"id": 1, "label": "Main"}])
+        svc = _make_service(client)
+
+        result = await svc.list_warehouses(limit=20, offset=5)
+
+        client.list.assert_called_once_with("warehouses", limit=20, offset=5)
+        assert len(result) == 1
+        assert result[0]["label"] == "Main"
+
+
+class TestGetWarehouse:
+    """Tests para get_warehouse."""
+
+    @pytest.mark.asyncio
+    async def test_gets_warehouse_by_id(self):
+        """get_warehouse obtiene almacén por ID."""
+        client = _make_client()
+        client.get = AsyncMock(return_value={"id": 5, "label": "Storage"})
+        svc = _make_service(client)
+
+        result = await svc.get_warehouse(5)
+
+        client.get.assert_called_once_with("warehouses", 5)
+        assert result["id"] == 5
+
+
+class TestGetProductStock:
+    """Tests para get_product_stock."""
+
+    @pytest.mark.asyncio
+    async def test_returns_stock_total_and_warehouse_breakdown(self):
+        """get_product_stock retorna stock_total y desglose."""
+        client = _make_client()
+        client.get = AsyncMock(
+            return_value={
+                "id": 10,
+                "stock": 100.0,
+                "warehouses": [
+                    {"id": 1, "label": "Main", "qty": 60.0},
+                    {"id": 2, "label": "Secondary", "qty": 40.0},
+                ],
+            }
+        )
+        svc = _make_service(client)
+
+        result = await svc.get_product_stock(10)
+
+        assert result["stock_total"] == 100.0
+        assert len(result["warehouses"]) == 2
+        assert result["warehouses"][0]["warehouse_label"] == "Main"
+
+
+class TestGetStockForProducts:
+    """Tests para get_stock_for_products."""
+
+    @pytest.mark.asyncio
+    async def test_calls_get_product_stock_for_each_id(self):
+        """get_stock_for_products llama a get_product_stock para cada ID."""
+        client = _make_client()
+        client.get = AsyncMock(
+            side_effect=[
+                {"id": 1, "stock": 50.0, "warehouses": []},
+                {"id": 2, "stock": 30.0, "warehouses": []},
+            ]
+        )
+        svc = _make_service(client)
+
+        result = await svc.get_stock_for_products([1, 2])
+
+        assert len(result) == 2
+        assert 1 in result
+        assert 2 in result
+        assert client.get.call_count == 2
+
+
+class TestAddStockMovement:
+    """Tests para add_stock_movement."""
+
+    @pytest.mark.asyncio
+    async def test_raises_valueerror_when_qty_is_zero(self):
+        """add_stock_movement lanza ValueError si qty == 0."""
+        svc = _make_service()
+
+        with pytest.raises(ValueError, match="qty cannot be zero"):
+            await svc.add_stock_movement(
+                product_id=1,
+                warehouse_id=1,
+                qty=0,
+                movement_type=0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_raises_valueerror_for_invalid_movement_type(self):
+        """add_stock_movement lanza ValueError para movement_type inválido."""
+        svc = _make_service()
+
+        with pytest.raises(ValueError, match="movement_type must be"):
+            await svc.add_stock_movement(
+                product_id=1,
+                warehouse_id=1,
+                qty=10.0,
+                movement_type=5,
+            )
+
+    @pytest.mark.asyncio
+    async def test_creates_movement_with_valid_data(self):
+        """add_stock_movement crea movimiento con datos válidos."""
+        client = _make_client()
+        client.create = AsyncMock(return_value={"id": 100, "qty": 10.0})
+        svc = _make_service(client)
+
+        result = await svc.add_stock_movement(
+            product_id=1,
+            warehouse_id=2,
+            qty=10.0,
+            movement_type=0,
+            label="Test",
+        )
+
+        client.create.assert_called_once()
+        call_args = client.create.call_args
+        assert call_args[0][0] == "stockmovements"
+        assert call_args[0][1]["product_id"] == 1
+        assert call_args[0][1]["qty"] == 10.0
+
+
+class TestGetStockMovements:
+    """Tests para get_stock_movements."""
+
+    @pytest.mark.asyncio
+    async def test_passes_product_id_filter(self):
+        """get_stock_movements pasa product_id como filtro."""
+        client = _make_client()
+        client.list = AsyncMock(return_value=[])
+        svc = _make_service(client)
+
+        await svc.get_stock_movements(product_id=5)
+
+        call_args = client.list.call_args
+        assert call_args[1]["filters"]["fk_product"] == 5
+
+    @pytest.mark.asyncio
+    async def test_passes_warehouse_id_filter(self):
+        """get_stock_movements pasa warehouse_id como filtro."""
+        client = _make_client()
+        client.list = AsyncMock(return_value=[])
+        svc = _make_service(client)
+
+        await svc.get_stock_movements(warehouse_id=3)
+
+        call_args = client.list.call_args
+        assert call_args[1]["filters"]["fk_warehouse"] == 3
+
+
+class TestTransferStock:
+    """Tests para transfer_stock."""
+
+    @pytest.mark.asyncio
+    async def test_raises_valueerror_when_warehouses_equal(self):
+        """transfer_stock lanza ValueError si from == to."""
+        svc = _make_service()
+
+        with pytest.raises(ValueError, match="cannot be the same"):
+            await svc.transfer_stock(
+                product_id=1,
+                from_warehouse_id=5,
+                to_warehouse_id=5,
+                qty=10.0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_raises_valueerror_when_qty_zero_or_negative(self):
+        """transfer_stock lanza ValueError si qty <= 0."""
+        svc = _make_service()
+
+        with pytest.raises(ValueError, match="qty must be greater than 0"):
+            await svc.transfer_stock(
+                product_id=1,
+                from_warehouse_id=1,
+                to_warehouse_id=2,
+                qty=-5.0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_creates_two_movements(self):
+        """transfer_stock crea dos movimientos (salida + entrada)."""
+        client = _make_client()
+        client.create = AsyncMock(
+            side_effect=[
+                {"id": 101, "qty": -10.0},  # out
+                {"id": 102, "qty": 10.0},   # in
+            ]
+        )
+        svc = _make_service(client)
+
+        result = await svc.transfer_stock(
+            product_id=1,
+            from_warehouse_id=1,
+            to_warehouse_id=2,
+            qty=10.0,
+        )
+
+        assert "out_movement" in result
+        assert "in_movement" in result
+        assert client.create.call_count == 2


### PR DESCRIPTION
## Qué se implementa
- DolibarrStockService: list_warehouses · get_warehouse · get_product_stock · get_stock_for_products · add_stock_movement · get_stock_movements · transfer_stock
- 6 endpoints /api/v1/dolibarr/stocks:
  * GET /warehouses — listar almacenes (paginado)
  * GET /warehouses/{warehouse_id} — obtener almacén
  * GET /products/{product_id} — stock con desglose
  * GET /movements — listar movimientos (con filtros)
  * POST /movements — crear movimiento
  * POST /transfer — transferir entre almacenes
- 12 tests unitarios + 17 tests de integración (29 tests totales)

## Validaciones
- add_stock_movement: valida qty!=0 y movement_type en 0-3 antes de API
- transfer_stock: valida from!=to y qty>0 antes de API
- transfer_stock implementado como dos movimientos (salida + entrada)

## Checklist
- [x] pytest pasa al 100% (518 tests)
- [x] Cobertura stocks.py: 96%
- [x] Un commit por acción
- [x] @author BenjaminDTS en stocks.py
- [x] Validaciones antes de API
- [x] Conventional Commits

## QA
- Listado de almacenes paginado
- Stock de producto con desglose por almacén
- Movimientos con filtros product_id/warehouse_id
- Transferencias: dos movimientos creados atómicamente