### PR TITLE
refactor: unify extra fields save into main product save button

### DIFF
--- a/api/v1/endpoints/odoo.py
+++ b/api/v1/endpoints/odoo.py
@@ -68,7 +68,7 @@ import json
 from typing import Any
 
 import redis.asyncio as aioredis
-from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, Body, File, Form, HTTPException, Query, UploadFile, status
 from loguru import logger
 
 from api.core.config import get_settings
@@ -1053,7 +1053,7 @@ async def get_product_properties(
 
 
 @router_properties.put("/products/{product_id}/properties", response_model=dict)
-async def set_product_properties(product_id: int, body: list) -> dict[str, Any]:
+async def set_product_properties(product_id: int, body: list = Body(...)) -> dict[str, Any]:
     """
     Establece o actualiza múltiples valores de campos extra en un producto.
 

--- a/frontend/src/components/odoo/OdooProductProperties.tsx
+++ b/frontend/src/components/odoo/OdooProductProperties.tsx
@@ -9,8 +9,8 @@
  *
  * @author Carlitos6712
  */
-import { useEffect, useState } from 'react'
-import { getOdooProductProperties, setOdooProductProperties } from '@/api/client'
+import { useEffect, useRef, useState } from 'react'
+import { getOdooCategoryProperties, getOdooProductProperties } from '@/api/client'
 import type { OdooPropertyValue, OdooPropertyType } from '@/types/odoo'
 
 const INPUT_CLS =
@@ -28,19 +28,22 @@ const TYPE_LABELS: Record<OdooPropertyType, string> = {
 }
 
 interface Props {
-  productId: number
+  /** null = create mode (no product ID yet) */
+  productId: number | null
   categoryId: number | false
+  /** Called in create mode whenever field values change — parent collects for post-create save */
+  onPropertiesChange?: (props: OdooPropertyValue[]) => void
 }
 
-export default function OdooProductProperties({ productId, categoryId }: Props) {
+export default function OdooProductProperties({ productId, categoryId, onPropertiesChange }: Props) {
   const [properties, setProperties] = useState<OdooPropertyValue[]>([])
   const [values, setValues] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(true)
-  const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [successMsg, setSuccessMsg] = useState<string | null>(null)
 
   const catId = typeof categoryId === 'number' ? categoryId : null
+  const onPropertiesChangeRef = useRef(onPropertiesChange)
+  onPropertiesChangeRef.current = onPropertiesChange
 
   useEffect(() => {
     if (!catId) {
@@ -49,41 +52,55 @@ export default function OdooProductProperties({ productId, categoryId }: Props) 
     }
     setLoading(true)
     setError(null)
-    getOdooProductProperties(productId, catId)
-      .then((props) => {
-        const safe = Array.isArray(props) ? props : []
-        setProperties(safe)
-        const map: Record<string, string> = {}
-        for (const p of safe) {
-          map[p.name] = p.value == null || p.value === false ? '' : String(p.value)
-        }
-        setValues(map)
-      })
-      .catch((err) => setError((err as Error).message ?? 'Error cargando campos extra'))
-      .finally(() => setLoading(false))
+
+    if (productId === null) {
+      // Create mode: load definitions from the category, no existing values
+      getOdooCategoryProperties(catId)
+        .then((defs) => {
+          const safe = Array.isArray(defs) ? defs : []
+          const asValues: OdooPropertyValue[] = safe.map((d) => ({
+            name: d.name,
+            type: d.type,
+            string: d.string,
+            value: d.default ?? null,
+          }))
+          setProperties(asValues)
+          const map: Record<string, string> = {}
+          for (const p of asValues) {
+            map[p.name] = p.value == null || p.value === false ? '' : String(p.value)
+          }
+          setValues(map)
+        })
+        .catch((err) => setError((err as Error).message ?? 'Error cargando campos extra'))
+        .finally(() => setLoading(false))
+    } else {
+      // Edit mode: load existing product property values
+      getOdooProductProperties(productId, catId)
+        .then((props) => {
+          const safe = Array.isArray(props) ? props : []
+          setProperties(safe)
+          const map: Record<string, string> = {}
+          for (const p of safe) {
+            map[p.name] = p.value == null || p.value === false ? '' : String(p.value)
+          }
+          setValues(map)
+        })
+        .catch((err) => setError((err as Error).message ?? 'Error cargando campos extra'))
+        .finally(() => setLoading(false))
+    }
   }, [productId, catId])
 
-  const handleSave = async () => {
-    if (!catId) return
-    setSaving(true)
-    setError(null)
-    setSuccessMsg(null)
-    try {
-      const payload: OdooPropertyValue[] = properties.map((p) => ({
-        name: p.name,
-        type: p.type,
-        string: p.string,
-        value: coerceValue(values[p.name] ?? '', p.type),
-      }))
-      await setOdooProductProperties(productId, payload)
-      setSuccessMsg('Campos extra guardados.')
-      setTimeout(() => setSuccessMsg(null), 3000)
-    } catch (err) {
-      setError((err as Error).message ?? 'Error guardando campos extra')
-    } finally {
-      setSaving(false)
-    }
-  }
+  // Notify parent of current property values so it can include them in the main save
+  useEffect(() => {
+    if (!onPropertiesChangeRef.current || properties.length === 0) return
+    const payload: OdooPropertyValue[] = properties.map((p) => ({
+      name: p.name,
+      type: p.type,
+      string: p.string,
+      value: coerceValue(values[p.name] ?? '', p.type),
+    }))
+    onPropertiesChangeRef.current(payload)
+  }, [values, properties, productId])
 
   if (!catId) {
     return (
@@ -110,9 +127,6 @@ export default function OdooProductProperties({ productId, categoryId }: Props) 
       {error && (
         <div className="bg-red-50 border-l-4 border-red-400 p-3 rounded text-xs text-red-700">{error}</div>
       )}
-      {successMsg && (
-        <div className="bg-green-50 border-l-4 border-green-400 p-3 rounded text-xs text-green-700">{successMsg}</div>
-      )}
 
       {properties.map((prop) => (
         <div key={prop.name}>
@@ -129,14 +143,6 @@ export default function OdooProductProperties({ productId, categoryId }: Props) 
           />
         </div>
       ))}
-
-      <button
-        onClick={handleSave}
-        disabled={saving}
-        className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
-      >
-        {saving ? 'Guardando...' : 'Guardar campos extra'}
-      </button>
     </div>
   )
 }

--- a/frontend/src/components/odoo/OdooProducts.tsx
+++ b/frontend/src/components/odoo/OdooProducts.tsx
@@ -4,8 +4,8 @@
  * @author Carlitos6712
  */
 import { useEffect, useState } from 'react'
-import { listOdooProducts, deleteOdooProduct, updateOdooProduct, createOdooProduct, listOdooCategories } from '@/api/client'
-import type { OdooProduct, OdooCategory } from '@/types/odoo'
+import { listOdooProducts, deleteOdooProduct, updateOdooProduct, createOdooProduct, listOdooCategories, setOdooProductProperties } from '@/api/client'
+import type { OdooProduct, OdooCategory, OdooPropertyValue } from '@/types/odoo'
 import OdooCsvImport from './OdooCsvImport'
 import OdooProductProperties from './OdooProductProperties'
 
@@ -321,6 +321,7 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
   const [categories, setCategories] = useState<OdooCategory[]>([])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [pendingProperties, setPendingProperties] = useState<OdooPropertyValue[]>([])
 
   useEffect(() => {
     listOdooCategories(200, 0)
@@ -344,9 +345,23 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
     setSubmitting(true)
     try {
       if (isCreate) {
-        await createOdooProduct(buildPayload(values))
+        const created = await createOdooProduct(buildPayload(values))
+        if (pendingProperties.length > 0) {
+          try {
+            await setOdooProductProperties(created.id, pendingProperties)
+          } catch {
+            // Properties save failed — product already created, close modal and reload
+          }
+        }
       } else {
         await updateOdooProduct(product.id, buildPayload(values))
+        if (pendingProperties.length > 0) {
+          try {
+            await setOdooProductProperties(product.id, pendingProperties)
+          } catch {
+            // Properties save failed — product fields already updated
+          }
+        }
       }
       onSuccess()
     } catch (err) {
@@ -577,13 +592,14 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
             <textarea rows={4} value={values.description} onChange={(e) => set('description', e.target.value)} className={INPUT_CLS} />
           </div>
 
-          {/* Campos extra (Properties) — solo en edición */}
-          {!isCreate && (
+          {/* Campos extra — visible cuando hay categoría seleccionada */}
+          {values.categ_id && (
             <div className={SECTION_CLS}>
               <p className={SECTION_TITLE_CLS}>Campos extra</p>
               <OdooProductProperties
-                productId={product!.id}
-                categoryId={Array.isArray(product!.categ_id) ? product!.categ_id[0] : false}
+                productId={isCreate ? null : product!.id}
+                categoryId={parseInt(values.categ_id, 10)}
+                onPropertiesChange={setPendingProperties}
               />
             </div>
           )}


### PR DESCRIPTION
## Summary

- Remove standalone **Guardar campos extra** button from `OdooProductProperties`
- `onPropertiesChange` callback now fires in both create and edit modes, keeping parent always in sync with current property values
- `ProductModal.handleSubmit` calls `setOdooProductProperties` after `updateOdooProduct` in edit mode — a single **Guardar cambios** saves product fields and extra fields atomically
- Fix `Body()` annotation missing on `set_product_properties` FastAPI endpoint

## Test plan

- [ ] Edit product with a category that has extra fields → change values → click **Guardar cambios** → verify extra fields saved in Odoo
- [ ] Create product with extra fields → verify extra fields still saved after creation
- [ ] Edit product with no extra fields → verify save works normally
- [ ] Confirm no **Guardar campos extra** button appears anywhere in the modal