### PR TITLE
feat: Dolibarr CSV bulk import with column mapping and extrafields support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@ BROWSER_TYPE=chrome
 # Ejemplos por navegador y OS:
 #
 # -- Chrome (Windows) — dejar vacío para auto-detección:
-BROWSER_BINARY_PATH=
+BROWSER_BINARY_PATH="C:\Program Files\Google\Chrome\Application\chrome.exe"
 #
 # -- Chrome ruta explícita (Windows):
 # BROWSER_BINARY_PATH=C:\Program Files\Google\Chrome\Application\chrome.exe
@@ -58,12 +58,12 @@ BROWSER_BINARY_PATH=
 # BROWSER_VERSION_MAIN=134
 
 # Modo headless: true en producción/CI, false para depurar
-BROWSER_HEADLESS=false
+BROWSER_HEADLESS=true
 # Versión principal de Chromium (solo requerida para opera | brave — uc la necesita)
-BROWSER_VERSION_MAIN=
+BROWSER_VERSION_MAIN=147
 # Segundos máximos de espera de Selenium
 BROWSER_TIMEOUT=15
- 
+
 # ==========================================
 # SCRAPER — MOTOR DE BÚSQUEDA
 # ==========================================
@@ -72,7 +72,7 @@ SEARCH_ENGINE=bing
 # Si true, en modo EAN se hace primero una búsqueda web exacta en Google
 # para resolver el EAN al nombre real del producto antes de buscar imágenes.
 # Desactivar solo si Google bloquea las peticiones de forma persistente.
-EAN_ENRICHMENT_ENABLED=true
+EAN_ENRICHMENT_ENABLED=false
 
 # ==========================================
 # SCRAPER — BÚSQUEDA
@@ -190,3 +190,13 @@ CANDIDATES_TTL_HOURS=24
 # Ejemplo: https://mi-dolibarr.com
 DOLIBARR_URL=
 DOLIBARR_API_KEY=
+
+# ── Base de datos Dolibarr (fallback para gestión de campos extra) ────────────
+# Necesario solo si tu versión de Dolibarr no soporta la API REST /extrafields.
+# Credenciales del servidor MySQL/MariaDB donde está instalado Dolibarr.
+DOLIBARR_DB_HOST=
+DOLIBARR_DB_PORT=3306
+DOLIBARR_DB_NAME=
+DOLIBARR_DB_USER=
+DOLIBARR_DB_PASS=
+DOLIBARR_DB_PREFIX=llx_

--- a/api/core/config.py
+++ b/api/core/config.py
@@ -212,12 +212,29 @@ class Settings(BaseSettings):
         ),
     )
 
+    # ── Base de datos Dolibarr (para gestión de campos extra) ────────────────
+    dolibarr_db_host: str = Field(default="", description="Host MySQL/MariaDB de Dolibarr.")
+    dolibarr_db_port: int = Field(default=3306, ge=1, le=65535)
+    dolibarr_db_name: str = Field(default="", description="Nombre de la BD de Dolibarr.")
+    dolibarr_db_user: str = Field(default="", description="Usuario MySQL de Dolibarr.")
+    dolibarr_db_pass: str = Field(default="", description="Contraseña MySQL de Dolibarr.")
+    dolibarr_db_prefix: str = Field(default="llx_", description="Prefijo de tablas Dolibarr.")
+
     @property
     def dolibarr_configured(self) -> bool:
         """True si Dolibarr tiene URL y API key definidas y no vacías."""
         return bool(
             self.dolibarr_url.strip()
             and self.dolibarr_api_key.strip()
+        )
+
+    @property
+    def dolibarr_db_configured(self) -> bool:
+        """True si las credenciales de BD de Dolibarr están definidas."""
+        return bool(
+            self.dolibarr_db_host.strip()
+            and self.dolibarr_db_name.strip()
+            and self.dolibarr_db_user.strip()
         )
 
     # ── Logging ───────────────────────────────────────────────────────────────

--- a/api/v1/endpoints/dolibarr.py
+++ b/api/v1/endpoints/dolibarr.py
@@ -57,14 +57,21 @@ from pathlib import Path
 from typing import Any
 
 import redis.asyncio as aioredis
-from fastapi import APIRouter, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import JSONResponse
 from loguru import logger
 
 from api.core.config import get_settings
 from api.v1.schemas.integrations import (
+    CsvImportPreview,
+    CsvImportResponse,
+    CsvImportRowResult,
     DolibarrConfigRequest,
     DolibarrConfigResponse,
+    DolibarrDBConfigRequest,
+    DolibarrDBConfigResponse,
+    DolibarrExtraField,
+    DolibarrExtraFieldCreate,
     IntegrationStatus,
     PaginatedResponse,
     SyncFromJobRequest,
@@ -72,6 +79,7 @@ from api.v1.schemas.integrations import (
 from services.integrations.base import IntegrationError, IntegrationNotConfiguredError
 from services.integrations.dolibarr.categories import DolibarrCategoryService
 from services.integrations.dolibarr.client import DolibarrClient
+from services.integrations.dolibarr.extrafields import DolibarrExtraFieldService
 from services.integrations.dolibarr.invoices import DolibarrInvoiceService
 from services.integrations.dolibarr.orders import DolibarrOrderService
 from services.integrations.dolibarr.products import DolibarrProductService
@@ -351,6 +359,109 @@ async def save_config(request: DolibarrConfigRequest) -> DolibarrConfigResponse:
             await redis_client.aclose()
 
 
+# ── Configuración BD ─────────────────────────────────────────────────────
+
+_REDIS_DB_CONFIG_KEY = "integration:dolibarr:db_config"
+
+
+async def _get_dolibarr_db_config() -> dict:
+    """
+    Lee configuración de BD de Dolibarr desde Redis.
+    Fallback a variables de entorno si Redis no tiene la clave.
+
+    Returns:
+        Dict con host, port, db_name, user, password, prefix.
+    """
+    settings = get_settings()
+    redis_client: aioredis.Redis | None = None
+
+    try:
+        redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+        stored = await redis_client.get(_REDIS_DB_CONFIG_KEY)
+        if stored:
+            return json.loads(stored)
+    except Exception as exc:
+        logger.debug("Redis no disponible para DB config Dolibarr", exc_info=exc)
+    finally:
+        if redis_client:
+            await redis_client.aclose()
+
+    return {
+        "host": settings.dolibarr_db_host,
+        "port": settings.dolibarr_db_port,
+        "db_name": settings.dolibarr_db_name,
+        "user": settings.dolibarr_db_user,
+        "password": settings.dolibarr_db_pass,
+        "prefix": settings.dolibarr_db_prefix,
+    }
+
+
+@router_main.get("/db-config", response_model=DolibarrDBConfigResponse)
+async def get_db_config() -> DolibarrDBConfigResponse:
+    """
+    Obtiene la configuración de BD de Dolibarr guardada en Redis o .env.
+
+    Returns:
+        DolibarrDBConfigResponse con credenciales y estado.
+    """
+    cfg = await _get_dolibarr_db_config()
+    configured = bool(
+        cfg.get("host", "").strip()
+        and cfg.get("db_name", "").strip()
+        and cfg.get("user", "").strip()
+    )
+    return DolibarrDBConfigResponse(
+        host=cfg.get("host", ""),
+        port=cfg.get("port", 3306),
+        db_name=cfg.get("db_name", ""),
+        user=cfg.get("user", ""),
+        password=cfg.get("password", ""),
+        prefix=cfg.get("prefix", "llx_"),
+        configured=configured,
+    )
+
+
+@router_main.post("/db-config", response_model=DolibarrDBConfigResponse)
+async def save_db_config(request: DolibarrDBConfigRequest) -> DolibarrDBConfigResponse:
+    """
+    Guarda las credenciales de BD de Dolibarr en Redis.
+
+    Args:
+        request: DolibarrDBConfigRequest con las credenciales de acceso a MySQL.
+
+    Returns:
+        DolibarrDBConfigResponse confirmando los datos guardados.
+    """
+    settings = get_settings()
+    redis_client: aioredis.Redis | None = None
+
+    try:
+        redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+        config = {
+            "host": request.host.strip(),
+            "port": request.port,
+            "db_name": request.db_name.strip(),
+            "user": request.user.strip(),
+            "password": request.password,
+            "prefix": request.prefix.strip() or "llx_",
+        }
+        await redis_client.set(_REDIS_DB_CONFIG_KEY, json.dumps(config))
+        logger.info(
+            "Configuración BD Dolibarr guardada",
+            extra={"host": config["host"], "db_name": config["db_name"]},
+        )
+        return DolibarrDBConfigResponse(**config, configured=True)
+    except Exception as exc:
+        logger.error("Error guardando configuración BD Dolibarr", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error guardando configuración BD: {str(exc)}",
+        )
+    finally:
+        if redis_client:
+            await redis_client.aclose()
+
+
 # ── Productos ────────────────────────────────────────────────────────────
 
 
@@ -402,15 +513,19 @@ async def get_product_fields() -> JSONResponse:
     """
     Devuelve el schema de campos para productos de esta instancia Dolibarr.
 
-    Combina campos estándar con los campos extra configurados (extrafields).
-    El frontend usa este endpoint para renderizar el formulario de producto dinámicamente.
+    Combina campos estándar con los campos extra. Usa DolibarrExtraFieldService
+    (con fallback a BD MariaDB) para obtener los extrafields, garantizando que
+    los campos creados manualmente en Dolibarr se detecten aunque la API REST
+    de extrafields no esté disponible.
 
     Returns:
         Lista de DolibarrFieldSchema con key, label, type, required, section, is_extra, options.
     """
     svc = await _get_service_async()
+    extra_svc = await _get_extrafield_service()
     try:
-        fields = await svc.get_product_fields()
+        pre_fetched = await extra_svc.list_extrafields(elementtype="product")
+        fields = await svc.get_product_fields(pre_fetched_extras=pre_fetched)
     except Exception as exc:
         logger.error("Error obteniendo schema de campos Dolibarr", exc_info=exc)
         raise HTTPException(
@@ -420,44 +535,24 @@ async def get_product_fields() -> JSONResponse:
     return JSONResponse(content=_ok(fields, "Schema de campos obtenido."))
 
 
-@router_products.get("/{product_id}")
-async def get_product(product_id: int) -> JSONResponse:
-    """
-    Obtiene un producto de Dolibarr por su ID.
-
-    Args:
-        product_id: ID del producto en Dolibarr.
-
-    Returns:
-        Respuesta estándar con los datos del producto.
-    """
-    svc = await _get_service_async()
-    try:
-        product = await svc.get_product(product_id)
-    except IntegrationError as exc:
-        if exc.status_code == 404:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Producto {product_id} no encontrado en Dolibarr.",
-            )
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=str(exc),
-        )
-    return JSONResponse(content=_ok(product, "Producto obtenido."))
-
-
 @router_products.post("", status_code=status.HTTP_201_CREATED)
 async def create_product(data: dict) -> JSONResponse:
     """
     Crea un producto en Dolibarr.
 
+    Si el payload incluye ``array_options`` (extrafields), estos se guardan via
+    BD directa para evitar el error de Dolibarr "Field X doesn't have a default
+    value" que afecta al endpoint REST PUT /products/{id}.
+
     Args:
-        data: campos del producto (ref, label, price, description, type, status).
+        data: campos del producto (ref, label, price, description, type, status,
+              array_options opcional con extrafields).
 
     Returns:
         Respuesta estándar (201) con el producto creado.
     """
+    array_options: dict = data.pop("array_options", None) or {}
+
     svc = await _get_service_async()
     try:
         created = await svc.create_product(data)
@@ -466,6 +561,26 @@ async def create_product(data: dict) -> JSONResponse:
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=str(exc),
         )
+
+    product_id: int | None = created.get("id") if isinstance(created, dict) else None
+
+    if array_options and product_id:
+        try:
+            db = await _get_extrafield_db()
+            await db.update_product_extrafields(
+                product_id=product_id,
+                array_options=array_options,
+                elementtype="product",
+            )
+        except HTTPException:
+            pass  # BD no configurada — extrafields omitidos sin romper la respuesta
+        except Exception as exc:
+            logger.warning(
+                "Extrafields no guardados tras crear producto",
+                exc_info=exc,
+                extra={"product_id": product_id},
+            )
+
     return JSONResponse(
         content=_ok(created, "Producto creado."),
         status_code=status.HTTP_201_CREATED,
@@ -477,13 +592,19 @@ async def update_product(product_id: int, data: dict) -> JSONResponse:
     """
     Actualiza un producto existente en Dolibarr.
 
+    Separa ``array_options`` (extrafields) del payload estándar y los persiste
+    via BD directa para evitar el error MySQL "Field X doesn't have a default
+    value" que devuelve Dolibarr al actualizar extrafields via REST.
+
     Args:
         product_id: ID del producto en Dolibarr.
-        data:       campos a actualizar.
+        data:       campos a actualizar (puede incluir array_options).
 
     Returns:
         Respuesta estándar con el producto actualizado.
     """
+    array_options: dict = data.pop("array_options", None) or {}
+
     svc = await _get_service_async()
     try:
         updated = await svc.update_product(product_id, data)
@@ -492,6 +613,24 @@ async def update_product(product_id: int, data: dict) -> JSONResponse:
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=str(exc),
         )
+
+    if array_options:
+        try:
+            db = await _get_extrafield_db()
+            await db.update_product_extrafields(
+                product_id=product_id,
+                array_options=array_options,
+                elementtype="product",
+            )
+        except HTTPException:
+            pass  # BD no configurada — extrafields omitidos sin romper la respuesta
+        except Exception as exc:
+            logger.warning(
+                "Extrafields no guardados tras actualizar producto",
+                exc_info=exc,
+                extra={"product_id": product_id},
+            )
+
     return JSONResponse(content=_ok(updated, "Producto actualizado."))
 
 
@@ -564,6 +703,151 @@ async def upload_image(product_id: int, file: UploadFile) -> JSONResponse:
         tmp_path.unlink(missing_ok=True)
 
     return JSONResponse(content=_ok(result, "Imagen subida correctamente."))
+
+
+_MAX_CSV_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+@router_products.post("/csv-preview")
+async def csv_preview(file: UploadFile) -> JSONResponse:
+    """
+    Pre-analiza un CSV de productos y devuelve cabeceras + filas de muestra.
+
+    No requiere conexión a Dolibarr. Sirve para que el frontend construya
+    la UI de mapeo de columnas antes de lanzar la importación real.
+
+    Args:
+        file: archivo CSV (multipart).
+
+    Returns:
+        CsvImportPreview con headers, preview (≤5 filas) y total_rows.
+    """
+    content = await file.read()
+    if len(content) > _MAX_CSV_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"El CSV supera el límite de 10 MB ({len(content)} bytes).",
+        )
+
+    svc = DolibarrProductService.__new__(DolibarrProductService)
+    try:
+        preview_data = svc.parse_csv_preview(content, preview_rows=5)
+    except Exception as exc:
+        logger.error("Error pre-analizando CSV", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"No se pudo parsear el CSV: {exc}",
+        )
+
+    result = CsvImportPreview(**preview_data)
+    return JSONResponse(content=_ok(result.model_dump(), "CSV analizado."))
+
+
+@router_products.post("/import")
+async def import_from_csv(
+    file: UploadFile,
+    mapping: str = Form(...),
+    overwrite: bool = Form(default=False),
+) -> JSONResponse:
+    """
+    Importa productos en masa a Dolibarr desde un CSV con mapeo de columnas.
+
+    El campo ``mapping`` debe ser un JSON que mapea nombre_columna_csv →
+    campo_dolibarr (e.g. ``{"Referencia": "ref", "Nombre": "label"}``).
+    El campo ``ref`` es obligatorio en el mapeo.
+
+    Args:
+        file:      CSV de productos (multipart).
+        mapping:   JSON string con el mapeo columna → campo Dolibarr.
+        overwrite: si True, actualiza productos que ya existen en Dolibarr.
+
+    Returns:
+        CsvImportResponse con contadores (created/updated/skipped/errors) y resultados por fila.
+    """
+    content = await file.read()
+    if len(content) > _MAX_CSV_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"El CSV supera el límite de 10 MB ({len(content)} bytes).",
+        )
+
+    try:
+        mapping_dict: dict[str, str] = json.loads(mapping)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"El campo 'mapping' no es JSON válido: {exc}",
+        )
+
+    if not any(v == "ref" for v in mapping_dict.values()):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="El mapeo debe incluir al menos una columna asignada al campo 'ref'.",
+        )
+
+    svc = await _get_service_async()
+
+    logger.info(
+        "Iniciando importación CSV a Dolibarr",
+        extra={"mapped_fields": len(mapping_dict), "overwrite": overwrite},
+    )
+
+    try:
+        rows = await svc.import_from_csv(content, mapping=mapping_dict, overwrite=overwrite)
+    except Exception as exc:
+        logger.error("Error en importación CSV Dolibarr", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error durante la importación: {exc}",
+        )
+
+    created = sum(1 for r in rows if r["action"] == "created")
+    updated = sum(1 for r in rows if r["action"] == "updated")
+    skipped = sum(1 for r in rows if r["action"] == "skipped")
+    errors = sum(1 for r in rows if r["action"] == "error")
+
+    response = CsvImportResponse(
+        total=len(rows),
+        created=created,
+        updated=updated,
+        skipped=skipped,
+        errors=errors,
+        results=[CsvImportRowResult(**r) for r in rows],
+    )
+
+    logger.info(
+        "Importación CSV Dolibarr completada",
+        extra={"total": len(rows), "created": created, "updated": updated, "errors": errors},
+    )
+
+    return JSONResponse(content=_ok(response.model_dump(), f"Importación completada: {len(rows)} filas procesadas."))
+
+
+@router_products.get("/{product_id}")
+async def get_product(product_id: int) -> JSONResponse:
+    """
+    Obtiene un producto de Dolibarr por su ID.
+
+    Args:
+        product_id: ID del producto en Dolibarr.
+
+    Returns:
+        Respuesta estándar con los datos del producto.
+    """
+    svc = await _get_service_async()
+    try:
+        product = await svc.get_product(product_id)
+    except IntegrationError as exc:
+        if exc.status_code == 404:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Producto {product_id} no encontrado en Dolibarr.",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content=_ok(product, "Producto obtenido."))
 
 
 @router_products.post("/sync")
@@ -2019,3 +2303,244 @@ async def transfer_stock(data: dict) -> JSONResponse:
         content=_ok(result, "Transferencia de stock completada."),
         status_code=status.HTTP_201_CREATED,
     )
+
+
+# ── Campos extra (extrafields) ────────────────────────────────────────────
+
+extrafields_router = APIRouter(prefix="/dolibarr/extrafields", tags=["dolibarr-extrafields"])
+
+
+async def _get_extrafield_service() -> DolibarrExtraFieldService:
+    """
+    Construye y devuelve una instancia de DolibarrExtraFieldService.
+    Lee credenciales desde Redis o .env.
+    Si DOLIBARR_DB_* está configurado, adjunta DolibarrExtraFieldDB como fallback
+    para cuando la REST API devuelve 501.
+
+    Raises:
+        HTTPException 503: si Dolibarr no está configurado.
+    """
+    from services.integrations.dolibarr.extrafields_db import DolibarrExtraFieldDB
+
+    settings = get_settings()
+    try:
+        url, api_key = await _get_dolibarr_credentials()
+        client = DolibarrClient(settings, override_url=url, override_api_key=api_key)
+    except IntegrationNotConfiguredError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_NOT_CONFIGURED_MSG,
+        )
+
+    db_fallback = None
+    try:
+        db_cfg = await _get_dolibarr_db_config()
+        if db_cfg.get("host", "").strip() and db_cfg.get("db_name", "").strip() and db_cfg.get("user", "").strip():
+            db_fallback = DolibarrExtraFieldDB(
+                settings,
+                override_host=db_cfg.get("host", ""),
+                override_port=db_cfg.get("port"),
+                override_db=db_cfg.get("db_name", ""),
+                override_user=db_cfg.get("user", ""),
+                override_pass=db_cfg.get("password", ""),
+                override_prefix=db_cfg.get("prefix", ""),
+            )
+    except Exception as exc:
+        logger.warning("DB fallback para extrafields no disponible", exc_info=exc)
+
+    return DolibarrExtraFieldService(client, db_fallback=db_fallback)
+
+
+@extrafields_router.get("")
+async def list_extrafields(
+    elementtype: str = Query(default="product"),
+) -> JSONResponse:
+    """
+    Lista los campos extra configurados para un tipo de elemento Dolibarr.
+
+    Usa BD directa como fuente primaria (no requiere REST API configurada).
+    Solo recurre a la REST API si la BD no está configurada.
+
+    Args:
+        elementtype: tipo de elemento (product, societe, facture, etc.).
+
+    Returns:
+        Respuesta estándar con lista de campos extra.
+    """
+    # DB-direct path — does not require Dolibarr REST API credentials
+    try:
+        db = await _get_extrafield_db()
+        fields = await db.list_extrafields(elementtype=elementtype)
+        return JSONResponse(content=_ok(fields, f"{len(fields)} campos extra encontrados."))
+    except HTTPException as exc:
+        if "BD_NO_CONFIGURADA" not in str(exc.detail):
+            raise
+    except Exception as exc:
+        logger.error("Error listando extrafields via BD Dolibarr", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Error al conectar con la BD de Dolibarr: {exc}",
+        )
+
+    # Fallback: REST API when DB is not configured
+    try:
+        svc = await _get_extrafield_service()
+        fields = await svc.list_extrafields(elementtype=elementtype)
+    except IntegrationError as exc:
+        logger.error("Error listando extrafields Dolibarr via REST", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    return JSONResponse(content=_ok(fields, f"{len(fields)} campos extra encontrados."))
+
+
+async def _get_extrafield_db() -> "DolibarrExtraFieldDB":
+    """
+    Construye DolibarrExtraFieldDB con credenciales desde Redis o .env.
+
+    La lógica de creación/eliminación de campos extra siempre usa BD directa
+    porque la REST API de Dolibarr no soporta este operación en todas las versiones.
+    Es exactamente la misma lógica usada para crear los campos de prueba.
+
+    Raises:
+        HTTPException 400: si las credenciales de BD no están configuradas.
+        HTTPException 503: si no se puede conectar a la BD.
+    """
+    from services.integrations.dolibarr.extrafields_db import DolibarrExtraFieldDB
+
+    settings = get_settings()
+    db_cfg = await _get_dolibarr_db_config()
+
+    host = db_cfg.get("host", "").strip()
+    db_name = db_cfg.get("db_name", "").strip()
+    user = db_cfg.get("user", "").strip()
+
+    if not host or not db_name or not user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "BD_NO_CONFIGURADA: Para crear o eliminar campos extra necesitas configurar "
+                "el acceso directo a la base de datos MySQL de Dolibarr. "
+                "Ve a la pestaña Configuración → BD Dolibarr e introduce: "
+                "host, puerto, nombre de BD, usuario y contraseña."
+            ),
+        )
+
+    try:
+        return DolibarrExtraFieldDB(
+            settings,
+            override_host=host,
+            override_port=db_cfg.get("port"),
+            override_db=db_name,
+            override_user=user,
+            override_pass=db_cfg.get("password", ""),
+            override_prefix=db_cfg.get("prefix", ""),
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"BD_NO_CONFIGURADA: {exc}",
+        )
+
+
+@extrafields_router.post("", status_code=status.HTTP_201_CREATED)
+async def create_extrafield(request: DolibarrExtraFieldCreate) -> JSONResponse:
+    """
+    Crea un nuevo campo extra en Dolibarr via acceso directo a BD MySQL.
+
+    Replica exactamente la lógica de los scripts de prueba:
+      1. INSERT en llx_extrafields (definición del campo)
+      2. ALTER TABLE llx_{element}_extrafields ADD COLUMN (columna de datos)
+
+    El campo queda disponible de inmediato en la interfaz de Dolibarr
+    y aparece automáticamente en el formulario dinámico de Harvist.
+
+    Args:
+        request: DolibarrExtraFieldCreate con los datos del nuevo campo.
+
+    Returns:
+        Respuesta estándar (201) con la definición del campo creado.
+    """
+    if not request.attrname or not request.attrname.replace("_", "").isalnum():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Nombre interno '{request.attrname}' inválido: solo letras, números y guión bajo.",
+        )
+
+    db = await _get_extrafield_db()
+
+    try:
+        created = await db.create_extrafield(
+            attrname=request.attrname.lower(),
+            label=request.label,
+            field_type=request.type,
+            elementtype=request.elementtype,
+            size=request.size,
+            required=request.required,
+            field_default=request.fielddefault,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        )
+    except RuntimeError as exc:
+        logger.error("Error creando extrafield via BD Dolibarr", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(exc),
+        )
+    except Exception as exc:
+        logger.error("Error inesperado creando extrafield: %s: %s", type(exc).__name__, exc, exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"{type(exc).__name__}: {exc}",
+        )
+
+    logger.info(
+        "Campo extra creado desde dashboard",
+        extra={"attrname": request.attrname, "elementtype": request.elementtype, "type": request.type},
+    )
+    return JSONResponse(
+        content=_ok(created, f"Campo extra '{request.attrname}' creado correctamente."),
+        status_code=status.HTTP_201_CREATED,
+    )
+
+
+@extrafields_router.delete("/{attrname}")
+async def delete_extrafield(
+    attrname: str,
+    elementtype: str = Query(default="product"),
+) -> JSONResponse:
+    """
+    Elimina un campo extra de Dolibarr via acceso directo a BD MySQL.
+
+    Replica exactamente la lógica de los scripts de prueba:
+      1. DELETE de llx_extrafields
+      2. ALTER TABLE llx_{element}_extrafields DROP COLUMN
+
+    Args:
+        attrname:    nombre interno del campo a eliminar.
+        elementtype: tipo de elemento al que pertenece el campo.
+
+    Returns:
+        Respuesta estándar con confirmación de eliminación.
+    """
+    db = await _get_extrafield_db()
+
+    try:
+        await db.delete_extrafield(attrname=attrname, elementtype=elementtype)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        )
+    except RuntimeError as exc:
+        logger.error("Error eliminando extrafield via BD Dolibarr", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(exc),
+        )
+
+    return JSONResponse(content={"success": True, "message": f"Campo extra '{attrname}' eliminado."})

--- a/api/v1/router.py
+++ b/api/v1/router.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter
 
 from api.v1.endpoints.dolibarr import (
     categories_router,
+    extrafields_router,
     invoices_router,
     orders_router,
     router_main as dolibarr_router_main,
@@ -37,3 +38,4 @@ router.include_router(thirdparties_router)
 router.include_router(orders_router)
 router.include_router(invoices_router)
 router.include_router(stocks_router)
+router.include_router(extrafields_router)

--- a/api/v1/schemas/integrations.py
+++ b/api/v1/schemas/integrations.py
@@ -54,3 +54,91 @@ class DolibarrConfigResponse(BaseModel):
     url: str
     api_key: str
     configured: bool
+
+
+class DolibarrDBConfigRequest(BaseModel):
+    """Petición para guardar credenciales de BD de Dolibarr."""
+
+    host: str = Field(..., min_length=1, description="Host MySQL/MariaDB.")
+    port: int = Field(default=3306, ge=1, le=65535)
+    db_name: str = Field(..., min_length=1, description="Nombre de la base de datos.")
+    user: str = Field(..., min_length=1, description="Usuario MySQL.")
+    password: str = Field(default="", description="Contraseña MySQL.")
+    prefix: str = Field(default="llx_", description="Prefijo de tablas Dolibarr.")
+
+
+class DolibarrDBConfigResponse(BaseModel):
+    """Respuesta con configuración de BD de Dolibarr."""
+
+    host: str
+    port: int
+    db_name: str
+    user: str
+    password: str
+    prefix: str
+    configured: bool
+
+
+class DolibarrExtraFieldCreate(BaseModel):
+    """Petición para crear un campo extra en Dolibarr."""
+
+    attrname: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Nombre interno del campo (minúsculas, sin espacios).",
+    )
+    label: str = Field(..., min_length=1, description="Etiqueta visible en la interfaz.")
+    type: str = Field(
+        default="varchar",
+        description="Tipo de campo Dolibarr: varchar, int, double, price, date, select, boolean, text, html.",
+    )
+    elementtype: str = Field(
+        default="product",
+        description="Tipo de elemento Dolibarr: product, societe, facture, etc.",
+    )
+    size: str = Field(default="255", description="Tamaño del campo (relevante para varchar).")
+    required: bool = Field(default=False, description="Si el campo es obligatorio.")
+    fielddefault: str = Field(default="", description="Valor por defecto.")
+
+
+class DolibarrExtraField(BaseModel):
+    """Definición de un campo extra de Dolibarr."""
+
+    attrname: str
+    label: str
+    type: str
+    type_normalized: str
+    elementtype: str
+    size: str
+    required: bool
+    fielddefault: str
+
+
+class CsvImportPreview(BaseModel):
+    """Resultado del pre-análisis de un CSV de productos para importación masiva."""
+
+    headers: list[str]
+    preview: list[dict[str, str]]
+    total_rows: int
+
+
+class CsvImportRowResult(BaseModel):
+    """Resultado de importar una fila del CSV a Dolibarr."""
+
+    row: int
+    ref: str
+    action: str
+    dolibarr_id: int | None = None
+    error: str | None = None
+
+
+class CsvImportResponse(BaseModel):
+    """Resumen completo de una importación masiva de CSV a Dolibarr."""
+
+    total: int
+    created: int
+    updated: int
+    skipped: int
+    errors: int
+    results: list[CsvImportRowResult]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -24,6 +24,12 @@ import {
   type OrderType,
   type InvoiceType,
   type DolibarrFieldSchema,
+  type DolibarrDBConfig,
+  type DolibarrDBConfigCreate,
+  type DolibarrExtraField,
+  type DolibarrExtraFieldCreate,
+  type CsvImportPreview,
+  type CsvImportResponse,
 } from '@/types/dolibarr'
 
 /** Estructura estándar de respuesta de la API */
@@ -781,5 +787,119 @@ export async function getDolibarrProductStock(
       }>
     }>
   >(`/dolibarr/stocks/products/${productId}`)
+  return response.data.data
+}
+
+/**
+ * Lista los campos extra configurados en Dolibarr para un tipo de elemento.
+ *
+ * @author Carlitos6712
+ * @param elementtype - Tipo de elemento (product, societe, etc.).
+ * @returns Lista de campos extra con su definición.
+ */
+export async function listDolibarrExtraFields(
+  elementtype = 'product',
+): Promise<DolibarrExtraField[]> {
+  const response = await apiClient.get<ApiResponse<DolibarrExtraField[]>>(
+    '/dolibarr/extrafields',
+    { params: { elementtype } },
+  )
+  return response.data.data
+}
+
+/**
+ * Crea un nuevo campo extra en Dolibarr.
+ *
+ * @author Carlitos6712
+ * @param data - Definición del nuevo campo extra.
+ * @returns Campo extra creado.
+ */
+export async function createDolibarrExtraField(
+  data: DolibarrExtraFieldCreate,
+): Promise<DolibarrExtraField> {
+  const response = await apiClient.post<ApiResponse<DolibarrExtraField>>(
+    '/dolibarr/extrafields',
+    data,
+  )
+  return response.data.data
+}
+
+/**
+ * Elimina un campo extra de Dolibarr.
+ *
+ * @author Carlitos6712
+ * @param attrname - Nombre interno del campo a eliminar.
+ * @param elementtype - Tipo de elemento al que pertenece.
+ */
+export async function deleteDolibarrExtraField(
+  attrname: string,
+  elementtype = 'product',
+): Promise<void> {
+  await apiClient.delete(`/dolibarr/extrafields/${attrname}`, {
+    params: { elementtype },
+  })
+}
+
+/**
+ * Obtiene la configuración de BD directa de Dolibarr guardada en Redis.
+ *
+ * @author Carlitos6712
+ */
+export async function getDolibarrDBConfig(): Promise<DolibarrDBConfig> {
+  const response = await apiClient.get<DolibarrDBConfig>('/dolibarr/db-config')
+  return response.data
+}
+
+/**
+ * Guarda las credenciales de BD directa de Dolibarr en Redis.
+ *
+ * @author Carlitos6712
+ * @param data - Credenciales de acceso a MySQL/MariaDB.
+ */
+export async function saveDolibarrDBConfig(data: DolibarrDBConfigCreate): Promise<DolibarrDBConfig> {
+  const response = await apiClient.post<DolibarrDBConfig>('/dolibarr/db-config', data)
+  return response.data
+}
+
+/**
+ * Pre-analiza un CSV de productos: devuelve cabeceras, filas de muestra y total.
+ *
+ * @author BenjaminDTS | Carlos Vico
+ * @param file - Archivo CSV seleccionado por el usuario.
+ * @returns CsvImportPreview con headers, preview y total_rows.
+ */
+export async function previewDolibarrCsv(file: File): Promise<CsvImportPreview> {
+  const form = new FormData()
+  form.append('file', file)
+  const response = await apiClient.post<ApiResponse<CsvImportPreview>>(
+    '/dolibarr/products/csv-preview',
+    form,
+  )
+  return response.data.data
+}
+
+/**
+ * Importa productos en masa a Dolibarr desde un CSV con mapeo de columnas.
+ *
+ * @author BenjaminDTS | Carlos Vico
+ * @param file      - Archivo CSV.
+ * @param mapping   - Mapeo columna_csv → campo_dolibarr.
+ * @param overwrite - Si true, actualiza productos existentes.
+ * @returns CsvImportResponse con contadores y resultados por fila.
+ */
+export async function importDolibarrCsv(
+  file: File,
+  mapping: Record<string, string>,
+  overwrite: boolean,
+): Promise<CsvImportResponse> {
+  const form = new FormData()
+  form.append('file', file)
+  form.append('mapping', JSON.stringify(mapping))
+  form.append('overwrite', String(overwrite))
+  const response = await apiClient.post<ApiResponse<CsvImportResponse>>(
+    '/dolibarr/products/import',
+    form,
+    { timeout: 120_000 },
+  )
   return response.data.data
 }

--- a/frontend/src/components/dolibarr/DolibarrConfig.tsx
+++ b/frontend/src/components/dolibarr/DolibarrConfig.tsx
@@ -1,11 +1,14 @@
 /**
  * Panel de configuración de Dolibarr.
- * Permite guardar URL y API Key en la interfaz gráfica.
+ * Permite guardar URL, API Key y credenciales de BD MariaDB/MySQL
+ * desde la interfaz gráfica, sin editar variables de entorno.
  *
- * @author BenjaminDTS
+ * @author BenjaminDTS | Carlitos6712
  */
 import { useEffect, useState } from 'react'
 import { apiClient } from '@/api/client'
+import { getDolibarrDBConfig, saveDolibarrDBConfig } from '@/api/client'
+import type { DolibarrDBConfig, DolibarrDBConfigCreate } from '@/types/dolibarr'
 
 interface DolibarrConfigData {
   url: string
@@ -18,56 +21,119 @@ interface Props {
   onSaved?: () => void
 }
 
+const INPUT_CLS =
+  'w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-sm'
+const LABEL_CLS = 'block text-sm font-medium text-gray-700 mb-1'
+
 export default function DolibarrConfig({ className = '', onSaved }: Props) {
+  // ── API config ──────────────────────────────────────────────────────────
   const [url, setUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
-  const [message, setMessage] = useState({ type: '', text: '' })
+  const [apiMessage, setApiMessage] = useState({ type: '', text: '' })
 
-  // Cargar config guardada
+  // ── DB config ───────────────────────────────────────────────────────────
+  const [dbConfig, setDbConfig] = useState<DolibarrDBConfigCreate>({
+    host: '',
+    port: 3306,
+    db_name: '',
+    user: '',
+    password: '',
+    prefix: 'llx_',
+  })
+  const [dbConfigured, setDbConfigured] = useState(false)
+  const [savingDb, setSavingDb] = useState(false)
+  const [dbMessage, setDbMessage] = useState({ type: '', text: '' })
+  const [showDbSection, setShowDbSection] = useState(false)
+
   useEffect(() => {
     ;(async () => {
       try {
         setLoading(true)
-        const res = await apiClient.get<DolibarrConfigData>('/dolibarr/config')
-        if (res.data) {
-          setUrl(res.data.url || '')
-          setApiKey(res.data.api_key || '')
+        const [apiRes, dbRes] = await Promise.allSettled([
+          apiClient.get<DolibarrConfigData>('/dolibarr/config'),
+          getDolibarrDBConfig(),
+        ])
+
+        if (apiRes.status === 'fulfilled' && apiRes.value.data) {
+          setUrl(apiRes.value.data.url || '')
+          setApiKey(apiRes.value.data.api_key || '')
+        }
+
+        if (dbRes.status === 'fulfilled') {
+          const db: DolibarrDBConfig = dbRes.value
+          setDbConfigured(db.configured)
+          if (db.configured) {
+            setDbConfig({
+              host: db.host,
+              port: db.port,
+              db_name: db.db_name,
+              user: db.user,
+              password: db.password,
+              prefix: db.prefix,
+            })
+          }
         }
       } catch (err) {
         console.error('Error cargando config Dolibarr:', err)
-        setMessage({ type: 'error', text: 'Error al cargar configuración' })
+        setApiMessage({ type: 'error', text: 'Error al cargar configuración' })
       } finally {
         setLoading(false)
       }
     })()
   }, [])
 
-  const handleSave = async () => {
+  const handleSaveApi = async () => {
     if (!url.trim() || !apiKey.trim()) {
-      setMessage({ type: 'error', text: 'URL y API Key son requeridas' })
+      setApiMessage({ type: 'error', text: 'URL y API Key son requeridas' })
       return
     }
-
     try {
       setSaving(true)
-      const res = await apiClient.post<DolibarrConfigData>('/dolibarr/config', {
+      await apiClient.post<DolibarrConfigData>('/dolibarr/config', {
         url: url.trim(),
         api_key: apiKey.trim(),
       })
-
-      if (res.data) {
-        setMessage({ type: 'success', text: 'Configuración guardada correctamente ✓' })
-        onSaved?.()
-      }
+      setApiMessage({ type: 'success', text: 'Configuración guardada correctamente ✓' })
+      onSaved?.()
     } catch (err) {
       console.error('Error guardando config:', err)
-      setMessage({ type: 'error', text: 'Error al guardar configuración' })
+      setApiMessage({ type: 'error', text: 'Error al guardar configuración' })
     } finally {
       setSaving(false)
     }
   }
+
+  const handleSaveDB = async () => {
+    if (!dbConfig.host.trim() || !dbConfig.db_name.trim() || !dbConfig.user.trim()) {
+      setDbMessage({ type: 'error', text: 'Host, nombre de BD y usuario son obligatorios.' })
+      return
+    }
+    try {
+      setSavingDb(true)
+      setDbMessage({ type: '', text: '' })
+      await saveDolibarrDBConfig(dbConfig)
+      setDbConfigured(true)
+      setDbMessage({
+        type: 'success',
+        text: 'Credenciales de BD guardadas ✓ — Harvist usará acceso directo a MariaDB como fallback.',
+      })
+    } catch (err) {
+      console.error('Error guardando config BD:', err)
+      setDbMessage({
+        type: 'error',
+        text: (err as Error).message ?? 'Error al guardar credenciales de BD',
+      })
+    } finally {
+      setSavingDb(false)
+    }
+  }
+
+  const setDb = <K extends keyof DolibarrDBConfigCreate>(
+    key: K,
+    value: DolibarrDBConfigCreate[K],
+  ) => setDbConfig((prev) => ({ ...prev, [key]: value }))
 
   if (loading) {
     return (
@@ -81,89 +147,213 @@ export default function DolibarrConfig({ className = '', onSaved }: Props) {
 
   return (
     <div className={`p-6 ${className}`}>
-      <div className="max-w-xl">
-        <h3 className="text-lg font-semibold text-gray-900 mb-6">Configuración Dolibarr</h3>
+      <div className="max-w-xl space-y-10">
 
-        {/* Advertencia informativa */}
-        <div className="bg-blue-50 border-l-4 border-blue-400 p-4 mb-6 rounded">
-          <p className="text-sm text-blue-800">
-            Ingresa la URL base de tu instancia Dolibarr y la API Key. Estos datos se guardan
-            localmente y se utilizan para conectar con Dolibarr.
-          </p>
-        </div>
+        {/* ── Sección API ──────────────────────────────────────────────── */}
+        <section>
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">Conexión API REST</h3>
 
-        {/* Formulario */}
-        <div className="space-y-4">
-          {/* URL */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              URL de Dolibarr
-            </label>
-            <input
-              type="url"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              placeholder="https://mi-dolibarr.com"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-            />
-            <p className="text-xs text-gray-500 mt-1">
-              Ejemplo: https://dolibarr.ejemplo.com (sin barra final)
-            </p>
+          <div className="bg-blue-50 border-l-4 border-blue-400 p-4 mb-5 rounded text-sm text-blue-800">
+            URL base de tu instancia Dolibarr y API Key para conectar via REST.
           </div>
 
-          {/* API Key */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              API Key
-            </label>
-            <input
-              type="password"
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-              placeholder="Pega tu API Key aquí"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-            />
-            <p className="text-xs text-gray-500 mt-1">
-              Obtén la API Key en: Inicio → Configuración → API/REST → Generar clave
-            </p>
-          </div>
-
-          {/* Mensaje de estado */}
-          {message.text && (
-            <div
-              className={`p-3 rounded text-sm ${
-                message.type === 'success'
-                  ? 'bg-green-50 text-green-800 border border-green-200'
-                  : 'bg-red-50 text-red-800 border border-red-200'
-              }`}
-            >
-              {message.text}
+          <div className="space-y-4">
+            <div>
+              <label className={LABEL_CLS}>URL de Dolibarr</label>
+              <input
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://mi-dolibarr.com"
+                className={INPUT_CLS}
+              />
+              <p className="text-xs text-gray-500 mt-1">Sin barra final</p>
             </div>
-          )}
 
-          {/* Botón guardar */}
-          <div className="flex gap-2 pt-2">
+            <div>
+              <label className={LABEL_CLS}>API Key</label>
+              <input
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="Pega tu API Key aquí"
+                className={INPUT_CLS}
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                Inicio → Configuración → API/REST → Generar clave
+              </p>
+            </div>
+
+            {apiMessage.text && (
+              <div
+                className={`p-3 rounded text-sm ${
+                  apiMessage.type === 'success'
+                    ? 'bg-green-50 text-green-800 border border-green-200'
+                    : 'bg-red-50 text-red-800 border border-red-200'
+                }`}
+              >
+                {apiMessage.text}
+              </div>
+            )}
+
             <button
-              onClick={handleSave}
+              onClick={handleSaveApi}
               disabled={saving}
-              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-sm transition-colors"
+              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 font-medium text-sm transition-colors"
             >
-              {saving ? 'Guardando...' : 'Guardar Configuración'}
+              {saving ? 'Guardando...' : 'Guardar configuración API'}
             </button>
           </div>
-        </div>
+        </section>
 
-        {/* Info de ayuda */}
-        <div className="mt-8 pt-6 border-t border-gray-200">
-          <h4 className="text-sm font-semibold text-gray-900 mb-3">¿Cómo obtener las credenciales?</h4>
-          <ol className="text-sm text-gray-600 space-y-2">
+        {/* ── Sección BD directa ───────────────────────────────────────── */}
+        <section>
+          <button
+            onClick={() => setShowDbSection((v) => !v)}
+            className="flex items-center gap-2 w-full text-left"
+          >
+            <h3 className="text-lg font-semibold text-gray-900">
+              Acceso directo a BD (MariaDB / MySQL)
+            </h3>
+            {dbConfigured && (
+              <span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs rounded-full font-medium">
+                Configurado
+              </span>
+            )}
+            <svg
+              className={`ml-auto h-5 w-5 text-gray-400 transition-transform ${showDbSection ? 'rotate-180' : ''}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          {showDbSection && (
+            <div className="mt-4 space-y-4">
+              <div className="bg-amber-50 border-l-4 border-amber-400 p-4 rounded text-sm text-amber-800 space-y-1">
+                <p className="font-medium">¿Para qué sirve esto?</p>
+                <p>
+                  Algunas versiones de Dolibarr no exponen el endpoint REST de campos extra.
+                  Con acceso directo a MariaDB, Harvist puede crear y listar campos extra
+                  sin depender de la API. Solo se usa como <strong>fallback</strong> cuando
+                  la API devuelve error.
+                </p>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className={LABEL_CLS}>
+                    Host <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={dbConfig.host}
+                    onChange={(e) => setDb('host', e.target.value)}
+                    placeholder="localhost o IP del servidor"
+                    className={INPUT_CLS}
+                  />
+                </div>
+                <div>
+                  <label className={LABEL_CLS}>Puerto</label>
+                  <input
+                    type="number"
+                    value={dbConfig.port}
+                    onChange={(e) => setDb('port', Number(e.target.value))}
+                    min={1}
+                    max={65535}
+                    className={INPUT_CLS}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className={LABEL_CLS}>
+                  Nombre de la BD <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={dbConfig.db_name}
+                  onChange={(e) => setDb('db_name', e.target.value)}
+                  placeholder="dolibarr"
+                  className={INPUT_CLS}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className={LABEL_CLS}>
+                    Usuario <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={dbConfig.user}
+                    onChange={(e) => setDb('user', e.target.value)}
+                    placeholder="dolibarr_user"
+                    className={INPUT_CLS}
+                  />
+                </div>
+                <div>
+                  <label className={LABEL_CLS}>Contraseña</label>
+                  <input
+                    type="password"
+                    value={dbConfig.password}
+                    onChange={(e) => setDb('password', e.target.value)}
+                    placeholder="••••••••"
+                    className={INPUT_CLS}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className={LABEL_CLS}>Prefijo de tablas</label>
+                <input
+                  type="text"
+                  value={dbConfig.prefix}
+                  onChange={(e) => setDb('prefix', e.target.value)}
+                  placeholder="llx_"
+                  className={INPUT_CLS}
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  Por defecto <code className="bg-gray-100 px-1 rounded">llx_</code> en todas las instalaciones estándar de Dolibarr
+                </p>
+              </div>
+
+              {dbMessage.text && (
+                <div
+                  className={`p-3 rounded text-sm ${
+                    dbMessage.type === 'success'
+                      ? 'bg-green-50 text-green-800 border border-green-200'
+                      : 'bg-red-50 text-red-800 border border-red-200'
+                  }`}
+                >
+                  {dbMessage.text}
+                </div>
+              )}
+
+              <button
+                onClick={handleSaveDB}
+                disabled={savingDb}
+                className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 disabled:opacity-50 font-medium text-sm transition-colors"
+              >
+                {savingDb ? 'Guardando...' : 'Guardar credenciales BD'}
+              </button>
+            </div>
+          )}
+        </section>
+
+        {/* ── Ayuda ────────────────────────────────────────────────────── */}
+        <section className="pt-4 border-t border-gray-200">
+          <h4 className="text-sm font-semibold text-gray-900 mb-3">¿Cómo obtener las credenciales API?</h4>
+          <ol className="text-sm text-gray-600 space-y-1">
             <li>1. Accede a tu instancia Dolibarr como administrador</li>
             <li>2. Navega a Inicio → Configuración → API/REST</li>
-            <li>3. En la sección "Gestión de tokens", pulsa "Crear una nueva clave API"</li>
+            <li>3. En "Gestión de tokens", pulsa "Crear una nueva clave API"</li>
             <li>4. Copia la clave generada y pégala aquí</li>
-            <li>5. La URL es simplemente tu dominio de Dolibarr (ej: https://mi-dolibarr.com)</li>
           </ol>
-        </div>
+        </section>
+
       </div>
     </div>
   )

--- a/frontend/src/components/dolibarr/DolibarrExtraFields.tsx
+++ b/frontend/src/components/dolibarr/DolibarrExtraFields.tsx
@@ -1,0 +1,453 @@
+/**
+ * Módulo de gestión de campos extra (extrafields) de Dolibarr.
+ *
+ * Permite crear, visualizar y eliminar atributos personalizados
+ * para productos. Los cambios se reflejan de inmediato tanto en
+ * Harvist como en la interfaz de Dolibarr.
+ *
+ * @author Carlitos6712
+ */
+import { useEffect, useState } from 'react'
+import {
+  listDolibarrExtraFields,
+  createDolibarrExtraField,
+  deleteDolibarrExtraField,
+} from '@/api/client'
+import { type DolibarrExtraField, type DolibarrExtraFieldCreate } from '@/types/dolibarr'
+
+const SUPPORTED_TYPES: Array<{ value: string; label: string }> = [
+  { value: 'varchar', label: 'Texto corto (varchar)' },
+  { value: 'text', label: 'Texto largo' },
+  { value: 'int', label: 'Número entero (int)' },
+  { value: 'double', label: 'Número decimal (double)' },
+  { value: 'price', label: 'Precio' },
+  { value: 'date', label: 'Fecha' },
+  { value: 'datetime', label: 'Fecha y hora' },
+  { value: 'boolean', label: 'Sí / No (boolean)' },
+  { value: 'select', label: 'Lista desplegable (select)' },
+  { value: 'html', label: 'HTML / Editor rico' },
+  { value: 'phone', label: 'Teléfono' },
+  { value: 'mail', label: 'Email' },
+  { value: 'url', label: 'URL' },
+]
+
+const ELEMENTTYPE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'product', label: 'Productos' },
+  { value: 'societe', label: 'Terceros' },
+  { value: 'facture', label: 'Facturas cliente' },
+  { value: 'facture_fourn', label: 'Facturas proveedor' },
+  { value: 'commande', label: 'Pedidos cliente' },
+  { value: 'commande_fournisseur', label: 'Pedidos proveedor' },
+]
+
+const TYPE_BADGE: Record<string, string> = {
+  varchar: 'bg-blue-100 text-blue-800',
+  text: 'bg-blue-100 text-blue-800',
+  html: 'bg-purple-100 text-purple-800',
+  int: 'bg-green-100 text-green-800',
+  double: 'bg-green-100 text-green-800',
+  price: 'bg-green-100 text-green-800',
+  date: 'bg-yellow-100 text-yellow-800',
+  datetime: 'bg-yellow-100 text-yellow-800',
+  boolean: 'bg-gray-100 text-gray-800',
+  select: 'bg-orange-100 text-orange-800',
+  phone: 'bg-blue-100 text-blue-800',
+  mail: 'bg-blue-100 text-blue-800',
+  url: 'bg-blue-100 text-blue-800',
+}
+
+const INPUT_CLS =
+  'w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm'
+const LABEL_CLS = 'block text-xs font-medium text-gray-700 mb-1'
+
+export default function DolibarrExtraFields() {
+  const [fields, setFields] = useState<DolibarrExtraField[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [dbNotConfigured, setDbNotConfigured] = useState(false)
+  const [elementtype, setElementtype] = useState('product')
+  const [showCreateModal, setShowCreateModal] = useState(false)
+
+  const loadFields = async (et = elementtype) => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await listDolibarrExtraFields(et)
+      setFields(data)
+    } catch (err) {
+      setError((err as Error).message ?? 'Error cargando campos extra')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadFields(elementtype)
+  }, [elementtype])
+
+  const handleDelete = async (attrname: string) => {
+    if (!confirm(`¿Eliminar el campo extra "${attrname}"? Esta acción no se puede deshacer.`))
+      return
+    try {
+      await deleteDolibarrExtraField(attrname, elementtype)
+      loadFields(elementtype)
+    } catch (err) {
+      const msg = (err as Error).message ?? 'Error eliminando campo extra'
+      if (msg.includes('BD_NO_CONFIGURADA')) setDbNotConfigured(true)
+      else setError(msg)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap gap-4 items-center justify-between">
+        <div className="flex items-center gap-3">
+          <label className="text-sm font-medium text-gray-700">Elemento:</label>
+          <select
+            value={elementtype}
+            onChange={(e) => setElementtype(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+          >
+            {ELEMENTTYPE_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          onClick={() => setShowCreateModal(true)}
+          className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors text-sm font-medium"
+        >
+          + Nuevo campo extra
+        </button>
+      </div>
+
+      {dbNotConfigured && (
+        <div className="bg-amber-50 border-l-4 border-amber-500 p-4 rounded text-sm text-amber-900 space-y-2">
+          <p className="font-semibold">Acceso a BD no configurado</p>
+          <p>
+            La creación de campos extra usa acceso directo a MySQL (mismo método que los scripts Python).
+            Configura las credenciales en la pestaña{' '}
+            <strong>Configuración → BD Dolibarr</strong>:
+          </p>
+          <ul className="list-disc list-inside text-xs space-y-1 text-amber-800">
+            <li>Host MySQL (ej: <code>localhost</code>)</li>
+            <li>Puerto (por defecto <code>3306</code>)</li>
+            <li>Nombre de la BD de Dolibarr</li>
+            <li>Usuario y contraseña MySQL</li>
+          </ul>
+          <button
+            onClick={() => setDbNotConfigured(false)}
+            className="text-xs text-amber-700 underline"
+          >
+            Cerrar aviso
+          </button>
+        </div>
+      )}
+
+      <div className="bg-blue-50 border border-blue-200 rounded p-3 text-xs text-blue-700">
+        <strong>Nota:</strong> Los campos se crean via acceso directo a MySQL (INSERT en{' '}
+        <code>llx_extrafields</code> + ALTER TABLE). Requiere credenciales BD en{' '}
+        <strong>Configuración → BD Dolibarr</strong>.
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border-l-4 border-red-400 p-4 rounded text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded-lg border border-gray-200">
+        <table className="w-full">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">
+                Nombre interno
+              </th>
+              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">
+                Etiqueta
+              </th>
+              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Tipo</th>
+              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">
+                Requerido
+              </th>
+              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">
+                Por defecto
+              </th>
+              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">
+                Acciones
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {loading ? (
+              <tr>
+                <td colSpan={6} className="px-6 py-8 text-center text-gray-500 text-sm">
+                  Cargando campos extra...
+                </td>
+              </tr>
+            ) : fields.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-6 py-8 text-center text-gray-500 text-sm">
+                  No hay campos extra configurados para este elemento.
+                </td>
+              </tr>
+            ) : (
+              fields.map((f) => (
+                <tr key={f.attrname} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 text-sm font-mono text-gray-900">{f.attrname}</td>
+                  <td className="px-6 py-4 text-sm text-gray-900">{f.label}</td>
+                  <td className="px-6 py-4 text-sm">
+                    <span
+                      className={`px-2 py-1 rounded text-xs font-medium ${
+                        TYPE_BADGE[f.type] ?? 'bg-gray-100 text-gray-800'
+                      }`}
+                    >
+                      {f.type}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 text-sm">
+                    {f.required ? (
+                      <span className="text-green-600 font-medium">Sí</span>
+                    ) : (
+                      <span className="text-gray-400">No</span>
+                    )}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-500 font-mono">
+                    {f.fielddefault || '—'}
+                  </td>
+                  <td className="px-6 py-4 text-sm">
+                    <button
+                      onClick={() => handleDelete(f.attrname)}
+                      className="text-red-600 hover:text-red-800 text-xs font-medium"
+                    >
+                      Eliminar
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+
+      {showCreateModal && (
+        <CreateExtraFieldModal
+          defaultElementtype={elementtype}
+          onClose={() => setShowCreateModal(false)}
+          onDbNotConfigured={() => {
+            setShowCreateModal(false)
+            setDbNotConfigured(true)
+          }}
+          onSuccess={() => {
+            setShowCreateModal(false)
+            loadFields(elementtype)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+// ── Modal de creación ──────────────────────────────────────────────────────
+
+interface CreateExtraFieldModalProps {
+  defaultElementtype: string
+  onClose: () => void
+  onSuccess: () => void
+  onDbNotConfigured: () => void
+}
+
+const EMPTY_FORM: DolibarrExtraFieldCreate = {
+  attrname: '',
+  label: '',
+  type: 'varchar',
+  elementtype: 'product',
+  size: '255',
+  required: false,
+  fielddefault: '',
+}
+
+function CreateExtraFieldModal({
+  defaultElementtype,
+  onClose,
+  onSuccess,
+  onDbNotConfigured,
+}: CreateExtraFieldModalProps) {
+  const [form, setForm] = useState<DolibarrExtraFieldCreate>({
+    ...EMPTY_FORM,
+    elementtype: defaultElementtype,
+  })
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const set = <K extends keyof DolibarrExtraFieldCreate>(
+    key: K,
+    value: DolibarrExtraFieldCreate[K],
+  ) => setForm((prev) => ({ ...prev, [key]: value }))
+
+  const handleSubmit = async () => {
+    if (!form.attrname || !form.label) {
+      setError('Nombre interno y etiqueta son obligatorios.')
+      return
+    }
+    if (!/^[a-z0-9_]+$/.test(form.attrname)) {
+      setError('Nombre interno: solo minúsculas, números y guión bajo (_).')
+      return
+    }
+    try {
+      setSubmitting(true)
+      setError(null)
+      await createDolibarrExtraField(form)
+      onSuccess()
+    } catch (err) {
+      const msg = (err as Error).message ?? 'Error creando campo extra'
+      if (msg.includes('BD_NO_CONFIGURADA')) {
+        onDbNotConfigured()
+      } else {
+        setError(msg)
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-lg">
+        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900">Nuevo campo extra</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">
+            &times;
+          </button>
+        </div>
+
+        <div className="px-6 py-4 space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className={LABEL_CLS}>
+                Nombre interno <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={form.attrname}
+                onChange={(e) => set('attrname', e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ''))}
+                placeholder="mi_campo"
+                className={INPUT_CLS}
+              />
+              <p className="text-xs text-gray-400 mt-1">Solo minúsculas, números y _</p>
+            </div>
+            <div>
+              <label className={LABEL_CLS}>
+                Etiqueta <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={form.label}
+                onChange={(e) => set('label', e.target.value)}
+                placeholder="Mi campo personalizado"
+                className={INPUT_CLS}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className={LABEL_CLS}>Tipo de campo</label>
+              <select
+                value={form.type}
+                onChange={(e) => set('type', e.target.value)}
+                className={INPUT_CLS}
+              >
+                {SUPPORTED_TYPES.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className={LABEL_CLS}>Elemento Dolibarr</label>
+              <select
+                value={form.elementtype}
+                onChange={(e) => set('elementtype', e.target.value)}
+                className={INPUT_CLS}
+              >
+                {ELEMENTTYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            {form.type === 'varchar' && (
+              <div>
+                <label className={LABEL_CLS}>Tamaño (caracteres)</label>
+                <input
+                  type="number"
+                  value={form.size}
+                  onChange={(e) => set('size', e.target.value)}
+                  min={1}
+                  max={255}
+                  className={INPUT_CLS}
+                />
+              </div>
+            )}
+            <div>
+              <label className={LABEL_CLS}>Valor por defecto</label>
+              <input
+                type="text"
+                value={form.fielddefault}
+                onChange={(e) => set('fielddefault', e.target.value)}
+                className={INPUT_CLS}
+              />
+            </div>
+          </div>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={form.required}
+              onChange={(e) => set('required', e.target.checked)}
+              className="rounded border-gray-300 text-purple-600 focus:ring-purple-500"
+            />
+            <span className="text-sm text-gray-700">Campo obligatorio</span>
+          </label>
+
+          {form.type === 'select' && (
+            <div className="bg-amber-50 border border-amber-200 rounded p-3">
+              <p className="text-xs text-amber-800">
+                Para campos de tipo <strong>select</strong>, añade las opciones desde la interfaz
+                de Dolibarr tras crear el campo (Admin → Otros atributos).
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="px-6 py-4 border-t border-gray-200 space-y-3">
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              className="flex-1 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={submitting}
+              className="flex-1 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50 text-sm font-medium"
+            >
+              {submitting ? 'Creando...' : 'Crear campo extra'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/dolibarr/DolibarrPanel.tsx
+++ b/frontend/src/components/dolibarr/DolibarrPanel.tsx
@@ -13,8 +13,9 @@ import DolibarrOrders from './DolibarrOrders'
 import DolibarrInvoices from './DolibarrInvoices'
 import DolibarrStocks from './DolibarrStocks'
 import DolibarrConfig from './DolibarrConfig'
+import DolibarrExtraFields from './DolibarrExtraFields'
 
-type DolibarrTab = 'productos' | 'terceros' | 'pedidos' | 'facturas' | 'stock' | 'config'
+type DolibarrTab = 'productos' | 'terceros' | 'pedidos' | 'facturas' | 'stock' | 'campos-extra' | 'config'
 
 interface Props {
   className?: string
@@ -129,6 +130,7 @@ export default function DolibarrPanel({ className = '' }: Props) {
               { id: 'pedidos', label: 'Pedidos' },
               { id: 'facturas', label: 'Facturas' },
               { id: 'stock', label: 'Stock' },
+              { id: 'campos-extra', label: 'Campos extra' },
               { id: 'config', label: 'Configuración' },
             ] as Array<{ id: DolibarrTab; label: string }>
           ).map((t) => {
@@ -156,6 +158,7 @@ export default function DolibarrPanel({ className = '' }: Props) {
           {tab === 'pedidos' && <DolibarrOrders />}
           {tab === 'facturas' && <DolibarrInvoices />}
           {tab === 'stock' && <DolibarrStocks />}
+          {tab === 'campos-extra' && <DolibarrExtraFields />}
           {tab === 'config' && <DolibarrConfig onSaved={handleConfigSaved} />}
         </div>
       </div>

--- a/frontend/src/components/dolibarr/DolibarrProducts.tsx
+++ b/frontend/src/components/dolibarr/DolibarrProducts.tsx
@@ -6,7 +6,7 @@
  *
  * @author BenjaminDTS
  */
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import {
   listDolibarrProducts,
   deleteDolibarrProduct,
@@ -14,12 +14,16 @@ import {
   createDolibarrProduct,
   updateDolibarrProduct,
   getDolibarrProductFields,
+  previewDolibarrCsv,
+  importDolibarrCsv,
 } from '@/api/client'
 import {
   type DolibarrProduct,
   type DolibarrFieldSchema,
   type DolibarrFieldType,
   type DolibarrFieldOption,
+  type CsvImportPreview,
+  type CsvImportResponse,
 } from '@/types/dolibarr'
 
 export default function DolibarrProducts() {
@@ -34,6 +38,7 @@ export default function DolibarrProducts() {
   })
   const [showSyncModal, setShowSyncModal] = useState(false)
   const [showCreateModal, setShowCreateModal] = useState(false)
+  const [showCsvImportModal, setShowCsvImportModal] = useState(false)
   const [editingProduct, setEditingProduct] = useState<DolibarrProduct | null>(null)
 
   const loadProducts = async (limit = 10, offset = 0) => {
@@ -82,6 +87,12 @@ export default function DolibarrProducts() {
           className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors text-sm font-medium"
         >
           ↓ Sincronizar desde job
+        </button>
+        <button
+          onClick={() => setShowCsvImportModal(true)}
+          className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors text-sm font-medium"
+        >
+          ↑ Importar CSV
         </button>
       </div>
 
@@ -221,6 +232,16 @@ export default function DolibarrProducts() {
           }}
         />
       )}
+
+      {showCsvImportModal && (
+        <CsvImportModal
+          onClose={() => setShowCsvImportModal(false)}
+          onSuccess={() => {
+            setShowCsvImportModal(false)
+            loadProducts()
+          }}
+        />
+      )}
     </div>
   )
 }
@@ -316,6 +337,9 @@ function buildPayload(
       const n = parseFloat(raw)
       if (isNaN(n)) continue
       coerced = n
+    } else if ((field.type === 'select' || field.type === 'boolean') && !field.is_extra) {
+      // Dolibarr expects integer values for standard select fields (type, status, weight_units…)
+      if (/^-?\d+$/.test(raw)) coerced = parseInt(raw, 10)
     }
 
     if (field.is_extra) {
@@ -611,6 +635,301 @@ function EditProductModal({ product, onClose, onSuccess }: EditProductModalProps
               {submitting ? 'Guardando...' : 'Guardar cambios'}
             </button>
           </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── CSV Import modal ─────────────────────────────────────────────────────
+
+type CsvImportStep = 'upload' | 'mapping' | 'importing' | 'results'
+
+interface CsvImportModalProps {
+  onClose: () => void
+  onSuccess: () => void
+}
+
+/**
+ * Modal multi-paso para importación masiva de productos desde CSV a Dolibarr.
+ *
+ * Paso 1 — Upload: usuario selecciona el CSV.
+ * Paso 2 — Mapping: mapea cada columna CSV a un campo Dolibarr.
+ * Paso 3 — Importing: progreso en curso.
+ * Paso 4 — Results: resumen de creados/actualizados/omitidos/errores.
+ *
+ * @author BenjaminDTS | Carlos Vico
+ */
+function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps) {
+  const [step, setStep] = useState<CsvImportStep>('upload')
+  const [file, setFile] = useState<File | null>(null)
+  const [preview, setPreview] = useState<CsvImportPreview | null>(null)
+  const [fields, setFields] = useState<DolibarrFieldSchema[]>([])
+  const [mapping, setMapping] = useState<Record<string, string>>({})
+  const [overwrite, setOverwrite] = useState(false)
+  const [result, setResult] = useState<CsvImportResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    getDolibarrProductFields()
+      .then(setFields)
+      .catch(() => {})
+  }, [])
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0]
+    if (!f) return
+    setFile(f)
+    setError(null)
+    setLoading(true)
+    try {
+      const data = await previewDolibarrCsv(f)
+      setPreview(data)
+      const initial: Record<string, string> = {}
+      data.headers.forEach((h) => { initial[h] = '' })
+      setMapping(initial)
+      setStep('mapping')
+    } catch (err) {
+      setError((err as { message?: string }).message ?? 'Error analizando CSV')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleImport = async () => {
+    const activeMapping = Object.fromEntries(
+      Object.entries(mapping).filter(([, v]) => v !== '')
+    )
+    if (!Object.values(activeMapping).includes('ref')) {
+      setError("Debes asignar al menos una columna al campo 'ref' (Referencia).")
+      return
+    }
+    if (!file) return
+    setError(null)
+    setStep('importing')
+    try {
+      const res = await importDolibarrCsv(file, activeMapping, overwrite)
+      setResult(res)
+      setStep('results')
+    } catch (err) {
+      setError((err as { message?: string }).message ?? 'Error durante la importación')
+      setStep('mapping')
+    }
+  }
+
+  const allFieldOptions = useMemo(() => {
+    const opts: { value: string; label: string }[] = [{ value: '', label: '— Ignorar columna —' }]
+    for (const f of fields) {
+      opts.push({ value: f.key, label: `${f.label}${f.required ? ' *' : ''} (${f.section})` })
+    }
+    return opts
+  }, [fields])
+
+  const refMapped = Object.values(mapping).includes('ref')
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-3xl max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">Importar productos desde CSV</h3>
+            <p className="text-xs text-gray-500 mt-0.5">
+              {step === 'upload' && 'Selecciona el archivo CSV'}
+              {step === 'mapping' && `${preview?.total_rows ?? 0} filas detectadas — asigna las columnas`}
+              {step === 'importing' && 'Importando productos a Dolibarr...'}
+              {step === 'results' && 'Importación completada'}
+            </p>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
+        </div>
+
+        {/* Body */}
+        <div className="overflow-y-auto flex-1 px-6 py-5">
+
+          {/* ── Step 1: Upload ── */}
+          {step === 'upload' && (
+            <div className="space-y-4">
+              <div
+                onClick={() => fileInputRef.current?.click()}
+                className="border-2 border-dashed border-gray-300 rounded-lg p-10 text-center cursor-pointer hover:border-purple-400 hover:bg-purple-50 transition-colors"
+              >
+                <p className="text-gray-500 text-sm">Haz clic para seleccionar un archivo CSV</p>
+                <p className="text-gray-400 text-xs mt-1">UTF-8 o Latin-1 · Máximo 10 MB</p>
+              </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".csv,text/csv"
+                className="hidden"
+                onChange={handleFileChange}
+              />
+              {loading && (
+                <p className="text-sm text-gray-500 text-center">Analizando CSV...</p>
+              )}
+              {error && <p className="text-sm text-red-600">{error}</p>}
+            </div>
+          )}
+
+          {/* ── Step 2: Mapping ── */}
+          {step === 'mapping' && preview && (
+            <div className="space-y-5">
+              {/* Preview table */}
+              <div>
+                <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+                  Previsualización — primeras {preview.preview.length} filas
+                </p>
+                <div className="overflow-x-auto rounded border border-gray-200 text-xs">
+                  <table className="min-w-full">
+                    <thead className="bg-gray-50">
+                      <tr>
+                        {preview.headers.map((h) => (
+                          <th key={h} className="px-3 py-2 text-left font-medium text-gray-700 whitespace-nowrap">{h}</th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100">
+                      {preview.preview.map((row, i) => (
+                        <tr key={i} className="hover:bg-gray-50">
+                          {preview.headers.map((h) => (
+                            <td key={h} className="px-3 py-2 text-gray-600 max-w-[160px] truncate">{row[h]}</td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              {/* Mapping */}
+              <div>
+                <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+                  Mapeo de columnas
+                </p>
+                <div className="space-y-2">
+                  {preview.headers.map((header) => (
+                    <div key={header} className="flex items-center gap-3">
+                      <span className="w-40 text-xs font-mono bg-gray-100 px-2 py-1 rounded truncate flex-shrink-0 text-gray-700">
+                        {header}
+                      </span>
+                      <span className="text-gray-400 text-xs">→</span>
+                      <select
+                        value={mapping[header] ?? ''}
+                        onChange={(e) => setMapping((prev) => ({ ...prev, [header]: e.target.value }))}
+                        className="flex-1 text-xs px-2 py-1.5 border border-gray-300 rounded focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                      >
+                        {allFieldOptions.map((o) => (
+                          <option key={o.value} value={o.value}>{o.label}</option>
+                        ))}
+                      </select>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Overwrite toggle */}
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={overwrite}
+                  onChange={(e) => setOverwrite(e.target.checked)}
+                  className="rounded"
+                />
+                Sobreescribir productos existentes (busca por referencia)
+              </label>
+
+              {!refMapped && (
+                <p className="text-xs text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+                  Asigna al menos una columna al campo <strong>Referencia (ref)</strong> para poder importar.
+                </p>
+              )}
+
+              {error && <p className="text-sm text-red-600">{error}</p>}
+            </div>
+          )}
+
+          {/* ── Step 3: Importing ── */}
+          {step === 'importing' && (
+            <div className="flex flex-col items-center justify-center py-16 space-y-4">
+              <div className="w-10 h-10 border-4 border-purple-600 border-t-transparent rounded-full animate-spin" />
+              <p className="text-gray-600 text-sm">Importando {preview?.total_rows ?? '...'} productos a Dolibarr...</p>
+              <p className="text-gray-400 text-xs">Esto puede tardar varios minutos para catálogos grandes.</p>
+            </div>
+          )}
+
+          {/* ── Step 4: Results ── */}
+          {step === 'results' && result && (
+            <div className="space-y-4">
+              <div className="grid grid-cols-4 gap-3">
+                {[
+                  { label: 'Creados', value: result.created, color: 'bg-green-100 text-green-800' },
+                  { label: 'Actualizados', value: result.updated, color: 'bg-blue-100 text-blue-800' },
+                  { label: 'Omitidos', value: result.skipped, color: 'bg-gray-100 text-gray-700' },
+                  { label: 'Errores', value: result.errors, color: 'bg-red-100 text-red-800' },
+                ].map(({ label, value, color }) => (
+                  <div key={label} className={`rounded-lg p-3 text-center ${color}`}>
+                    <p className="text-2xl font-bold">{value}</p>
+                    <p className="text-xs font-medium mt-0.5">{label}</p>
+                  </div>
+                ))}
+              </div>
+
+              {result.errors > 0 && (
+                <div>
+                  <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Filas con error</p>
+                  <div className="max-h-48 overflow-y-auto space-y-1">
+                    {result.results
+                      .filter((r) => r.action === 'error')
+                      .map((r) => (
+                        <div key={r.row} className="text-xs bg-red-50 border border-red-200 rounded px-3 py-2">
+                          <span className="font-medium">Fila {r.row}</span>
+                          {r.ref && <span className="text-gray-500 ml-1">({r.ref})</span>}
+                          {' — '}{r.error}
+                        </div>
+                      ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-gray-200 flex gap-3">
+          {step === 'upload' && (
+            <button onClick={onClose} className="flex-1 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm">
+              Cancelar
+            </button>
+          )}
+
+          {step === 'mapping' && (
+            <>
+              <button
+                onClick={() => { setStep('upload'); setPreview(null); setFile(null) }}
+                className="flex-1 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm"
+              >
+                ← Cambiar archivo
+              </button>
+              <button
+                onClick={handleImport}
+                disabled={!refMapped}
+                className="flex-1 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50 text-sm font-medium"
+              >
+                Importar {preview?.total_rows ?? ''} productos →
+              </button>
+            </>
+          )}
+
+          {step === 'results' && (
+            <button
+              onClick={onSuccess}
+              className="flex-1 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 text-sm font-medium"
+            >
+              Cerrar y actualizar lista
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/types/dolibarr.ts
+++ b/frontend/src/types/dolibarr.ts
@@ -117,3 +117,66 @@ export interface SyncFromJobRequest {
 export type ThirdpartyMode = 'all' | 'customers' | 'suppliers'
 export type OrderType = 'customer' | 'supplier'
 export type InvoiceType = 'customer' | 'supplier'
+
+export interface DolibarrDBConfig {
+  host: string
+  port: number
+  db_name: string
+  user: string
+  password: string
+  prefix: string
+  configured: boolean
+}
+
+export interface DolibarrDBConfigCreate {
+  host: string
+  port: number
+  db_name: string
+  user: string
+  password: string
+  prefix: string
+}
+
+export interface DolibarrExtraField {
+  attrname: string
+  label: string
+  type: string
+  type_normalized: DolibarrFieldType
+  elementtype: string
+  size: string
+  required: boolean
+  fielddefault: string
+}
+
+export interface DolibarrExtraFieldCreate {
+  attrname: string
+  label: string
+  type: string
+  elementtype: string
+  size: string
+  required: boolean
+  fielddefault: string
+}
+
+export interface CsvImportPreview {
+  headers: string[]
+  preview: Record<string, string>[]
+  total_rows: number
+}
+
+export interface CsvImportRowResult {
+  row: number
+  ref: string
+  action: 'created' | 'updated' | 'skipped' | 'error'
+  dolibarr_id: number | null
+  error: string | null
+}
+
+export interface CsvImportResponse {
+  total: number
+  created: number
+  updated: number
+  skipped: number
+  errors: number
+  results: CsvImportRowResult[]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dependencies = [
     # --- CORS / Seguridad ---
     "python-multipart==0.0.9",
     "httpx==0.27.0",
+
+    # --- BD directa Dolibarr (fallback extrafields) ---
+    "aiomysql==0.3.2",
 ]
 
 [project.optional-dependencies]

--- a/services/integrations/dolibarr/client.py
+++ b/services/integrations/dolibarr/client.py
@@ -114,12 +114,16 @@ class DolibarrClient(IntegrationClient):
             try:
                 response = await self._client.request(method, path, **kwargs)
 
-                if response.status_code >= 500:
+                if response.status_code >= 500 and response.status_code != 501:
                     last_status = response.status_code
                     last_exc = None
                     logger.warning(
                         "Reintentando Dolibarr",
-                        extra={"attempt": attempt, "path": path},
+                        extra={
+                            "attempt": attempt,
+                            "path": path,
+                            "dolibarr_error": response.text[:400],
+                        },
                     )
                     await asyncio.sleep(2 ** attempt)
                     continue

--- a/services/integrations/dolibarr/extrafields.py
+++ b/services/integrations/dolibarr/extrafields.py
@@ -1,0 +1,327 @@
+"""
+Módulo de gestión de campos extra (extrafields) en Dolibarr.
+
+Permite crear, listar y eliminar atributos personalizados para
+cualquier tipo de elemento (producto, tercero, factura, etc.).
+Los campos creados aquí aparecen de inmediato en la interfaz de Dolibarr.
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from services.integrations.base import IntegrationError
+from services.integrations.dolibarr.client import DolibarrClient
+
+if TYPE_CHECKING:
+    from services.integrations.dolibarr.extrafields_db import DolibarrExtraFieldDB
+
+_EXTRA_TYPE_MAP: dict[str, str] = {
+    "varchar": "text",
+    "char": "text",
+    "phone": "text",
+    "mail": "text",
+    "url": "text",
+    "int": "number",
+    "double": "number",
+    "price": "number",
+    "date": "date",
+    "datetime": "date",
+    "select": "select",
+    "radio": "select",
+    "boolean": "boolean",
+    "chkbxlst": "boolean",
+    "text": "textarea",
+    "html": "textarea",
+}
+
+SUPPORTED_TYPES: list[str] = [
+    "varchar",
+    "int",
+    "double",
+    "price",
+    "date",
+    "datetime",
+    "select",
+    "boolean",
+    "text",
+    "html",
+    "phone",
+    "mail",
+    "url",
+]
+
+
+class DolibarrExtraFieldService:
+    """
+    Servicio para gestión de campos extra (extrafields) en Dolibarr.
+
+    Encapsula las operaciones de listado, creación y eliminación de
+    atributos personalizados. Los cambios son inmediatamente visibles
+    en la interfaz web de Dolibarr.
+
+    :author: Carlitos6712
+    """
+
+    def __init__(
+        self,
+        client: DolibarrClient,
+        db_fallback: "DolibarrExtraFieldDB | None" = None,
+    ) -> None:
+        """
+        Args:
+            client:      instancia de DolibarrClient configurada y lista para usar.
+            db_fallback: instancia de DolibarrExtraFieldDB para usar como fallback
+                         cuando la REST API devuelve 501 Not Implemented.
+        """
+        self._client = client
+        self._db = db_fallback
+
+    async def list_extrafields(self, elementtype: str = "product") -> list[dict[str, Any]]:
+        """
+        Lista los campos extra configurados para un tipo de elemento.
+
+        Cuando la BD directa está configurada, se usa como fuente primaria porque
+        los campos creados via ALTER TABLE + INSERT directo no siempre aparecen
+        en la REST API de Dolibarr. Solo se recurre a la API si no hay BD configurada.
+
+        Args:
+            elementtype: tipo de elemento Dolibarr (product, societe, facture, etc.).
+
+        Returns:
+            Lista de dicts normalizados con la definición de cada campo extra.
+
+        Raises:
+            IntegrationError: si no hay BD configurada y Dolibarr devuelve error.
+        """
+        if self._db:
+            try:
+                db_fields = await self._db.list_extrafields(elementtype=elementtype)
+                logger.info(
+                    "Extrafields listados via BD directa",
+                    extra={"elementtype": elementtype, "count": len(db_fields)},
+                )
+                return db_fields
+            except Exception as db_exc:
+                raise IntegrationError(
+                    f"Error al conectar con la BD de Dolibarr: {db_exc}",
+                    platform="dolibarr",
+                    status_code=503,
+                ) from db_exc
+
+        # Sin BD configurada: intentar REST API
+        response = await self._client._request(
+            "GET", "extrafields", params={"attrname": elementtype}
+        )
+
+        if response.status_code in (404, 501):
+            return []
+        if response.status_code >= 400:
+            raise IntegrationError(
+                f"Error listando extrafields de '{elementtype}'",
+                platform="dolibarr",
+                status_code=response.status_code,
+            )
+
+        raw = response.json()
+        fields: list[dict[str, Any]] = []
+
+        if isinstance(raw, dict):
+            for key, field_def in raw.items():
+                if isinstance(field_def, dict):
+                    fields.append(self._normalize(key, field_def))
+        elif isinstance(raw, list):
+            for item in raw:
+                if isinstance(item, dict) and "attrname" in item:
+                    fields.append(self._normalize(str(item["attrname"]), item))
+
+        logger.info(
+            "Extrafields listados via API REST",
+            extra={"elementtype": elementtype, "count": len(fields)},
+        )
+        return fields
+
+    async def create_extrafield(
+        self,
+        attrname: str,
+        label: str,
+        field_type: str = "varchar",
+        elementtype: str = "product",
+        size: str = "255",
+        required: bool = False,
+        field_default: str = "",
+        param: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Crea un nuevo campo extra en Dolibarr.
+
+        Cuando la BD directa está configurada se usa como fuente primaria (igual
+        que list_extrafields), porque la REST API de extrafields no está disponible
+        en todas las instalaciones de Dolibarr. Solo se recurre a la API REST si
+        no hay BD configurada.
+
+        El campo queda disponible de inmediato en la interfaz de Dolibarr
+        y aparece en el formulario dinámico de productos de Harvist.
+
+        Args:
+            attrname:      nombre interno del campo (solo minúsculas, sin espacios ni caracteres especiales).
+            label:         etiqueta visible en la interfaz.
+            field_type:    tipo de campo Dolibarr (varchar, int, double, date, select, boolean, text, html, ...).
+            elementtype:   tipo de elemento al que se asocia (product, societe, facture, etc.).
+            size:          tamaño del campo (relevante para varchar).
+            required:      si el campo es obligatorio.
+            field_default: valor por defecto.
+            param:         parámetros adicionales, principalmente opciones para tipo select.
+
+        Returns:
+            Dict normalizado con la definición del campo recién creado.
+
+        Raises:
+            ValueError:        si attrname contiene caracteres inválidos.
+            IntegrationError:  si Dolibarr rechaza la creación.
+        """
+        if not attrname or not attrname.replace("_", "").isalnum():
+            raise ValueError(
+                f"attrname '{attrname}' inválido: solo letras, números y guión bajo."
+            )
+
+        # BD configurada → primaria (mismo comportamiento que list_extrafields)
+        if self._db:
+            try:
+                return await self._db.create_extrafield(
+                    attrname=attrname.lower(),
+                    label=label,
+                    field_type=field_type,
+                    elementtype=elementtype,
+                    size=size,
+                    required=required,
+                    field_default=field_default,
+                )
+            except Exception as db_exc:
+                raise IntegrationError(
+                    f"Error al crear campo extra en la BD de Dolibarr: {db_exc}",
+                    platform="dolibarr",
+                    status_code=503,
+                ) from db_exc
+
+        # Sin BD configurada → intentar REST API
+        payload: dict[str, Any] = {
+            "attrname": attrname.lower(),
+            "label": label,
+            "type": field_type,
+            "size": size,
+            "elementtype": elementtype,
+            "fieldrequired": "1" if required else "0",
+            "fieldunique": "0",
+            "fielddefault": field_default,
+            "param": param or {},
+        }
+
+        response = await self._client._request("POST", "extrafields", json=payload)
+
+        if response.status_code == 501:
+            raise IntegrationError(
+                "Esta versión de Dolibarr no soporta la gestión de campos extra via API REST. "
+                "Configura el acceso directo a BD en la pestaña Configuración → BD Dolibarr.",
+                platform="dolibarr",
+                status_code=501,
+            )
+        if response.status_code >= 400:
+            raise IntegrationError(
+                f"Error creando extrafield '{attrname}': {response.text}",
+                platform="dolibarr",
+                status_code=response.status_code,
+            )
+
+        logger.info(
+            "Extrafield creado via API REST",
+            extra={"attrname": attrname, "elementtype": elementtype, "type": field_type},
+        )
+
+        return {
+            "attrname": attrname.lower(),
+            "label": label,
+            "type": field_type,
+            "type_normalized": _EXTRA_TYPE_MAP.get(field_type, "text"),
+            "elementtype": elementtype,
+            "size": size,
+            "required": required,
+            "fielddefault": field_default,
+        }
+
+    async def delete_extrafield(self, attrname: str, elementtype: str = "product") -> bool:
+        """
+        Elimina un campo extra de Dolibarr.
+
+        Cuando la BD directa está configurada se usa como fuente primaria (mismo
+        patrón que list_extrafields y create_extrafield). Solo se recurre a la
+        API REST si no hay BD configurada.
+
+        Args:
+            attrname:    nombre interno del campo a eliminar.
+            elementtype: tipo de elemento al que pertenece el campo.
+
+        Returns:
+            True si se eliminó correctamente.
+
+        Raises:
+            IntegrationError: si Dolibarr devuelve error al eliminar.
+        """
+        # BD configurada → primaria
+        if self._db:
+            try:
+                return await self._db.delete_extrafield(attrname=attrname, elementtype=elementtype)
+            except Exception as db_exc:
+                raise IntegrationError(
+                    f"Error al eliminar campo extra en la BD de Dolibarr: {db_exc}",
+                    platform="dolibarr",
+                    status_code=503,
+                ) from db_exc
+
+        # Sin BD → intentar REST API
+        response = await self._client._request(
+            "DELETE",
+            f"extrafields/{attrname}",
+            params={"attrname": elementtype},
+        )
+
+        if response.status_code in (200, 204):
+            logger.info(
+                "Extrafield eliminado via API REST",
+                extra={"attrname": attrname, "elementtype": elementtype},
+            )
+            return True
+
+        if response.status_code == 501:
+            raise IntegrationError(
+                "Esta versión de Dolibarr no soporta la gestión de campos extra via API REST. "
+                "Configura el acceso directo a BD en la pestaña Configuración → BD Dolibarr.",
+                platform="dolibarr",
+                status_code=501,
+            )
+
+        raise IntegrationError(
+            f"Error eliminando extrafield '{attrname}'",
+            platform="dolibarr",
+            status_code=response.status_code,
+        )
+
+    def _normalize(self, key: str, field_def: dict[str, Any]) -> dict[str, Any]:
+        """Normaliza la definición bruta de un extrafield devuelta por Dolibarr."""
+        raw_type = str(field_def.get("type", "varchar"))
+        return {
+            "attrname": key,
+            "label": str(field_def.get("label", key)),
+            "type": raw_type,
+            "type_normalized": _EXTRA_TYPE_MAP.get(raw_type, "text"),
+            "elementtype": str(field_def.get("elementtype", "")),
+            "size": str(field_def.get("size", "")),
+            "required": str(field_def.get("required", "0")) == "1",
+            "fielddefault": str(field_def.get("fielddefault", "") or ""),
+            "param": field_def.get("param", {}),
+        }

--- a/services/integrations/dolibarr/extrafields_db.py
+++ b/services/integrations/dolibarr/extrafields_db.py
@@ -1,0 +1,452 @@
+﻿"""
+GestiÃ³n de campos extra de Dolibarr via acceso directo a base de datos.
+
+Fallback cuando el endpoint REST /extrafields no estÃ¡ disponible en la
+versiÃ³n instalada de Dolibarr. Replica exactamente el comportamiento
+del admin de Dolibarr: INSERT en llx_extrafields + ALTER TABLE en la
+tabla de datos del elemento.
+
+:author: Carlitos6712
+:version: 1.0.0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiomysql
+from loguru import logger
+
+from api.core.config import Settings
+
+_ELEMENT_TABLE_MAP: dict[str, str] = {
+    "product": "product_extrafields",
+    "societe": "societe_extrafields",
+    "facture": "facture_extrafields",
+    "facture_fourn": "facture_fourn_det_extrafields",
+    "commande": "commande_extrafields",
+    "commande_fournisseur": "commande_fournisseur_det_extrafields",
+    "propal": "propal_extrafields",
+    "contrat": "contrat_extrafields",
+    "user": "user_extrafields",
+    "contact": "socpeople_extrafields",
+}
+
+_DOLIBARR_TYPE_TO_SQL: dict[str, str] = {
+    "varchar": "VARCHAR({size})",
+    "char": "VARCHAR({size})",
+    "phone": "VARCHAR(20)",
+    "mail": "VARCHAR(128)",
+    "url": "VARCHAR(255)",
+    "int": "INT",
+    "double": "DOUBLE",
+    "price": "DOUBLE(24,8)",
+    "date": "DATE",
+    "datetime": "DATETIME",
+    "select": "VARCHAR(255)",
+    "radio": "VARCHAR(255)",
+    "boolean": "SMALLINT",
+    "chkbxlst": "VARCHAR(255)",
+    "text": "TEXT",
+    "html": "TEXT",
+}
+
+
+class DolibarrExtraFieldDB:
+    """
+    Servicio de gestiÃ³n de campos extra de Dolibarr via MySQL directo.
+
+    Usado como fallback cuando el endpoint REST /extrafields devuelve 501.
+    Requiere DOLIBARR_DB_* configurado en .env.
+
+    :author: Carlitos6712
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        override_host: str = "",
+        override_port: int | None = None,
+        override_db: str = "",
+        override_user: str = "",
+        override_pass: str = "",
+        override_prefix: str = "",
+    ) -> None:
+        """
+        Prioridad de credenciales: override_* > Settings > error.
+
+        Args:
+            settings:        instancia de Settings con credenciales de BD.
+            override_host:   host MySQL (sobreescribe .env).
+            override_port:   puerto MySQL (sobreescribe .env).
+            override_db:     nombre de BD (sobreescribe .env).
+            override_user:   usuario MySQL (sobreescribe .env).
+            override_pass:   contraseÃ±a MySQL (sobreescribe .env).
+            override_prefix: prefijo de tablas (sobreescribe .env).
+
+        Raises:
+            ValueError: si no hay credenciales suficientes (host + db + user).
+        """
+        self._host = (override_host or settings.dolibarr_db_host or "").strip()
+        self._port = override_port if override_port is not None else settings.dolibarr_db_port
+        self._db = (override_db or settings.dolibarr_db_name or "").strip()
+        self._user = (override_user or settings.dolibarr_db_user or "").strip()
+        self._pass = (override_pass or settings.dolibarr_db_pass or "").strip()
+        self._prefix = (override_prefix or settings.dolibarr_db_prefix or "llx_").strip()
+
+        if not self._host or not self._db or not self._user:
+            raise ValueError(
+                "BD de Dolibarr no configurada. "
+                "Define DOLIBARR_DB_HOST, DOLIBARR_DB_NAME y DOLIBARR_DB_USER en .env "
+                "o configÃºralos en la interfaz grÃ¡fica."
+            )
+
+    async def _connect(self) -> aiomysql.Connection:
+        """Abre una conexiÃ³n MySQL asÃ­ncrona."""
+        return await aiomysql.connect(
+            host=self._host,
+            port=self._port,
+            db=self._db,
+            user=self._user,
+            password=self._pass,
+            autocommit=False,
+            charset="utf8mb4",
+        )
+
+    async def _repair_null_defaults(self, conn: "aiomysql.Connection", data_table: str) -> None:
+        """
+        Hace nullable todas las columnas NOT NULL sin default en la tabla de datos.
+
+        Usa MODIFY COLUMN (compatible MySQL 5.7+) en lugar de ALTER COLUMN SET DEFAULT NULL,
+        que falla para columnas TEXT/BLOB en MySQL 5.7.
+
+        Args:
+            conn:       conexiÃ³n MySQL activa.
+            data_table: nombre completo de la tabla (p. ej. llx_product_extrafields).
+        """
+        try:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    """
+                    SELECT COLUMN_NAME, COLUMN_TYPE
+                    FROM INFORMATION_SCHEMA.COLUMNS
+                    WHERE TABLE_SCHEMA = DATABASE()
+                      AND TABLE_NAME = %s
+                      AND IS_NULLABLE = 'NO'
+                      AND COLUMN_DEFAULT IS NULL
+                      AND COLUMN_NAME NOT IN ('rowid', 'fk_object')
+                    """,
+                    (data_table,),
+                )
+                bad_cols = [(row[0], row[1]) for row in await cur.fetchall()]
+
+            for col_name, col_type in bad_cols:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        f"ALTER TABLE `{data_table}` MODIFY COLUMN `{col_name}` {col_type} NULL"
+                    )
+                logger.info(
+                    "Columna extrafield hecha nullable",
+                    extra={"table": data_table, "column": col_name, "type": col_type},
+                )
+        except Exception:
+            logger.opt(exception=True).warning(
+                "No se pudo hacer nullable columna extrafield â€” table={}",
+                data_table,
+            )
+
+    async def list_extrafields(self, elementtype: str = "product") -> list[dict[str, Any]]:
+        """
+        Lista los campos extra de un elemento desde llx_extrafields.
+
+        TambiÃ©n repara columnas sin DEFAULT NULL en la tabla de datos para
+        evitar errores MySQL al actualizar productos con extrafields via REST.
+
+        Args:
+            elementtype: tipo de elemento Dolibarr.
+
+        Returns:
+            Lista de dicts con la definiciÃ³n de cada campo.
+        """
+        data_table_key = _ELEMENT_TABLE_MAP.get(elementtype)
+
+        conn = await self._connect()
+        try:
+            if data_table_key:
+                await self._repair_null_defaults(conn, f"{self._prefix}{data_table_key}")
+
+            async with conn.cursor(aiomysql.DictCursor) as cur:
+                table = f"{self._prefix}extrafields"
+                await cur.execute(
+                    f"SELECT * FROM `{table}` WHERE elementtype = %s ORDER BY pos ASC",
+                    (elementtype,),
+                )
+                rows = await cur.fetchall()
+                return [self._normalize(r) for r in rows]
+        finally:
+            conn.close()
+
+    async def create_extrafield(
+        self,
+        attrname: str,
+        label: str,
+        field_type: str = "varchar",
+        elementtype: str = "product",
+        size: str = "255",
+        required: bool = False,
+        field_default: str = "",
+    ) -> dict[str, Any]:
+        """
+        Crea un campo extra en Dolibarr via BD directa.
+
+        Ejecuta dos operaciones en transacciÃ³n:
+          1. INSERT en llx_extrafields (definiciÃ³n del campo)
+          2. ALTER TABLE en llx_{element}_extrafields (columna de datos)
+
+        Args:
+            attrname:      nombre interno del campo (minÃºsculas, sin espacios).
+            label:         etiqueta visible.
+            field_type:    tipo Dolibarr (varchar, int, date, select, boolean, text...).
+            elementtype:   tipo de elemento (product, societe, etc.).
+            size:          tamaÃ±o para tipos varchar.
+            required:      si el campo es obligatorio.
+            field_default: valor por defecto.
+
+        Returns:
+            Dict con la definiciÃ³n del campo creado.
+
+        Raises:
+            ValueError: si el tipo no estÃ¡ soportado o el elemento no tiene tabla mapeada.
+            RuntimeError: si la transacciÃ³n falla.
+        """
+        if field_type not in _DOLIBARR_TYPE_TO_SQL:
+            raise ValueError(f"Tipo '{field_type}' no soportado. Tipos vÃ¡lidos: {list(_DOLIBARR_TYPE_TO_SQL)}")
+
+        data_table_key = _ELEMENT_TABLE_MAP.get(elementtype)
+        if not data_table_key:
+            raise ValueError(
+                f"Elemento '{elementtype}' no tiene tabla de datos mapeada. "
+                f"Elementos soportados: {list(_ELEMENT_TABLE_MAP)}"
+            )
+
+        sql_type = _DOLIBARR_TYPE_TO_SQL[field_type].replace("{size}", size)
+        def_table = f"{self._prefix}extrafields"
+        data_table = f"{self._prefix}{data_table_key}"
+
+        conn = await self._connect()
+        try:
+            # Repair columns without DEFAULT NULL before any write operation.
+            await self._repair_null_defaults(conn, data_table)
+
+            async with conn.cursor() as cur:
+                # Some Dolibarr installations have a trigger referencing `hidden`.
+                # Ensure the column exists before the INSERT to avoid error 1054.
+                await cur.execute(
+                    f"ALTER TABLE `{def_table}` ADD COLUMN IF NOT EXISTS `hidden` INT DEFAULT 0"
+                )
+
+                await cur.execute(
+                    f"""
+                    INSERT IGNORE INTO `{def_table}`
+                      (name, label, type, size, elementtype,
+                       fieldrequired, fieldunique, fielddefault,
+                       pos, alwayseditable, entity, enabled, list)
+                    VALUES
+                      (%s, %s, %s, %s, %s,
+                       %s, 0, %s,
+                       0, 0, 1, '1', '0')
+                    """,
+                    (
+                        attrname, label, field_type, size, elementtype,
+                        1 if required else 0, field_default,
+                    ),
+                )
+
+                await cur.execute(
+                    f"ALTER TABLE `{data_table}` ADD COLUMN IF NOT EXISTS `{attrname}` {sql_type} DEFAULT NULL"
+                )
+
+            await conn.commit()
+
+            logger.info(
+                "Extrafield creado via BD",
+                extra={"attrname": attrname, "elementtype": elementtype, "type": field_type},
+            )
+
+            from services.integrations.dolibarr.extrafields import _EXTRA_TYPE_MAP
+            return {
+                "attrname": attrname,
+                "label": label,
+                "type": field_type,
+                "type_normalized": _EXTRA_TYPE_MAP.get(field_type, "text"),
+                "elementtype": elementtype,
+                "size": size,
+                "required": required,
+                "fielddefault": field_default,
+            }
+
+        except Exception as exc:
+            await conn.rollback()
+            logger.error(
+                "Error creando extrafield via BD â€” rollback ejecutado",
+                exc_info=exc,
+                extra={"attrname": attrname, "elementtype": elementtype},
+            )
+            raise RuntimeError(f"Error creando campo extra '{attrname}': {exc}") from exc
+        finally:
+            conn.close()
+
+    async def delete_extrafield(self, attrname: str, elementtype: str = "product") -> bool:
+        """
+        Elimina un campo extra de Dolibarr via BD directa.
+
+        Ejecuta dos operaciones en transacciÃ³n:
+          1. DELETE de llx_extrafields
+          2. ALTER TABLE DROP COLUMN en llx_{element}_extrafields
+
+        Args:
+            attrname:    nombre interno del campo.
+            elementtype: tipo de elemento.
+
+        Returns:
+            True si se eliminÃ³ correctamente.
+
+        Raises:
+            RuntimeError: si la transacciÃ³n falla.
+        """
+        data_table_key = _ELEMENT_TABLE_MAP.get(elementtype)
+        if not data_table_key:
+            raise ValueError(f"Elemento '{elementtype}' no tiene tabla de datos mapeada.")
+
+        def_table = f"{self._prefix}extrafields"
+        data_table = f"{self._prefix}{data_table_key}"
+
+        conn = await self._connect()
+        try:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    f"DELETE FROM `{def_table}` WHERE name = %s AND elementtype = %s",
+                    (attrname, elementtype),
+                )
+                await cur.execute(
+                    f"ALTER TABLE `{data_table}` DROP COLUMN IF EXISTS `{attrname}`"
+                )
+
+            await conn.commit()
+
+            logger.info(
+                "Extrafield eliminado via BD",
+                extra={"attrname": attrname, "elementtype": elementtype},
+            )
+            return True
+
+        except Exception as exc:
+            await conn.rollback()
+            logger.error(
+                "Error eliminando extrafield via BD â€” rollback ejecutado",
+                exc_info=exc,
+                extra={"attrname": attrname},
+            )
+            raise RuntimeError(f"Error eliminando campo extra '{attrname}': {exc}") from exc
+        finally:
+            conn.close()
+
+    async def update_product_extrafields(
+        self,
+        product_id: int,
+        array_options: dict[str, Any],
+        elementtype: str = "product",
+    ) -> None:
+        """
+        Actualiza los extrafields de un producto via BD directa.
+
+        Usa UPSERT directo en llx_{element}_extrafields en lugar del endpoint
+        REST de Dolibarr, que falla cuando alguna columna no tiene DEFAULT NULL.
+        Aplica ``_repair_null_defaults`` antes de escribir.
+
+        Los keys de ``array_options`` pueden venir con o sin el prefijo ``options_``
+        que usa Dolibarr en su REST API.
+
+        Args:
+            product_id:    ID del producto en Dolibarr.
+            array_options: dict de extrafields a guardar.
+            elementtype:   tipo de elemento (product por defecto).
+
+        Raises:
+            RuntimeError: si la operaciÃ³n de BD falla.
+        """
+        data_table_key = _ELEMENT_TABLE_MAP.get(elementtype)
+        if not data_table_key:
+            return
+
+        data_table = f"{self._prefix}{data_table_key}"
+
+        # Strip "options_" prefix: REST API uses it, column names don't
+        clean: dict[str, Any] = {
+            (k[8:] if k.startswith("options_") else k): v
+            for k, v in array_options.items()
+            if v is not None and v != ""
+        }
+        if not clean:
+            return
+
+        conn = await self._connect()
+        try:
+            await self._repair_null_defaults(conn, data_table)
+
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    f"SELECT rowid FROM `{data_table}` WHERE fk_object = %s LIMIT 1",
+                    (product_id,),
+                )
+                existing = await cur.fetchone()
+
+            async with conn.cursor() as cur:
+                if existing:
+                    set_clause = ", ".join(f"`{col}` = %s" for col in clean)
+                    await cur.execute(
+                        f"UPDATE `{data_table}` SET {set_clause} WHERE fk_object = %s",
+                        (*clean.values(), product_id),
+                    )
+                else:
+                    cols = list(clean.keys())
+                    col_clause = ", ".join(f"`{c}`" for c in cols) + ", fk_object"
+                    val_clause = ", ".join(["%s"] * (len(cols) + 1))
+                    await cur.execute(
+                        f"INSERT INTO `{data_table}` ({col_clause}) VALUES ({val_clause})",
+                        (*clean.values(), product_id),
+                    )
+
+            await conn.commit()
+            logger.info(
+                "Extrafields de producto actualizados via BD",
+                extra={"product_id": product_id, "elementtype": elementtype, "fields": list(clean)},
+            )
+
+        except Exception as exc:
+            await conn.rollback()
+            logger.opt(exception=True).error(
+                "Error actualizando extrafields via BD â€” product_id={} fields={}",
+                product_id,
+                list(clean),
+            )
+            raise RuntimeError(f"Error actualizando extrafields de producto {product_id}: {exc}") from exc
+        finally:
+            conn.close()
+
+    def _normalize(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Normaliza una fila de llx_extrafields al formato estÃ¡ndar de Harvist."""
+        from services.integrations.dolibarr.extrafields import _EXTRA_TYPE_MAP
+        raw_type = str(row.get("type", "varchar"))
+        return {
+            "attrname": str(row.get("name", "")),
+            "label": str(row.get("label", "")),
+            "type": raw_type,
+            "type_normalized": _EXTRA_TYPE_MAP.get(raw_type, "text"),
+            "elementtype": str(row.get("elementtype", "")),
+            "size": str(row.get("size", "")),
+            "required": bool(row.get("fieldrequired", 0)),
+            "fielddefault": str(row.get("fielddefault", "") or ""),
+            "param": row.get("param", {}),
+        }
+

--- a/services/integrations/dolibarr/products.py
+++ b/services/integrations/dolibarr/products.py
@@ -11,6 +11,8 @@ validación, imagen, sincronización desde job Harvist.
 from __future__ import annotations
 
 import base64
+import csv
+import io
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -65,6 +67,30 @@ _STANDARD_FIELDS: list[dict[str, Any]] = [
     {"key": "customcode", "label": "Código HS", "type": "text", "required": False, "section": "Aduanas", "is_extra": False},
     {"key": "country_id", "label": "País de origen (ID Dolibarr)", "type": "number", "required": False, "section": "Aduanas", "is_extra": False},
 ]
+
+
+def _decode_csv(content: bytes) -> str:
+    """Decodifica bytes CSV intentando UTF-8 y latin-1 como fallback."""
+    try:
+        return content.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return content.decode("latin-1")
+
+
+def _detect_delimiter(text: str) -> str:
+    """Detecta el delimitador CSV priorizando ; y , sobre tabulador y pipe.
+
+    Usa csv.Sniffer primero; si falla cuenta ocurrencias en la primera línea.
+    """
+    sample = text[:4096]
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=",;\t|")
+        return dialect.delimiter
+    except csv.Error:
+        first_line = sample.split("\n")[0]
+        counts = {d: first_line.count(d) for d in (";", ",", "\t", "|")}
+        best = max(counts, key=lambda d: counts[d])
+        return best if counts[best] > 0 else ","
 
 
 def _normalize_product(raw: dict[str, Any]) -> dict[str, Any]:
@@ -135,66 +161,79 @@ class DolibarrProductService:
         """
         self._client = client
 
-    async def get_product_fields(self) -> list[dict[str, Any]]:
+    async def get_product_fields(
+        self,
+        pre_fetched_extras: list[dict[str, Any]] | None = None,
+    ) -> list[dict[str, Any]]:
         """
         Devuelve el schema de campos para productos de esta instancia Dolibarr.
 
-        Combina los campos estándar (siempre presentes) con los campos extra
-        configurados en esta instancia específica vía GET /extrafields?attrname=product.
+        Combina los campos estándar con los campos extra. Si se proveen
+        ``pre_fetched_extras`` (ya normalizados por DolibarrExtraFieldService),
+        se usan directamente en vez de llamar a la REST API. Esto permite que
+        el endpoint use el fallback de BD sin duplicar la lógica aquí.
+
+        Args:
+            pre_fetched_extras: lista de extrafields ya normalizados, con las
+                claves ``attrname``, ``label``, ``type``, ``required`` y ``param``.
+                Si es None, se consulta la REST API de Dolibarr directamente.
 
         Returns:
             Lista de dicts con key, label, type, required, section, is_extra y options.
         """
         fields: list[dict[str, Any]] = [dict(f) for f in _STANDARD_FIELDS]
 
-        try:
-            response = await self._client._request(
-                "GET", "extrafields", params={"attrname": "product"}
-            )
-            if response.status_code == 200:
-                raw = response.json()
+        if pre_fetched_extras is not None:
+            extra_items = [
+                (str(ef.get("attrname", "")), ef)
+                for ef in pre_fetched_extras
+                if ef.get("attrname")
+            ]
+        else:
+            try:
+                response = await self._client._request(
+                    "GET", "extrafields", params={"attrname": "product"}
+                )
+                extra_items = []
+                if response.status_code == 200:
+                    raw = response.json()
+                    if isinstance(raw, dict):
+                        extra_items = [(k, v) for k, v in raw.items() if isinstance(v, dict)]
+                    elif isinstance(raw, list):
+                        extra_items = [
+                            (str(item["attrname"]), item)
+                            for item in raw
+                            if isinstance(item, dict) and "attrname" in item
+                        ]
+            except Exception as exc:
+                logger.warning("No se pudieron obtener extra fields de Dolibarr", exc_info=exc)
+                extra_items = []
 
-                extra_items: list[tuple[str, dict[str, Any]]] = []
-                if isinstance(raw, dict):
-                    for k, v in raw.items():
-                        if isinstance(v, dict):
-                            extra_items.append((k, v))
-                elif isinstance(raw, list):
-                    for item in raw:
-                        if isinstance(item, dict) and "attrname" in item:
-                            extra_items.append((str(item["attrname"]), item))
+        for field_key, field_def in extra_items:
+            field_type_raw = str(field_def.get("type", "varchar"))
+            field_type = _EXTRA_TYPE_MAP.get(field_type_raw, "text")
 
-                for field_key, field_def in extra_items:
-                    field_type_raw = str(field_def.get("type", "varchar"))
-                    field_type = _EXTRA_TYPE_MAP.get(field_type_raw, "text")
+            options: list[dict[str, str]] = []
+            if field_type == "select":
+                param = field_def.get("param") or {}
+                if isinstance(param, str):
+                    try:
+                        param = json.loads(param)
+                    except (json.JSONDecodeError, ValueError):
+                        param = {}
+                raw_opts = param.get("options", {}) if isinstance(param, dict) else {}
+                if isinstance(raw_opts, dict):
+                    options = [{"value": str(k), "label": str(v)} for k, v in raw_opts.items()]
 
-                    options: list[dict[str, str]] = []
-                    if field_type == "select":
-                        param = field_def.get("param") or {}
-                        if isinstance(param, str):
-                            try:
-                                param = json.loads(param)
-                            except (json.JSONDecodeError, ValueError):
-                                param = {}
-                        raw_opts = param.get("options", {}) if isinstance(param, dict) else {}
-                        if isinstance(raw_opts, dict):
-                            options = [{"value": str(k), "label": str(v)} for k, v in raw_opts.items()]
-
-                    fields.append({
-                        "key": f"options_{field_key}",
-                        "label": str(field_def.get("label", field_key)),
-                        "type": field_type,
-                        "required": str(field_def.get("required", "0")) == "1",
-                        "section": "Campos personalizados",
-                        "is_extra": True,
-                        "options": options if options else None,
-                    })
-
-        except Exception as exc:
-            logger.warning(
-                "No se pudieron obtener extra fields de Dolibarr",
-                exc_info=exc,
-            )
+            fields.append({
+                "key": f"options_{field_key}",
+                "label": str(field_def.get("label", field_key)),
+                "type": field_type,
+                "required": field_def.get("required", False) if isinstance(field_def.get("required"), bool) else str(field_def.get("required", "0")) == "1",
+                "section": "Campos personalizados",
+                "is_extra": True,
+                "options": options if options else None,
+            })
 
         return fields
 
@@ -243,15 +282,55 @@ class DolibarrProductService:
         """
         Crea un producto en Dolibarr.
 
+        Algunas versiones de Dolibarr devuelven HTTP 500 cuando se incluyen
+        ``array_options`` en la creación. Por eso se separa el proceso:
+          1. Crear el producto sin extrafields.
+          2. Si hay extrafields, actualizarlos con PUT en un segundo paso.
+
         Args:
             data: campos del producto. Campos esperados: ref, label, price,
                   description, type (0=producto, 1=servicio), status (0/1).
+                  Puede incluir ``array_options`` con extrafields.
 
         Returns:
             Dict con el producto creado, incluyendo el ID asignado por Dolibarr.
         """
-        raw = await self._client.create(_DOLIBARR_PRODUCTS_RESOURCE, data)
-        return _normalize_product(raw) if isinstance(raw, dict) else raw
+        payload = dict(data)
+        array_options = payload.pop("array_options", None)
+
+        raw = await self._client.create(_DOLIBARR_PRODUCTS_RESOURCE, payload)
+
+        product_id: int | None = None
+        if isinstance(raw, dict):
+            product_id = int(raw.get("id", 0)) or None
+        elif isinstance(raw, (int, str)):
+            try:
+                product_id = int(raw)
+            except (ValueError, TypeError):
+                pass
+
+        if product_id and array_options:
+            try:
+                await self._client.update(
+                    _DOLIBARR_PRODUCTS_RESOURCE,
+                    product_id,
+                    {"array_options": array_options},
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Extrafields no guardados en producto creado",
+                    exc_info=exc,
+                    extra={"product_id": product_id},
+                )
+
+        if product_id:
+            try:
+                full = await self._client.get(_DOLIBARR_PRODUCTS_RESOURCE, product_id)
+                return _normalize_product(full)
+            except Exception:
+                pass
+
+        return _normalize_product(raw) if isinstance(raw, dict) else {"id": product_id}
 
     async def update_product(
         self,
@@ -438,6 +517,139 @@ class DolibarrProductService:
                     exc_info=exc,
                     extra={"codigo": codigo, "job_id": job_id},
                 )
+                result["error"] = str(exc)
+
+            results.append(result)
+
+        return results
+
+    @staticmethod
+    def parse_csv_preview(
+        content: bytes,
+        preview_rows: int = 5,
+    ) -> dict[str, Any]:
+        """
+        Parsea las primeras filas de un CSV para previsualización.
+
+        Detecta delimitador automáticamente. Soporta UTF-8 y latin-1.
+
+        Args:
+            content:      contenido raw del archivo CSV.
+            preview_rows: número máximo de filas de previsualización.
+
+        Returns:
+            Dict con headers, preview (list of dicts) y total_rows.
+        """
+        text = _decode_csv(content)
+        delimiter = _detect_delimiter(text)
+        reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
+        headers = list(reader.fieldnames or [])
+        preview: list[dict[str, str]] = []
+        total = 0
+
+        for row in reader:
+            total += 1
+            if len(preview) < preview_rows:
+                preview.append({k: str(v or "") for k, v in row.items() if k is not None})
+
+        return {"headers": headers, "preview": preview, "total_rows": total}
+
+    async def import_from_csv(
+        self,
+        content: bytes,
+        mapping: dict[str, str],
+        overwrite: bool = False,
+    ) -> list[dict[str, Any]]:
+        """
+        Importa productos en masa a Dolibarr desde un CSV con mapeo de columnas.
+
+        Cada fila del CSV se convierte en un producto usando ``mapping``
+        (clave=columna CSV, valor=campo Dolibarr). El campo ``ref`` es
+        obligatorio: si no está en el mapping la fila se marca como error.
+
+        Campos cuya clave Dolibarr empiece por ``options_`` se tratan como
+        extrafields y se agrupan en ``array_options``.
+
+        Args:
+            content:  contenido raw del archivo CSV.
+            mapping:  dict que mapea nombre_columna_csv → campo_dolibarr.
+            overwrite: si True, actualiza productos existentes (busca por ref).
+
+        Returns:
+            Lista de dicts con row, ref, action, dolibarr_id y error.
+        """
+        text = _decode_csv(content)
+        delimiter = _detect_delimiter(text)
+        reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
+        results: list[dict[str, Any]] = []
+
+        for row_num, row in enumerate(reader, start=2):
+            payload: dict[str, Any] = {}
+            array_options: dict[str, Any] = {}
+
+            for csv_col, doli_field in mapping.items():
+                raw_val = (row.get(csv_col) or "").strip()
+                if not raw_val:
+                    continue
+                if doli_field.startswith("options_"):
+                    array_options[doli_field] = raw_val
+                else:
+                    payload[doli_field] = raw_val
+
+            ref = str(payload.get("ref", "")).strip()
+            result: dict[str, Any] = {
+                "row": row_num,
+                "ref": ref,
+                "action": None,
+                "dolibarr_id": None,
+                "error": None,
+            }
+
+            if not ref:
+                result["action"] = "error"
+                result["error"] = "Columna 'ref' vacía o no mapeada."
+                results.append(result)
+                continue
+
+            if array_options:
+                payload["array_options"] = array_options
+
+            try:
+                existing = await self._find_product_by_ref(ref)
+
+                if existing is not None:
+                    dolibarr_id = int(existing["id"])
+                    if overwrite:
+                        await self.update_product(dolibarr_id, payload)
+                        result["action"] = "updated"
+                        logger.info(
+                            "Producto actualizado via CSV import",
+                            extra={"ref": ref, "dolibarr_id": dolibarr_id, "row": row_num},
+                        )
+                    else:
+                        result["action"] = "skipped"
+                        result["dolibarr_id"] = dolibarr_id
+                        logger.debug("Producto ya existe, omitido", extra={"ref": ref})
+                        results.append(result)
+                        continue
+                else:
+                    created = await self.create_product(payload)
+                    dolibarr_id = int(created["id"]) if isinstance(created, dict) else int(created)
+                    result["action"] = "created"
+                    logger.info(
+                        "Producto creado via CSV import",
+                        extra={"ref": ref, "dolibarr_id": dolibarr_id, "row": row_num},
+                    )
+
+                result["dolibarr_id"] = dolibarr_id
+
+            except Exception as exc:
+                logger.error(
+                    "Error importando fila CSV a Dolibarr",
+                    exc_info=exc,
+                    extra={"row": row_num, "ref": ref},
+                )
+                result["action"] = "error"
                 result["error"] = str(exc)
 
             results.append(result)


### PR DESCRIPTION
## Summary

- Add CSV bulk import for Dolibarr products with auto-delimiter detection (`,` `;` `\t` `|`)
- Multi-step import modal: upload → column mapping → import → results summary
- Support standard product fields + extra fields (`options_*`) via column mapping UI
- Add `DolibarrExtraFieldService` with direct DB fallback when API lacks extrafields endpoint
- Add `DolibarrExtraFields` panel in config to manage and preview extrafield definitions
- New endpoints: `POST /api/v1/dolibarr/products/csv-preview` and `/import`

## Test plan

- [ ] Upload CSV with `,` delimiter → preview shows headers and sample rows
- [ ] Upload CSV with `;` delimiter → auto-detected correctly
- [ ] Map `ref` column to Dolibarr ref field → import runs without error
- [ ] Import with `overwrite=false` → existing products skipped
- [ ] Import with `overwrite=true` → existing products updated
- [ ] Map extra field column (e.g. `options_color`) → extrafield set on product
- [ ] Results panel shows created / updated / skipped / errors counters
- [ ] DolibarrExtraFields panel loads from API or DB fallback

