### PR TITLE
fix: raise Odoo CSV import timeout to 300s

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1053,7 +1053,7 @@ export async function importOdooCsv(
     errors: Array<{ row: number; error: string }>
   }>>('/odoo/products/csv/import', form, {
     headers: { 'Content-Type': 'multipart/form-data' },
-    timeout: 0,
+    timeout: 300_000,
   })
   return response.data.data
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,6 +24,8 @@ export default defineConfig({
         target: 'http://localhost:8000',
         changeOrigin: true,
         ws: true,
+        proxyTimeout: 300_000,
+        timeout: 300_000,
       },
       '/ws': {
         target: 'ws://localhost:8000',


### PR DESCRIPTION
## Problem

`timeout:0` in Axios 1.7.x does not reliably override the instance-level `timeout:30_000` during config merge — the merge strategy uses `defaultToConfig2` and `0` (falsy) can fall back to the instance value. Result: bulk imports of ~50+ products hit the 30 s wall, Axios cancels the request, but FastAPI continues processing (so products still appear in Odoo).

Vite's http-proxy had no explicit timeout, but adding one prevents any Node socket-level hang on slow Odoo instances.

## Changes

- `frontend/src/api/client.ts` — `importOdooCsv` timeout `0` → `300_000` (explicit, non-falsy)
- `frontend/vite.config.ts` — proxy `/api` adds `proxyTimeout: 300_000` and `timeout: 300_000`

## Test plan

- [ ] Import 100+ products via CSV — no timeout error in UI, result panel shows correct counts
- [ ] Network tab shows the `/csv/import` request completes without being cancelled
