### PR TITLE
feat: add Dolibarr configuration GUI

### DIFF
--- a/api/v1/endpoints/dolibarr.py
+++ b/api/v1/endpoints/dolibarr.py
@@ -50,16 +50,24 @@ Todos los endpoints devuelven 503 si Dolibarr no está configurado.
 
 from __future__ import annotations
 
+import json
 import tempfile
 from pathlib import Path
 from typing import Any
 
+import redis.asyncio as aioredis
 from fastapi import APIRouter, HTTPException, Query, UploadFile, status
 from fastapi.responses import JSONResponse
 from loguru import logger
 
 from api.core.config import get_settings
-from api.v1.schemas.integrations import IntegrationStatus, PaginatedResponse, SyncFromJobRequest
+from api.v1.schemas.integrations import (
+    DolibarrConfigRequest,
+    DolibarrConfigResponse,
+    IntegrationStatus,
+    PaginatedResponse,
+    SyncFromJobRequest,
+)
 from services.integrations.base import IntegrationError, IntegrationNotConfiguredError
 from services.integrations.dolibarr.categories import DolibarrCategoryService
 from services.integrations.dolibarr.client import DolibarrClient
@@ -81,9 +89,69 @@ _NOT_CONFIGURED_MSG = (
 )
 
 
+async def _get_dolibarr_credentials() -> tuple[str, str]:
+    """
+    Obtiene credenciales de Dolibarr desde Redis o .env.
+
+    Retorna:
+        Tupla (url, api_key).
+
+    Raises:
+        IntegrationNotConfiguredError: si no hay credenciales configuradas.
+    """
+    settings = get_settings()
+    redis_client: aioredis.Redis | None = None
+
+    try:
+        redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+        stored = await redis_client.get("integration:dolibarr:config")
+        if stored:
+            config = json.loads(stored)
+            url = config.get("url", "").strip()
+            api_key = config.get("api_key", "").strip()
+            if url and api_key:
+                return url, api_key
+    except Exception as exc:
+        logger.debug("Redis no disponible para config Dolibarr", exc_info=exc)
+    finally:
+        if redis_client:
+            await redis_client.aclose()
+
+    # Fallback a settings
+    if settings.dolibarr_configured:
+        return settings.dolibarr_url, settings.dolibarr_api_key
+
+    raise IntegrationNotConfiguredError(
+        "Dolibarr no configurado: define DOLIBARR_URL y DOLIBARR_API_KEY en .env "
+        "o configúralas en la interfaz gráfica."
+    )
+
+
+async def _get_service_async() -> DolibarrProductService:
+    """
+    Construye y devuelve una instancia de DolibarrProductService.
+    Lee credenciales desde Redis o .env.
+
+    Raises:
+        HTTPException 503: si Dolibarr no está configurado.
+    """
+    settings = get_settings()
+    try:
+        url, api_key = await _get_dolibarr_credentials()
+        client = DolibarrClient(settings, override_url=url, override_api_key=api_key)
+    except IntegrationNotConfiguredError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_NOT_CONFIGURED_MSG,
+        )
+    return DolibarrProductService(client)
+
+
 def _get_service() -> DolibarrProductService:
     """
     Construye y devuelve una instancia de DolibarrProductService.
+
+    NOTA: Esta versión usa solo .env. Usar _get_service_async para aprovechar Redis config.
 
     Raises:
         HTTPException 503: si Dolibarr no está configurado.
@@ -118,28 +186,52 @@ async def get_status() -> IntegrationStatus:
     Verifica estado de configuración y salud de la integración Dolibarr.
 
     Siempre devuelve HTTP 200. El estado se comunica en el body.
+    Prioridad: Redis config > variables de entorno.
 
     Returns:
         IntegrationStatus con platform, configured, healthy y message.
     """
     settings = get_settings()
+    redis_client: aioredis.Redis | None = None
+    override_url = ""
+    override_api_key = ""
 
-    if not settings.dolibarr_configured:
+    # Intentar leer config de Redis
+    try:
+        redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+        stored = await redis_client.get("integration:dolibarr:config")
+        if stored:
+            config = json.loads(stored)
+            override_url = config.get("url", "")
+            override_api_key = config.get("api_key", "")
+    except Exception as exc:
+        logger.debug("Redis no disponible para config Dolibarr", exc_info=exc)
+    finally:
+        if redis_client:
+            await redis_client.aclose()
+
+    # Verificar si hay configuración disponible
+    has_config = (
+        (override_url and override_api_key)
+        or settings.dolibarr_configured
+    )
+
+    if not has_config:
         return IntegrationStatus(
             platform="dolibarr",
             configured=False,
             healthy=None,
-            message="DOLIBARR_URL o DOLIBARR_API_KEY no están definidos en .env.",
+            message="DOLIBARR_URL o DOLIBARR_API_KEY no están definidos en .env o en la GUI.",
         )
 
     try:
-        client = DolibarrClient(settings)
+        client = DolibarrClient(settings, override_url=override_url, override_api_key=override_api_key)
     except IntegrationNotConfiguredError:
         return IntegrationStatus(
             platform="dolibarr",
             configured=False,
             healthy=None,
-            message="DOLIBARR_URL o DOLIBARR_API_KEY no están definidos en .env.",
+            message="Configuración de Dolibarr incompleta. Define URL y API Key.",
         )
 
     try:
@@ -168,6 +260,89 @@ async def get_status() -> IntegrationStatus:
         )
 
 
+# ── Configuración ────────────────────────────────────────────────────────
+
+
+@router_main.get("/config", response_model=DolibarrConfigResponse)
+async def get_config() -> DolibarrConfigResponse:
+    """
+    Obtiene la configuración guardada de Dolibarr (Redis) o del .env.
+
+    Returns:
+        DolibarrConfigResponse con URL, API key y estado configurado.
+    """
+    settings = get_settings()
+    redis_client: aioredis.Redis | None = None
+
+    try:
+        redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+        stored = await redis_client.get("integration:dolibarr:config")
+        if stored:
+            config = json.loads(stored)
+            return DolibarrConfigResponse(
+                url=config.get("url", ""),
+                api_key=config.get("api_key", ""),
+                configured=bool(config.get("url") and config.get("api_key")),
+            )
+    except Exception as exc:
+        logger.warning("Error accediendo a Redis para config Dolibarr", exc_info=exc)
+    finally:
+        if redis_client:
+            await redis_client.aclose()
+
+    # Fallback a variables de entorno
+    return DolibarrConfigResponse(
+        url=settings.dolibarr_url or "",
+        api_key=settings.dolibarr_api_key or "",
+        configured=settings.dolibarr_configured,
+    )
+
+
+@router_main.post("/config", response_model=DolibarrConfigResponse)
+async def save_config(request: DolibarrConfigRequest) -> DolibarrConfigResponse:
+    """
+    Guarda la configuración de Dolibarr en Redis.
+
+    Args:
+        request: DolibarrConfigRequest con URL y API key.
+
+    Returns:
+        DolibarrConfigResponse confirmando los datos guardados.
+    """
+    settings = get_settings()
+    redis_client: aioredis.Redis | None = None
+
+    try:
+        redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+        config = {
+            "url": request.url.rstrip("/"),
+            "api_key": request.api_key.strip(),
+        }
+        await redis_client.set(
+            "integration:dolibarr:config",
+            json.dumps(config),
+            ex=None,
+        )
+        logger.info(
+            "Configuración de Dolibarr guardada",
+            extra={"url": config["url"]},
+        )
+        return DolibarrConfigResponse(
+            url=config["url"],
+            api_key=config["api_key"],
+            configured=True,
+        )
+    except Exception as exc:
+        logger.error("Error guardando configuración de Dolibarr en Redis", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error guardando configuración: {str(exc)}",
+        )
+    finally:
+        if redis_client:
+            await redis_client.aclose()
+
+
 # ── Productos ────────────────────────────────────────────────────────────
 
 
@@ -186,7 +361,17 @@ async def list_products(
     Returns:
         PaginatedResponse con los productos encontrados.
     """
-    svc = _get_service()
+    try:
+        svc = await _get_service_async()
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Error creando servicio Dolibarr", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_NOT_CONFIGURED_MSG,
+        )
+
     try:
         items = await svc.list_products(limit=limit, offset=offset)
     except IntegrationError as exc:

--- a/api/v1/schemas/integrations.py
+++ b/api/v1/schemas/integrations.py
@@ -39,3 +39,18 @@ class SyncFromJobRequest(BaseModel):
         default=False,
         description="Si True, sobreescribe productos existentes en Dolibarr.",
     )
+
+
+class DolibarrConfigRequest(BaseModel):
+    """Petición para guardar configuración de Dolibarr."""
+
+    url: str = Field(..., min_length=1, description="URL base de Dolibarr.")
+    api_key: str = Field(..., min_length=1, description="API Key de Dolibarr.")
+
+
+class DolibarrConfigResponse(BaseModel):
+    """Respuesta con configuración actual de Dolibarr."""
+
+    url: str
+    api_key: str
+    configured: bool

--- a/frontend/src/components/dolibarr/DolibarrConfig.tsx
+++ b/frontend/src/components/dolibarr/DolibarrConfig.tsx
@@ -1,0 +1,169 @@
+/**
+ * Panel de configuración de Dolibarr.
+ * Permite guardar URL y API Key en la interfaz gráfica.
+ *
+ * @author BenjaminDTS
+ */
+import { useEffect, useState } from 'react'
+import { apiClient } from '@/api/client'
+
+interface DolibarrConfigData {
+  url: string
+  api_key: string
+  configured: boolean
+}
+
+interface Props {
+  className?: string
+}
+
+export default function DolibarrConfig({ className = '' }: Props) {
+  const [url, setUrl] = useState('')
+  const [apiKey, setApiKey] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState({ type: '', text: '' })
+
+  // Cargar config guardada
+  useEffect(() => {
+    ;(async () => {
+      try {
+        setLoading(true)
+        const res = await apiClient.get<DolibarrConfigData>('/dolibarr/config')
+        if (res.data) {
+          setUrl(res.data.url || '')
+          setApiKey(res.data.api_key || '')
+        }
+      } catch (err) {
+        console.error('Error cargando config Dolibarr:', err)
+        setMessage({ type: 'error', text: 'Error al cargar configuración' })
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [])
+
+  const handleSave = async () => {
+    if (!url.trim() || !apiKey.trim()) {
+      setMessage({ type: 'error', text: 'URL y API Key son requeridas' })
+      return
+    }
+
+    try {
+      setSaving(true)
+      const res = await apiClient.post<DolibarrConfigData>('/dolibarr/config', {
+        url: url.trim(),
+        api_key: apiKey.trim(),
+      })
+
+      if (res.data) {
+        setMessage({ type: 'success', text: 'Configuración guardada correctamente ✓' })
+        setTimeout(() => setMessage({ type: '', text: '' }), 3000)
+      }
+    } catch (err) {
+      console.error('Error guardando config:', err)
+      setMessage({ type: 'error', text: 'Error al guardar configuración' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className={`p-6 ${className}`}>
+        <div className="flex items-center justify-center h-64">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={`p-6 ${className}`}>
+      <div className="max-w-xl">
+        <h3 className="text-lg font-semibold text-gray-900 mb-6">Configuración Dolibarr</h3>
+
+        {/* Advertencia informativa */}
+        <div className="bg-blue-50 border-l-4 border-blue-400 p-4 mb-6 rounded">
+          <p className="text-sm text-blue-800">
+            Ingresa la URL base de tu instancia Dolibarr y la API Key. Estos datos se guardan
+            localmente y se utilizan para conectar con Dolibarr.
+          </p>
+        </div>
+
+        {/* Formulario */}
+        <div className="space-y-4">
+          {/* URL */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              URL de Dolibarr
+            </label>
+            <input
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://mi-dolibarr.com"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              Ejemplo: https://dolibarr.ejemplo.com (sin barra final)
+            </p>
+          </div>
+
+          {/* API Key */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              API Key
+            </label>
+            <input
+              type="password"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder="Pega tu API Key aquí"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              Obtén la API Key en: Inicio → Configuración → API/REST → Generar clave
+            </p>
+          </div>
+
+          {/* Mensaje de estado */}
+          {message.text && (
+            <div
+              className={`p-3 rounded text-sm ${
+                message.type === 'success'
+                  ? 'bg-green-50 text-green-800 border border-green-200'
+                  : 'bg-red-50 text-red-800 border border-red-200'
+              }`}
+            >
+              {message.text}
+            </div>
+          )}
+
+          {/* Botón guardar */}
+          <div className="flex gap-2 pt-2">
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-sm transition-colors"
+            >
+              {saving ? 'Guardando...' : 'Guardar Configuración'}
+            </button>
+          </div>
+        </div>
+
+        {/* Info de ayuda */}
+        <div className="mt-8 pt-6 border-t border-gray-200">
+          <h4 className="text-sm font-semibold text-gray-900 mb-3">¿Cómo obtener las credenciales?</h4>
+          <ol className="text-sm text-gray-600 space-y-2">
+            <li>1. Accede a tu instancia Dolibarr como administrador</li>
+            <li>2. Navega a Inicio → Configuración → API/REST</li>
+            <li>3. En la sección "Gestión de tokens", pulsa "Crear una nueva clave API"</li>
+            <li>4. Copia la clave generada y pégala aquí</li>
+            <li>5. La URL es simplemente tu dominio de Dolibarr (ej: https://mi-dolibarr.com)</li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/dolibarr/DolibarrPanel.tsx
+++ b/frontend/src/components/dolibarr/DolibarrPanel.tsx
@@ -12,8 +12,9 @@ import DolibarrThirdparties from './DolibarrThirdparties'
 import DolibarrOrders from './DolibarrOrders'
 import DolibarrInvoices from './DolibarrInvoices'
 import DolibarrStocks from './DolibarrStocks'
+import DolibarrConfig from './DolibarrConfig'
 
-type DolibarrTab = 'productos' | 'terceros' | 'pedidos' | 'facturas' | 'stock'
+type DolibarrTab = 'productos' | 'terceros' | 'pedidos' | 'facturas' | 'stock' | 'config'
 
 interface Props {
   className?: string
@@ -127,7 +128,7 @@ export default function DolibarrPanel({ className = '' }: Props) {
         </div>
 
         {/* Tabs internos */}
-        <div className="flex border-b border-gray-200">
+        <div className="flex border-b border-gray-200 overflow-x-auto">
           {(
             [
               { id: 'productos', label: 'Productos' },
@@ -135,12 +136,13 @@ export default function DolibarrPanel({ className = '' }: Props) {
               { id: 'pedidos', label: 'Pedidos' },
               { id: 'facturas', label: 'Facturas' },
               { id: 'stock', label: 'Stock' },
+              { id: 'config', label: 'Configuración' },
             ] as Array<{ id: DolibarrTab; label: string }>
           ).map((t) => (
             <button
               key={t.id}
               onClick={() => setTab(t.id)}
-              className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${
+              className={`px-4 py-3 text-sm font-medium transition-colors whitespace-nowrap ${
                 tab === t.id
                   ? 'text-blue-600 border-b-2 border-blue-600'
                   : 'text-gray-700 hover:text-gray-900'
@@ -158,6 +160,7 @@ export default function DolibarrPanel({ className = '' }: Props) {
           {tab === 'pedidos' && <DolibarrOrders />}
           {tab === 'facturas' && <DolibarrInvoices />}
           {tab === 'stock' && <DolibarrStocks />}
+          {tab === 'config' && <DolibarrConfig />}
         </div>
       </div>
     </div>

--- a/services/integrations/dolibarr/client.py
+++ b/services/integrations/dolibarr/client.py
@@ -37,28 +37,37 @@ class DolibarrClient(IntegrationClient):
     :author: Carlitos6712
     """
 
-    def __init__(self, settings: Settings) -> None:
+    def __init__(self, settings: Settings, override_url: str = "", override_api_key: str = "") -> None:
         """
         Inicializa el cliente verificando que Dolibarr esté configurado.
 
+        Prioridad:
+          1. override_url / override_api_key (parámetros)
+          2. DOLIBARR_URL / DOLIBARR_API_KEY (Settings)
+
         Args:
             settings: instancia de Settings con las variables de entorno.
+            override_url: URL de Dolibarr (opcional, sobreescribe .env).
+            override_api_key: API Key de Dolibarr (opcional, sobreescribe .env).
 
         Raises:
-            IntegrationNotConfiguredError: si DOLIBARR_URL o DOLIBARR_API_KEY
-                no están definidas en el entorno.
+            IntegrationNotConfiguredError: si URL o API key están vacías.
         """
-        if not settings.dolibarr_configured:
+        url = (override_url or settings.dolibarr_url or "").strip()
+        api_key = (override_api_key or settings.dolibarr_api_key or "").strip()
+
+        if not url or not api_key:
             raise IntegrationNotConfiguredError(
-                "Dolibarr no configurado: define DOLIBARR_URL y DOLIBARR_API_KEY en .env"
+                "Dolibarr no configurado: define DOLIBARR_URL y DOLIBARR_API_KEY en .env "
+                "o configúralas en la interfaz gráfica."
             )
 
-        self._base_url: str = settings.dolibarr_url.rstrip("/")
+        self._base_url: str = url.rstrip("/")
 
         self._client: httpx.AsyncClient = httpx.AsyncClient(
             base_url=self._base_url + "/api/index.php/",
             headers={
-                "DOLAPIKEY": settings.dolibarr_api_key,
+                "DOLAPIKEY": api_key,
                 "Content-Type": "application/json",
                 "Accept": "application/json",
             },


### PR DESCRIPTION
## Summary

Permite configurar URL y API Key de Dolibarr desde la interfaz gráfica en lugar de solo variables de entorno.

- Backend: GET/POST `/api/v1/dolibarr/config` guardan en Redis
- Cliente Dolibarr: acepta parámetros override (con fallback a .env)
- Frontend: tab "Configuración" con form URL + API Key
- Status endpoint verifica Redis primero, luego .env

## Test Plan

- [ ] Abrir tab Configuración en panel Dolibarr
- [ ] Ingresar URL y API Key válidas
- [ ] Click "Guardar" → verificar GET `/api/v1/dolibarr/config`
- [ ] Recargar página → credenciales persisten
- [ ] Verificar que módulos Dolibarr usan config guardada
- [ ] Fallback: eliminar Redis config, verificar que usa .env