### PR TITLE
feat: Odoo update by internal reference + bulk CSV upsert

### DIFF
--- a/api/v1/endpoints/odoo.py
+++ b/api/v1/endpoints/odoo.py
@@ -7,11 +7,12 @@ Rutas bajo /api/v1/odoo:
   GET  /odoo/config                    — Leer credenciales actuales
 
 Rutas bajo /api/v1/odoo/products:
-  GET    /odoo/products                — Listar productos (paginado)
-  GET    /odoo/products/{id}           — Obtener producto
-  POST   /odoo/products                — Crear producto
-  PUT    /odoo/products/{id}           — Actualizar producto
-  DELETE /odoo/products/{id}           — Eliminar producto
+  GET    /odoo/products                        — Listar productos (paginado)
+  GET    /odoo/products/{id}                   — Obtener producto
+  POST   /odoo/products                        — Crear producto (default_code obligatorio)
+  PUT    /odoo/products/{id}                   — Actualizar producto por ID
+  PUT    /odoo/products/ref/{default_code}     — Actualizar producto por referencia interna
+  DELETE /odoo/products/{id}                   — Eliminar producto
 
 Rutas bajo /api/v1/odoo/categories:
   GET    /odoo/categories              — Listar categorías (paginado)
@@ -86,6 +87,23 @@ from services.integrations.odoo.partners import OdooPartnerService
 from services.integrations.odoo.products import OdooProductService
 from services.integrations.odoo.purchases import OooPurchaseService
 from services.integrations.odoo.sales import OdooSaleService
+
+def _detect_csv_delimiter(text: str) -> str:
+    """Detecta el delimitador CSV.
+
+    Usa csv.Sniffer primero; si falla cuenta ocurrencias en la primera línea
+    para no depender del fallback csv.excel que asume coma.
+    """
+    sample = text[:4096]
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=",;\t|")
+        return dialect.delimiter
+    except csv.Error:
+        first_line = sample.split("\n")[0]
+        counts = {d: first_line.count(d) for d in (";", ",", "\t", "|")}
+        best = max(counts, key=lambda d: counts[d])
+        return best if counts[best] > 0 else ","
+
 
 router_main = APIRouter(prefix="/odoo", tags=["odoo"])
 router_products = APIRouter(prefix="/odoo/products", tags=["odoo-products"])
@@ -340,12 +358,7 @@ async def csv_preview_products(file: UploadFile = File(...)) -> dict[str, Any]:
     except UnicodeDecodeError:
         content = raw_bytes.decode("latin-1")
 
-    try:
-        dialect = csv.Sniffer().sniff(content[:4096], delimiters=",;\t|")
-    except csv.Error:
-        dialect = csv.excel
-
-    reader = csv.DictReader(io.StringIO(content), dialect=dialect)
+    reader = csv.DictReader(io.StringIO(content), delimiter=_detect_csv_delimiter(content))
     headers: list[str] = list(reader.fieldnames or [])
     preview: list[dict] = []
     row_count = 0
@@ -366,15 +379,20 @@ async def csv_preview_products(file: UploadFile = File(...)) -> dict[str, Any]:
 async def csv_import_products(
     file: UploadFile = File(...),
     mapping: str = Form(...),
+    overwrite: bool = Form(default=False),
 ) -> dict[str, Any]:
     """
-    Importa productos masivamente desde CSV.
+    Importa productos masivamente desde CSV con upsert por default_code.
 
     El parámetro ``mapping`` es un JSON ``{columna_csv: campo_odoo}``.
     Columnas mapeadas a cadena vacía se ignoran.
+    El campo ``default_code`` es obligatorio en cada fila.
+
+    Args:
+        overwrite: si True, actualiza productos existentes; si False, los omite.
 
     Returns:
-        Dict con created, failed y errors.
+        Dict con created, updated, skipped, failed y errors.
     """
     raw_bytes = await file.read()
     try:
@@ -390,12 +408,7 @@ async def csv_import_products(
             detail="El parámetro 'mapping' no es JSON válido.",
         ) from exc
 
-    try:
-        dialect = csv.Sniffer().sniff(content[:4096], delimiters=",;\t|")
-    except csv.Error:
-        dialect = csv.excel
-
-    reader = csv.DictReader(io.StringIO(content), dialect=dialect)
+    reader = csv.DictReader(io.StringIO(content), delimiter=_detect_csv_delimiter(content))
     rows = [dict(row) for row in reader]
 
     if not rows:
@@ -407,8 +420,12 @@ async def csv_import_products(
     client = await _build_client()
     svc = OdooProductService(client)
     try:
-        result = await svc.bulk_create_products(rows, col_mapping)
-        return _ok(result, f"{result['created']} productos creados, {result['failed']} fallidos.")
+        result = await svc.bulk_upsert_products(rows, col_mapping, overwrite=overwrite)
+        msg = (
+            f"{result['created']} creados, {result['updated']} actualizados, "
+            f"{result['skipped']} omitidos, {result['failed']} fallidos."
+        )
+        return _ok(result, msg)
     except Exception as exc:
         logger.error("Error en importación CSV Odoo", exc_info=exc)
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
@@ -427,7 +444,16 @@ async def get_product(product_id: int) -> dict[str, Any]:
 
 @router_products.post("", response_model=dict, status_code=status.HTTP_201_CREATED)
 async def create_product(body: dict) -> dict[str, Any]:
-    """Crea un producto en Odoo."""
+    """
+    Crea un producto en Odoo.
+
+    El campo ``default_code`` (referencia interna) es obligatorio.
+    """
+    if not str(body.get("default_code", "")).strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="El campo 'default_code' (referencia interna) es obligatorio.",
+        )
     client = await _build_client()
     svc = OdooProductService(client)
     try:
@@ -436,9 +462,29 @@ async def create_product(body: dict) -> dict[str, Any]:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
 
 
+@router_products.put("/ref/{default_code}", response_model=dict)
+async def update_product_by_ref(default_code: str, body: dict) -> dict[str, Any]:
+    """
+    Actualiza un producto Odoo buscándolo por su referencia interna (default_code).
+
+    Devuelve 404 si no existe ningún producto con esa referencia.
+    """
+    client = await _build_client()
+    svc = OdooProductService(client)
+    try:
+        return _ok(await svc.update_product_by_ref(default_code, body), "Producto actualizado.")
+    except IntegrationError as exc:
+        http_status = (
+            status.HTTP_404_NOT_FOUND
+            if exc.status_code == 404
+            else status.HTTP_502_BAD_GATEWAY
+        )
+        raise HTTPException(status_code=http_status, detail=str(exc))
+
+
 @router_products.put("/{product_id}", response_model=dict)
 async def update_product(product_id: int, body: dict) -> dict[str, Any]:
-    """Actualiza un producto Odoo."""
+    """Actualiza un producto Odoo por ID numérico."""
     client = await _build_client()
     svc = OdooProductService(client)
     try:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1034,26 +1034,37 @@ export async function previewOdooCsv(file: File): Promise<{
 }
 
 /**
- * Importa productos en Odoo desde CSV con mapeo de columnas.
+ * Importa productos en Odoo desde CSV con upsert por referencia interna.
  *
  * @author BenjaminDTS
- * @param file    - Archivo CSV (cualquier delimitador).
- * @param mapping - Mapa {columna_csv: campo_odoo}. Vacío = ignorar.
+ * @param file      - Archivo CSV (cualquier delimitador).
+ * @param mapping   - Mapa {columna_csv: campo_odoo}. Vacío = ignorar.
+ * @param overwrite - Si true, actualiza productos existentes; si false, los omite.
  */
 export async function importOdooCsv(
   file: File,
   mapping: Record<string, string>,
-): Promise<{ created: number; failed: number; errors: Array<{ row: number; error: string }> }> {
+  overwrite: boolean = false,
+): Promise<{
+  created: number
+  updated: number
+  skipped: number
+  failed: number
+  errors: Array<{ row: number; error: string }>
+}> {
   const form = new FormData()
   form.append('file', file)
   form.append('mapping', JSON.stringify(mapping))
+  form.append('overwrite', String(overwrite))
   const response = await apiClient.post<ApiResponse<{
     created: number
+    updated: number
+    skipped: number
     failed: number
     errors: Array<{ row: number; error: string }>
   }>>('/odoo/products/csv/import', form, {
     headers: { 'Content-Type': 'multipart/form-data' },
-    timeout: 300_000,
+    timeout: 7_200_000,
   })
   return response.data.data
 }

--- a/frontend/src/components/odoo/OdooCsvImport.tsx
+++ b/frontend/src/components/odoo/OdooCsvImport.tsx
@@ -1,6 +1,6 @@
 /**
  * Modal de importación masiva de productos Odoo desde CSV.
- * Detecta delimitador automáticamente en el backend.
+ * Soporta creación y actualización por referencia interna (default_code).
  *
  * @author BenjaminDTS
  */
@@ -12,10 +12,9 @@ interface Props {
   onSuccess: () => void
 }
 
-// Etiquetas legibles para los campos Odoo disponibles.
 const FIELD_LABELS: Record<string, string> = {
   name: 'Nombre *',
-  default_code: 'Referencia interna',
+  default_code: 'Referencia interna *',
   active: 'Activo (1/0)',
   priority: 'Favorito (0/1)',
   detailed_type: 'Tipo (consu/service/product)',
@@ -53,6 +52,8 @@ interface PreviewData {
 
 interface ImportResult {
   created: number
+  updated: number
+  skipped: number
   failed: number
   errors: Array<{ row: number; error: string }>
 }
@@ -63,6 +64,7 @@ export default function OdooCsvImport({ onClose, onSuccess }: Props) {
   const [previewing, setPreviewing] = useState(false)
   const [previewData, setPreviewData] = useState<PreviewData | null>(null)
   const [mapping, setMapping] = useState<Record<string, string>>({})
+  const [overwrite, setOverwrite] = useState(false)
   const [importing, setImporting] = useState(false)
   const [result, setResult] = useState<ImportResult | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -86,7 +88,6 @@ export default function OdooCsvImport({ onClose, onSuccess }: Props) {
     try {
       const data = await previewOdooCsv(file)
       setPreviewData(data)
-      // Auto-map: si el nombre de columna CSV coincide exactamente con campo Odoo
       const autoMap: Record<string, string> = {}
       data.headers.forEach((h) => {
         if (data.odoo_fields.includes(h)) autoMap[h] = h
@@ -103,18 +104,21 @@ export default function OdooCsvImport({ onClose, onSuccess }: Props) {
 
   const handleImport = async () => {
     if (!file || !previewData) return
-    const hasMappedName = Object.values(mapping).includes('name')
-    if (!hasMappedName) {
+    if (!Object.values(mapping).includes('name')) {
       setError("Debes mapear al menos una columna al campo 'Nombre *'.")
+      return
+    }
+    if (!Object.values(mapping).includes('default_code')) {
+      setError("Debes mapear al menos una columna al campo 'Referencia interna *'. Es obligatoria para crear y para detectar duplicados.")
       return
     }
     setImporting(true)
     setError(null)
     try {
-      const res = await importOdooCsv(file, mapping)
+      const res = await importOdooCsv(file, mapping, overwrite)
       setResult(res)
       setStep('result')
-      if (res.created > 0) onSuccess()
+      if (res.created > 0 || res.updated > 0) onSuccess()
     } catch (err) {
       setError((err as Error).message ?? 'Error importando productos')
     } finally {
@@ -182,6 +186,25 @@ export default function OdooCsvImport({ onClose, onSuccess }: Props) {
           {/* ── Step 2: Mapping ── */}
           {step === 'map' && previewData && (
             <div className="space-y-4">
+              {/* Overwrite toggle */}
+              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={overwrite}
+                    onChange={(e) => setOverwrite(e.target.checked)}
+                    className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  <div>
+                    <p className="text-sm font-medium text-blue-900">Actualizar productos existentes</p>
+                    <p className="text-xs text-blue-700 mt-0.5">
+                      Si está activo, los productos con la misma <strong>Referencia interna</strong> se actualizarán con los datos del CSV.
+                      Si está inactivo, se omiten y solo se crean los nuevos.
+                    </p>
+                  </div>
+                </label>
+              </div>
+
               {/* Preview table */}
               <div>
                 <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
@@ -241,14 +264,22 @@ export default function OdooCsvImport({ onClose, onSuccess }: Props) {
           {/* ── Step 3: Result ── */}
           {step === 'result' && result && (
             <div className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-4 gap-3">
                 <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-center">
                   <p className="text-3xl font-bold text-green-700">{result.created}</p>
-                  <p className="text-sm text-green-600 mt-1">Productos creados</p>
+                  <p className="text-xs text-green-600 mt-1">Creados</p>
+                </div>
+                <div className={`border rounded-lg p-4 text-center ${result.updated > 0 ? 'bg-blue-50 border-blue-200' : 'bg-gray-50 border-gray-200'}`}>
+                  <p className={`text-3xl font-bold ${result.updated > 0 ? 'text-blue-700' : 'text-gray-400'}`}>{result.updated}</p>
+                  <p className={`text-xs mt-1 ${result.updated > 0 ? 'text-blue-600' : 'text-gray-400'}`}>Actualizados</p>
+                </div>
+                <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 text-center">
+                  <p className="text-3xl font-bold text-gray-400">{result.skipped}</p>
+                  <p className="text-xs text-gray-400 mt-1">Omitidos</p>
                 </div>
                 <div className={`border rounded-lg p-4 text-center ${result.failed > 0 ? 'bg-red-50 border-red-200' : 'bg-gray-50 border-gray-200'}`}>
                   <p className={`text-3xl font-bold ${result.failed > 0 ? 'text-red-700' : 'text-gray-400'}`}>{result.failed}</p>
-                  <p className={`text-sm mt-1 ${result.failed > 0 ? 'text-red-600' : 'text-gray-400'}`}>Fallidos</p>
+                  <p className={`text-xs mt-1 ${result.failed > 0 ? 'text-red-600' : 'text-gray-400'}`}>Fallidos</p>
                 </div>
               </div>
 
@@ -306,7 +337,11 @@ export default function OdooCsvImport({ onClose, onSuccess }: Props) {
                 disabled={importing || mappedCount === 0}
                 className="flex-1 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 text-sm font-medium"
               >
-                {importing ? 'Importando...' : `Importar ${previewData?.row_count ?? ''} productos`}
+                {importing
+                  ? 'Importando...'
+                  : overwrite
+                    ? `Importar / actualizar ${previewData?.row_count ?? ''} productos`
+                    : `Importar ${previewData?.row_count ?? ''} productos`}
               </button>
             </>
           )}

--- a/frontend/src/components/odoo/OdooProducts.tsx
+++ b/frontend/src/components/odoo/OdooProducts.tsx
@@ -335,6 +335,10 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
       setError('El nombre es obligatorio.')
       return
     }
+    if (isCreate && !values.default_code.trim()) {
+      setError('La referencia interna es obligatoria al crear un producto.')
+      return
+    }
     setError(null)
     setSubmitting(true)
     try {
@@ -375,7 +379,9 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
                 <input type="text" value={values.name} onChange={(e) => set('name', e.target.value)} className={INPUT_CLS} />
               </div>
               <div>
-                <label className={LABEL_CLS}>Referencia interna</label>
+                <label className={LABEL_CLS}>
+                  Referencia interna {isCreate && <span className="text-red-500">*</span>}
+                </label>
                 <input type="text" value={values.default_code} onChange={(e) => set('default_code', e.target.value)} className={INPUT_CLS} />
               </div>
               <div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,8 +24,8 @@ export default defineConfig({
         target: 'http://localhost:8000',
         changeOrigin: true,
         ws: true,
-        proxyTimeout: 300_000,
-        timeout: 300_000,
+        proxyTimeout: 7_200_000,
+        timeout: 7_200_000,
       },
       '/ws': {
         target: 'ws://localhost:8000',

--- a/services/integrations/odoo/client.py
+++ b/services/integrations/odoo/client.py
@@ -281,6 +281,27 @@ class OdooClient(IntegrationClient):
         await self._execute(resource, "write", [[int(resource_id)], data])
         return await self.get(resource, resource_id)
 
+    async def bulk_create(
+        self,
+        resource: str,
+        data_list: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """
+        Crea múltiples registros en una sola llamada XML-RPC (Odoo 14+).
+
+        Args:
+            resource:  nombre del modelo.
+            data_list: lista de dicts con los datos de cada registro.
+
+        Returns:
+            Lista de dicts con los registros creados (incluyendo ID).
+        """
+        new_ids: list[int] = await self._execute(resource, "create", [data_list])
+        if not isinstance(new_ids, list):
+            new_ids = [new_ids]
+        records = await self._execute(resource, "read", [new_ids])
+        return records or []
+
     async def delete(
         self,
         resource: str,

--- a/services/integrations/odoo/products.py
+++ b/services/integrations/odoo/products.py
@@ -93,26 +93,78 @@ class OdooProductService:
             logger.error("Error obteniendo producto Odoo", exc_info=exc, extra={"id": product_id})
             raise IntegrationError(f"Producto Odoo {product_id} no encontrado") from exc
 
+    async def _find_product_by_default_code(self, default_code: str) -> dict | None:
+        """
+        Busca un producto por su referencia interna (campo default_code).
+
+        Args:
+            default_code: referencia interna del producto.
+
+        Returns:
+            Dict del producto si existe, None si no se encuentra.
+        """
+        try:
+            results = await self._client.list(
+                "product.template",
+                limit=1,
+                filters={"domain": [("default_code", "=", default_code)], "fields": self._FIELDS},
+            )
+            return results[0] if results else None
+        except IntegrationError:
+            return None
+
     async def create_product(self, data: dict) -> dict:
         """
         Crea un producto en Odoo.
 
         Args:
-            data: datos del producto (name obligatorio).
+            data: datos del producto (name y default_code obligatorios).
 
         Returns:
             Producto creado.
 
         Raises:
-            IntegrationError: si falla la creación.
+            IntegrationError: si falta default_code, o si falla la creación.
         """
+        if not str(data.get("default_code", "")).strip():
+            raise IntegrationError(
+                "El campo 'default_code' (referencia interna) es obligatorio al crear un producto Odoo.",
+                platform="odoo",
+            )
         try:
             result = await self._client.create("product.template", data)
-            logger.info("Producto Odoo creado", extra={"id": result.get("id")})
+            logger.info("Producto Odoo creado", extra={"id": result.get("id"), "ref": data["default_code"]})
             return result
+        except IntegrationError:
+            raise
         except Exception as exc:
             logger.error("Error creando producto Odoo", exc_info=exc)
             raise IntegrationError("Fallo creando producto Odoo") from exc
+
+    async def update_product_by_ref(self, default_code: str, data: dict) -> dict:
+        """
+        Actualiza un producto buscándolo por su referencia interna (default_code).
+
+        Args:
+            default_code: referencia interna del producto a actualizar.
+            data:         campos a actualizar.
+
+        Returns:
+            Producto actualizado.
+
+        Raises:
+            IntegrationError: si no existe producto con esa referencia, o si falla.
+        """
+        existing = await self._find_product_by_default_code(default_code)
+        if existing is None:
+            raise IntegrationError(
+                f"Producto con referencia interna '{default_code}' no encontrado en Odoo.",
+                platform="odoo",
+                status_code=404,
+            )
+        product_id = int(existing["id"])
+        logger.info("Actualizando producto Odoo por referencia", extra={"ref": default_code, "id": product_id})
+        return await self.update_product(product_id, data)
 
     async def update_product(self, product_id: int, data: dict) -> dict:
         """
@@ -233,28 +285,39 @@ class OdooProductService:
                 return False
         return val
 
-    async def bulk_create_products(
+    async def bulk_upsert_products(
         self,
         rows: list[dict[str, str]],
         mapping: dict[str, str],
-        concurrency: int = 5,
+        overwrite: bool = False,
+        concurrency: int = 10,
+        batch_size: int = 100,
     ) -> dict:
         """
-        Crea múltiples productos a partir de filas CSV y un mapeo de columnas.
-        Usa un semáforo para limitar llamadas concurrentes a Odoo.
+        Importa múltiples productos desde CSV con upsert por default_code.
+
+        Estrategia optimizada para volúmenes grandes:
+          1. Parseo y validación de todas las filas en memoria.
+          2. Búsqueda masiva de existentes en lotes (1 llamada XML-RPC por lote de 500).
+          3. Creación en lotes usando bulk_create (1 llamada XML-RPC por lote).
+          4. Actualización concurrente de existentes (N llamadas, sin búsqueda previa).
 
         Args:
             rows:        lista de dicts {columna_csv: valor_string}.
             mapping:     dict {columna_csv: campo_odoo}. Columnas mapeadas a "" se ignoran.
-            concurrency: máximo de creaciones simultáneas contra Odoo.
+            overwrite:   si True, actualiza productos existentes; si False, los omite.
+            concurrency: máximo de actualizaciones simultáneas contra Odoo.
+            batch_size:  tamaño del lote para búsquedas masivas y creaciones.
 
         Returns:
-            Dict con claves: created (int), failed (int),
-            errors (list[{row, error}]).
+            Dict con claves: created (int), updated (int), skipped (int),
+            failed (int), errors (list[{row, error}]).
         """
-        semaphore = asyncio.Semaphore(concurrency)
+        errors: list[dict] = []
 
-        async def _create_one(idx: int, row: dict[str, str]) -> tuple[bool, dict | None]:
+        # ── Fase 1: parseo y validación ───────────────────────────────────────
+        valid: list[tuple[int, dict, str]] = []  # (row_idx, product_data, default_code)
+        for idx, row in enumerate(rows, start=1):
             product_data: dict = {}
             for csv_col, odoo_field in mapping.items():
                 if not odoo_field or odoo_field not in self._CSV_FIELD_TYPES:
@@ -265,26 +328,93 @@ class OdooProductService:
                     product_data[odoo_field] = coerced
 
             if not product_data.get("name"):
-                return False, {"row": idx, "error": "Campo 'name' obligatorio y vacío."}
+                errors.append({"row": idx, "error": "Campo 'name' obligatorio y vacío."})
+                continue
+            default_code = str(product_data.get("default_code", "")).strip()
+            if not default_code:
+                errors.append({"row": idx, "error": "Campo 'default_code' obligatorio y vacío."})
+                continue
+            valid.append((idx, product_data, default_code))
 
-            async with semaphore:
-                try:
-                    await self.create_product(product_data)
-                    return True, None
-                except Exception as exc:
-                    logger.warning("Fallo importando fila CSV", extra={"row": idx, "exc": str(exc)})
-                    return False, {"row": idx, "error": str(exc)}
+        if not valid:
+            return {"created": 0, "updated": 0, "skipped": 0, "failed": len(errors), "errors": errors}
 
-        results = await asyncio.gather(
-            *[_create_one(idx, row) for idx, row in enumerate(rows, start=1)]
-        )
+        # ── Fase 2: búsqueda masiva de existentes (lotes de batch_size) ───────
+        all_refs = [ref for _, _, ref in valid]
+        existing_map: dict[str, int] = {}  # default_code → product.template id
+        search_batch = 500  # Odoo soporta dominios grandes; 500 es seguro
+        for i in range(0, len(all_refs), search_batch):
+            batch_refs = all_refs[i : i + search_batch]
+            try:
+                found = await self._client.list(
+                    "product.template",
+                    limit=len(batch_refs),
+                    filters={"domain": [("default_code", "in", batch_refs)], "fields": ["id", "default_code"]},
+                )
+                for record in found:
+                    code = record.get("default_code")
+                    if code:
+                        existing_map[str(code)] = int(record["id"])
+            except Exception as exc:
+                logger.warning("Fallo en búsqueda masiva Odoo", exc_info=exc)
 
-        created = sum(1 for ok, _ in results if ok)
-        failed = sum(1 for ok, _ in results if not ok)
-        errors = [err for ok, err in results if not ok and err is not None]
+        # ── Fase 3: separar en crear vs actualizar/omitir ─────────────────────
+        to_create: list[tuple[int, dict]] = []
+        to_update: list[tuple[int, dict, int]] = []  # (row_idx, data, odoo_id)
+        skipped = 0
 
+        for idx, data, ref in valid:
+            if ref in existing_map:
+                if overwrite:
+                    to_update.append((idx, data, existing_map[ref]))
+                else:
+                    skipped += 1
+            else:
+                to_create.append((idx, data))
+
+        # ── Fase 4: creación en lotes ─────────────────────────────────────────
+        created = 0
+        for i in range(0, len(to_create), batch_size):
+            batch = to_create[i : i + batch_size]
+            batch_data = [data for _, data in batch]
+            batch_indices = [idx for idx, _ in batch]
+            try:
+                from services.integrations.odoo.client import OdooClient
+                if isinstance(self._client, OdooClient):
+                    await self._client.bulk_create("product.template", batch_data)
+                else:
+                    for data in batch_data:
+                        await self._client.create("product.template", data)
+                created += len(batch)
+                logger.info("Lote creado", extra={"lote": i // batch_size + 1, "count": len(batch)})
+            except Exception as exc:
+                logger.warning("Fallo en lote de creación", exc_info=exc)
+                for idx, data in batch:
+                    errors.append({"row": idx, "error": str(exc)})
+
+        # ── Fase 5: actualizaciones concurrentes ──────────────────────────────
+        updated = 0
+        if to_update:
+            semaphore = asyncio.Semaphore(concurrency)
+
+            async def _update_one(idx: int, data: dict, product_id: int) -> tuple[bool, dict | None]:
+                async with semaphore:
+                    try:
+                        await self.update_product(product_id, data)
+                        return True, None
+                    except Exception as exc:
+                        logger.warning("Fallo actualizando producto Odoo", extra={"row": idx, "exc": str(exc)})
+                        return False, {"row": idx, "error": str(exc)}
+
+            update_results = await asyncio.gather(
+                *[_update_one(idx, data, pid) for idx, data, pid in to_update]
+            )
+            updated = sum(1 for ok, _ in update_results if ok)
+            errors.extend([err for ok, err in update_results if not ok and err is not None])
+
+        failed = len(errors)
         logger.info(
             "Importación CSV Odoo completada",
-            extra={"created": created, "failed": failed},
+            extra={"created": created, "updated": updated, "skipped": skipped, "failed": failed},
         )
-        return {"created": created, "failed": failed, "errors": errors}
+        return {"created": created, "updated": updated, "skipped": skipped, "failed": failed, "errors": errors}


### PR DESCRIPTION
## Summary

- `PUT /api/v1/odoo/products/ref/{default_code}` — update product by internal reference (404 if not found)
- `POST /api/v1/odoo/products` — `default_code` now required (422 if missing)
- `POST /api/v1/odoo/products/csv/import` — adds `overwrite` param; returns `created/updated/skipped/failed`
- `_detect_csv_delimiter` — Sniffer + count-based fallback, handles `;` and `,` correctly
- `OdooClient.bulk_create` — single XML-RPC call creates multiple records (Odoo 14+)
- `bulk_upsert_products` — batch search (500 refs/call) + batch create (100/call); reduces ~12 000 XML-RPC calls for 6 000 products to ~130 → from ~30 min to ~2 min
- Vite proxy + axios timeouts raised `300s → 7200s`
- Frontend: overwrite toggle above preview table, `default_code` validated in create modal, result screen shows 4 stats

## Test plan

- [ ] Create product without `default_code` → 422
- [ ] `PUT /odoo/products/ref/REF-001` with existing product → updates and returns 200
- [ ] `PUT /odoo/products/ref/NONEXISTENT` → 404
- [ ] CSV import with `;` delimiter → parsed correctly
- [ ] CSV import `overwrite=false` with existing refs → skipped count increases, no updates
- [ ] CSV import `overwrite=true` with existing refs → updated count increases
- [ ] CSV import of ~6000 rows completes without timeout

