### PR TITLE
feat: Dolibarr async CSV import with categories and tosell/tobuy fix

### DIFF
--- a/api/v1/endpoints/dolibarr.py
+++ b/api/v1/endpoints/dolibarr.py
@@ -52,8 +52,12 @@ Todos los endpoints devuelven 503 si Dolibarr no está configurado.
 from __future__ import annotations
 
 import asyncio
+import base64
+import csv
+import io
 import json
 import tempfile
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -180,6 +184,25 @@ def _get_service() -> DolibarrProductService:
             detail=_NOT_CONFIGURED_MSG,
         )
     return DolibarrProductService(client)
+
+
+async def _get_services_async() -> tuple[DolibarrProductService, DolibarrCategoryService]:
+    """
+    Construye y devuelve DolibarrProductService y DolibarrCategoryService compartiendo cliente.
+
+    Raises:
+        HTTPException 503: si Dolibarr no está configurado.
+    """
+    settings = get_settings()
+    try:
+        url, api_key = await _get_dolibarr_credentials()
+        client = DolibarrClient(settings, override_url=url, override_api_key=api_key)
+    except IntegrationNotConfiguredError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_NOT_CONFIGURED_MSG,
+        )
+    return DolibarrProductService(client), DolibarrCategoryService(client)
 
 
 def _ok(data: Any, message: str = "OK") -> dict[str, Any]:
@@ -605,16 +628,36 @@ async def create_product(data: dict) -> JSONResponse:
     BD directa para evitar el error de Dolibarr "Field X doesn't have a default
     value" que afecta al endpoint REST PUT /products/{id}.
 
+    Si el payload incluye ``category_name``, el producto se asigna a esa
+    categoría tras la creación. La categoría debe existir previamente con ese
+    nombre exacto; si no existe se devuelve 422.
+
     Args:
         data: campos del producto (ref, label, price, description, type, status,
-              array_options opcional con extrafields).
+              array_options opcional con extrafields, category_name opcional).
 
     Returns:
         Respuesta estándar (201) con el producto creado.
     """
     array_options: dict = data.pop("array_options", None) or {}
+    category_name: str = (data.pop("category_name", None) or "").strip()
 
-    svc = await _get_service_async()
+    svc, cat_svc = await _get_services_async()
+
+    # Pre-validate category before creating the product to avoid partial state
+    category_id: int | None = None
+    if category_name:
+        cat = await cat_svc.find_category_by_name(category_name)
+        if cat is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"La categoría '{category_name}' no existe en Dolibarr. "
+                    "Créala primero desde el módulo de Categorías."
+                ),
+            )
+        category_id = int(cat["id"])
+
     try:
         created = await svc.create_product(data)
     except IntegrationError as exc:
@@ -642,6 +685,20 @@ async def create_product(data: dict) -> JSONResponse:
                 extra={"product_id": product_id},
             )
 
+    if category_id and product_id:
+        try:
+            await cat_svc.assign_product(category_id, product_id)
+            logger.info(
+                "Categoría asignada a producto creado",
+                extra={"product_id": product_id, "category": category_name},
+            )
+        except Exception as exc:
+            logger.warning(
+                "Error asignando categoría tras crear producto",
+                exc_info=exc,
+                extra={"product_id": product_id, "category": category_name},
+            )
+
     return JSONResponse(
         content=_ok(created, "Producto creado."),
         status_code=status.HTTP_201_CREATED,
@@ -657,16 +714,36 @@ async def update_product(product_id: int, data: dict) -> JSONResponse:
     via BD directa para evitar el error MySQL "Field X doesn't have a default
     value" que devuelve Dolibarr al actualizar extrafields via REST.
 
+    Si el payload incluye ``category_name``, asigna el producto a esa categoría
+    tras la actualización. La categoría debe existir previamente con ese nombre
+    exacto; si no existe se devuelve 422.
+
     Args:
         product_id: ID del producto en Dolibarr.
-        data:       campos a actualizar (puede incluir array_options).
+        data:       campos a actualizar (puede incluir array_options y category_name).
 
     Returns:
         Respuesta estándar con el producto actualizado.
     """
     array_options: dict = data.pop("array_options", None) or {}
+    category_name: str = (data.pop("category_name", None) or "").strip()
 
-    svc = await _get_service_async()
+    svc, cat_svc = await _get_services_async()
+
+    # Pre-validate category before updating
+    category_id: int | None = None
+    if category_name:
+        cat = await cat_svc.find_category_by_name(category_name)
+        if cat is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"La categoría '{category_name}' no existe en Dolibarr. "
+                    "Créala primero desde el módulo de Categorías."
+                ),
+            )
+        category_id = int(cat["id"])
+
     try:
         updated = await svc.update_product(product_id, data)
     except IntegrationError as exc:
@@ -690,6 +767,20 @@ async def update_product(product_id: int, data: dict) -> JSONResponse:
                 "Extrafields no guardados tras actualizar producto",
                 exc_info=exc,
                 extra={"product_id": product_id},
+            )
+
+    if category_id:
+        try:
+            await cat_svc.assign_product(category_id, product_id)
+            logger.info(
+                "Categoría asignada a producto actualizado",
+                extra={"product_id": product_id, "category": category_name},
+            )
+        except Exception as exc:
+            logger.warning(
+                "Error asignando categoría tras actualizar producto",
+                exc_info=exc,
+                extra={"product_id": product_id, "category": category_name},
             )
 
     return JSONResponse(content=_ok(updated, "Producto actualizado."))
@@ -804,27 +895,32 @@ async def csv_preview(file: UploadFile) -> JSONResponse:
     return JSONResponse(content=_ok(result.model_dump(), "CSV analizado."))
 
 
-@router_products.post("/import")
+@router_products.post("/import", status_code=status.HTTP_202_ACCEPTED)
 async def import_from_csv(
     file: UploadFile,
     mapping: str = Form(...),
     overwrite: bool = Form(default=False),
+    category_column: str = Form(default=""),
 ) -> JSONResponse:
     """
-    Importa productos en masa a Dolibarr desde un CSV con mapeo de columnas.
+    Inicia la importación masiva de productos desde CSV como tarea Celery asíncrona.
 
-    El campo ``mapping`` debe ser un JSON que mapea nombre_columna_csv →
-    campo_dolibarr (e.g. ``{"Referencia": "ref", "Nombre": "label"}``).
-    El campo ``ref`` es obligatorio en el mapeo.
+    Valida el CSV, el mapeo y las categorías de forma síncrona. Si todo es correcto,
+    encola la tarea y devuelve un ``task_id`` inmediatamente (HTTP 202).
+    El cliente debe hacer polling a ``GET /import/{task_id}/status`` para consultar
+    el progreso y obtener los resultados cuando la tarea termine.
 
     Args:
-        file:      CSV de productos (multipart).
-        mapping:   JSON string con el mapeo columna → campo Dolibarr.
-        overwrite: si True, actualiza productos que ya existen en Dolibarr.
+        file:            CSV de productos (multipart).
+        mapping:         JSON string con el mapeo columna → campo Dolibarr.
+        overwrite:       si True, actualiza productos que ya existen en Dolibarr.
+        category_column: nombre de la columna CSV que contiene el nombre de categoría.
 
     Returns:
-        CsvImportResponse con contadores (created/updated/skipped/errors) y resultados por fila.
+        HTTP 202 con ``{task_id, status: "pending"}``.
     """
+    from workers.tasks import importar_productos_dolibarr  # noqa: PLC0415
+
     content = await file.read()
     if len(content) > _MAX_CSV_BYTES:
         raise HTTPException(
@@ -846,42 +942,120 @@ async def import_from_csv(
             detail="El mapeo debe incluir al menos una columna asignada al campo 'ref'.",
         )
 
-    svc = await _get_service_async()
+    cat_col = category_column.strip()
+    _, cat_svc = await _get_services_async()
 
-    logger.info(
-        "Iniciando importación CSV a Dolibarr",
-        extra={"mapped_fields": len(mapping_dict), "overwrite": overwrite},
+    # Pre-validar categorías de forma síncrona antes de encolar
+    category_name_to_id: dict[str, int] = {}
+    if cat_col:
+        try:
+            text = content.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            text = content.decode("latin-1")
+        try:
+            dialect = csv.Sniffer().sniff(text[:4096], delimiters=",;\t|")
+            delimiter = dialect.delimiter
+        except csv.Error:
+            first_line = text.split("\n")[0]
+            counts = {d: first_line.count(d) for d in (";", ",", "\t", "|")}
+            best = max(counts, key=lambda d: counts[d])
+            delimiter = best if counts[best] > 0 else ","
+
+        reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
+        unique_names: set[str] = set()
+        for row in reader:
+            name = (row.get(cat_col) or "").strip()
+            if name:
+                unique_names.add(name)
+
+        missing: list[str] = []
+        for name in unique_names:
+            cat = await cat_svc.find_category_by_name(name)
+            if cat is None:
+                missing.append(name)
+            else:
+                category_name_to_id[name] = int(cat["id"])
+
+        if missing:
+            missing_list = ", ".join(f"'{c}'" for c in sorted(missing))
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"Categorías no encontradas en Dolibarr: {missing_list}. "
+                    "Créalas primero desde el módulo de Categorías con el nombre exacto."
+                ),
+            )
+
+    dolibarr_url, dolibarr_api_key = await _get_dolibarr_credentials()
+
+    task_id = str(uuid.uuid4())
+    settings = get_settings()
+    redis_client: aioredis.Redis | None = None
+    try:
+        redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+        await redis_client.set(
+            f"dolibarr_import:{task_id}",
+            json.dumps({"task_id": task_id, "status": "pending", "progress": {"processed": 0, "total": 0}, "message": "En cola...", "results": None}),
+            ex=86400,
+        )
+    finally:
+        if redis_client:
+            await redis_client.aclose()
+
+    csv_b64 = base64.b64encode(content).decode()
+
+    importar_productos_dolibarr.delay(
+        task_id,
+        csv_b64,
+        mapping_dict,
+        overwrite,
+        cat_col,
+        category_name_to_id,
+        dolibarr_url,
+        dolibarr_api_key,
     )
 
+    logger.info(
+        "Importación CSV Dolibarr encolada",
+        extra={"task_id": task_id, "mapped_fields": len(mapping_dict), "overwrite": overwrite},
+    )
+
+    return JSONResponse(
+        content=_ok({"task_id": task_id, "status": "pending"}, "Importación iniciada. Consulta el estado con el task_id."),
+        status_code=status.HTTP_202_ACCEPTED,
+    )
+
+
+@router_products.get("/import/{task_id}/status")
+async def get_import_status(task_id: str) -> JSONResponse:
+    """
+    Consulta el estado de una tarea de importación CSV en curso o completada.
+
+    Args:
+        task_id: UUID de la tarea devuelto por ``POST /import``.
+
+    Returns:
+        Dict con task_id, status, progress, message y results (cuando completed).
+
+    Raises:
+        HTTPException 404: si el task_id no existe o ha expirado (TTL 24 h).
+    """
+    settings = get_settings()
+    redis_client: aioredis.Redis | None = None
     try:
-        rows = await svc.import_from_csv(content, mapping=mapping_dict, overwrite=overwrite)
-    except Exception as exc:
-        logger.error("Error en importación CSV Dolibarr", exc_info=exc)
+        redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+        raw = await redis_client.get(f"dolibarr_import:{task_id}")
+    finally:
+        if redis_client:
+            await redis_client.aclose()
+
+    if not raw:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error durante la importación: {exc}",
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Tarea '{task_id}' no encontrada o expirada (TTL 24 h).",
         )
 
-    created = sum(1 for r in rows if r["action"] == "created")
-    updated = sum(1 for r in rows if r["action"] == "updated")
-    skipped = sum(1 for r in rows if r["action"] == "skipped")
-    errors = sum(1 for r in rows if r["action"] == "error")
-
-    response = CsvImportResponse(
-        total=len(rows),
-        created=created,
-        updated=updated,
-        skipped=skipped,
-        errors=errors,
-        results=[CsvImportRowResult(**r) for r in rows],
-    )
-
-    logger.info(
-        "Importación CSV Dolibarr completada",
-        extra={"total": len(rows), "created": created, "updated": updated, "errors": errors},
-    )
-
-    return JSONResponse(content=_ok(response.model_dump(), f"Importación completada: {len(rows)} filas procesadas."))
+    return JSONResponse(content=_ok(json.loads(raw), "Estado de importación obtenido."))
 
 
 @router_products.get("/{product_id}")

--- a/api/v1/schemas/integrations.py
+++ b/api/v1/schemas/integrations.py
@@ -150,6 +150,7 @@ class CsvImportRowResult(BaseModel):
     action: str
     dolibarr_id: int | None = None
     error: str | None = None
+    category_assigned: str | None = None
 
 
 class CsvImportResponse(BaseModel):

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -29,8 +29,10 @@ import {
   type DolibarrExtraField,
   type DolibarrExtraFieldCreate,
   type CsvImportPreview,
-  type CsvImportResponse,
   type DolibarrStats,
+  type DolibarrCategory,
+  type DolibarrCategoryTree,
+  type DolibarrImportTask,
 } from '@/types/dolibarr'
 import {
   type OdooProduct,
@@ -919,17 +921,135 @@ export async function importDolibarrCsv(
   file: File,
   mapping: Record<string, string>,
   overwrite: boolean,
-): Promise<CsvImportResponse> {
+  categoryColumn?: string,
+): Promise<DolibarrImportTask> {
   const form = new FormData()
   form.append('file', file)
   form.append('mapping', JSON.stringify(mapping))
   form.append('overwrite', String(overwrite))
-  const response = await apiClient.post<ApiResponse<CsvImportResponse>>(
+  if (categoryColumn) form.append('category_column', categoryColumn)
+  const response = await apiClient.post<ApiResponse<DolibarrImportTask>>(
     '/dolibarr/products/import',
     form,
-    { timeout: 120_000 },
+    { timeout: 30_000 },
   )
   return response.data.data
+}
+
+/**
+ * Consulta el estado de una tarea de importación CSV de Dolibarr.
+ *
+ * @author BenjaminDTS
+ * @param taskId - UUID de la tarea devuelto por importDolibarrCsv.
+ */
+export async function getDolibarrImportStatus(taskId: string): Promise<DolibarrImportTask> {
+  const response = await apiClient.get<ApiResponse<DolibarrImportTask>>(
+    `/dolibarr/products/import/${taskId}/status`,
+  )
+  return response.data.data
+}
+
+// ── Categorías Dolibarr ──────────────────────────────────────────
+
+/**
+ * Lista categorías Dolibarr con paginación.
+ *
+ * @author BenjaminDTS
+ * @param type   - Tipo de categoría (product, customer, supplier, member).
+ * @param limit  - Máximo de resultados.
+ * @param offset - Desplazamiento.
+ */
+export async function listDolibarrCategories(
+  type = 'product',
+  limit = 50,
+  offset = 0,
+): Promise<PaginatedResponse<DolibarrCategory>> {
+  const response = await apiClient.get<ApiResponse<PaginatedResponse<DolibarrCategory>>>(
+    '/dolibarr/categories',
+    { params: { type, limit, offset } },
+  )
+  return response.data.data
+}
+
+/**
+ * Obtiene el árbol jerárquico completo de categorías.
+ *
+ * @author BenjaminDTS
+ * @param type - Tipo de categoría.
+ */
+export async function getDolibarrCategoryTree(type = 'product'): Promise<DolibarrCategoryTree[]> {
+  const response = await apiClient.get<ApiResponse<DolibarrCategoryTree[]>>(
+    '/dolibarr/categories/tree',
+    { params: { type } },
+  )
+  return response.data.data
+}
+
+/**
+ * Crea una categoría en Dolibarr.
+ *
+ * @author BenjaminDTS
+ * @param label       - Nombre de la categoría.
+ * @param type        - Tipo de categoría.
+ * @param parent_id   - ID de la categoría padre (opcional).
+ * @param description - Descripción (opcional).
+ */
+export async function createDolibarrCategory(
+  label: string,
+  type = 'product',
+  parent_id?: number | string | null,
+  description = '',
+): Promise<DolibarrCategory> {
+  const params: Record<string, string | number> = { label, type, description }
+  if (parent_id != null) params.parent_id = Number(parent_id)
+  const response = await apiClient.post<ApiResponse<DolibarrCategory>>(
+    '/dolibarr/categories',
+    null,
+    { params },
+  )
+  return response.data.data
+}
+
+/**
+ * Actualiza una categoría existente.
+ *
+ * @author BenjaminDTS
+ * @param id   - ID de la categoría.
+ * @param data - Campos a actualizar.
+ */
+export async function updateDolibarrCategory(
+  id: number | string,
+  data: Partial<Pick<DolibarrCategory, 'label' | 'description'>>,
+): Promise<DolibarrCategory> {
+  const response = await apiClient.put<ApiResponse<DolibarrCategory>>(
+    `/dolibarr/categories/${id}`,
+    data,
+  )
+  return response.data.data
+}
+
+/**
+ * Elimina una categoría de Dolibarr.
+ *
+ * @author BenjaminDTS
+ * @param id - ID de la categoría a eliminar.
+ */
+export async function deleteDolibarrCategory(id: number | string): Promise<void> {
+  await apiClient.delete(`/dolibarr/categories/${id}`)
+}
+
+/**
+ * Asigna un producto a una categoría existente en Dolibarr.
+ *
+ * @author BenjaminDTS
+ * @param categoryId - ID de la categoría.
+ * @param productId  - ID del producto a asignar.
+ */
+export async function assignDolibarrProductToCategory(
+  categoryId: number | string,
+  productId: number | string,
+): Promise<void> {
+  await apiClient.post(`/dolibarr/categories/${categoryId}/products/${productId}`)
 }
 
 // ────────────────────────────────────────────────────────────────

--- a/frontend/src/components/dolibarr/DolibarrCategories.tsx
+++ b/frontend/src/components/dolibarr/DolibarrCategories.tsx
@@ -1,0 +1,457 @@
+/**
+ * Panel de gestión de categorías y subcategorías de Dolibarr.
+ * Muestra árbol jerárquico con soporte para crear, editar y eliminar nodos.
+ *
+ * @author BenjaminDTS
+ */
+import { useEffect, useState } from 'react'
+import {
+  getDolibarrCategoryTree,
+  createDolibarrCategory,
+  updateDolibarrCategory,
+  deleteDolibarrCategory,
+} from '@/api/client'
+import { type DolibarrCategoryTree } from '@/types/dolibarr'
+
+const CATEGORY_TYPES: Array<{ value: string; label: string }> = [
+  { value: 'product', label: 'Productos' },
+  { value: 'customer', label: 'Clientes' },
+  { value: 'supplier', label: 'Proveedores' },
+  { value: 'member', label: 'Miembros' },
+]
+
+const INPUT_CLS =
+  'w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm'
+const LABEL_CLS = 'block text-xs font-medium text-gray-700 mb-1'
+
+// ── Componente principal ───────────────────────────────────────────────────
+
+export default function DolibarrCategories() {
+  const [tree, setTree] = useState<DolibarrCategoryTree[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [categoryType, setCategoryType] = useState('product')
+  const [showCreateModal, setShowCreateModal] = useState(false)
+  const [createParentId, setCreateParentId] = useState<number | string | null>(null)
+  const [editTarget, setEditTarget] = useState<DolibarrCategoryTree | null>(null)
+
+  const loadTree = async (type = categoryType) => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await getDolibarrCategoryTree(type)
+      setTree(data)
+    } catch (err) {
+      setError((err as Error).message ?? 'Error cargando categorías')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadTree(categoryType)
+  }, [categoryType])
+
+  const handleDelete = async (node: DolibarrCategoryTree) => {
+    const hasChildren = node.children.length > 0
+    const msg = hasChildren
+      ? `¿Eliminar "${node.label}" y todas sus subcategorías? Esta acción no se puede deshacer.`
+      : `¿Eliminar la categoría "${node.label}"?`
+    if (!confirm(msg)) return
+    try {
+      await deleteDolibarrCategory(node.id)
+      loadTree(categoryType)
+    } catch (err) {
+      setError((err as Error).message ?? 'Error eliminando categoría')
+    }
+  }
+
+  const handleAddChild = (parentId: number | string) => {
+    setCreateParentId(parentId)
+    setShowCreateModal(true)
+  }
+
+  const handleAddRoot = () => {
+    setCreateParentId(null)
+    setShowCreateModal(true)
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Barra superior */}
+      <div className="flex flex-wrap gap-4 items-center justify-between">
+        <div className="flex items-center gap-3">
+          <label className="text-sm font-medium text-gray-700">Tipo:</label>
+          <select
+            value={categoryType}
+            onChange={(e) => setCategoryType(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+          >
+            {CATEGORY_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          onClick={handleAddRoot}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+        >
+          + Nueva categoría raíz
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border-l-4 border-red-400 p-4 rounded text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {/* Árbol */}
+      <div className="border border-gray-200 rounded-lg overflow-hidden">
+        {loading ? (
+          <div className="px-6 py-10 text-center text-gray-500 text-sm">
+            Cargando categorías...
+          </div>
+        ) : tree.length === 0 ? (
+          <div className="px-6 py-10 text-center text-gray-500 text-sm">
+            No hay categorías configuradas. Crea la primera arriba.
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {tree.map((node) => (
+              <CategoryNode
+                key={node.id}
+                node={node}
+                depth={0}
+                onAddChild={handleAddChild}
+                onEdit={setEditTarget}
+                onDelete={handleDelete}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {showCreateModal && (
+        <CreateCategoryModal
+          type={categoryType}
+          parentId={createParentId}
+          onClose={() => setShowCreateModal(false)}
+          onSuccess={() => {
+            setShowCreateModal(false)
+            loadTree(categoryType)
+          }}
+        />
+      )}
+
+      {editTarget && (
+        <EditCategoryModal
+          category={editTarget}
+          onClose={() => setEditTarget(null)}
+          onSuccess={() => {
+            setEditTarget(null)
+            loadTree(categoryType)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+// ── Nodo del árbol ─────────────────────────────────────────────────────────
+
+interface CategoryNodeProps {
+  node: DolibarrCategoryTree
+  depth: number
+  onAddChild: (parentId: number | string) => void
+  onEdit: (node: DolibarrCategoryTree) => void
+  onDelete: (node: DolibarrCategoryTree) => void
+}
+
+function CategoryNode({ node, depth, onAddChild, onEdit, onDelete }: CategoryNodeProps) {
+  const [expanded, setExpanded] = useState(true)
+  const hasChildren = node.children.length > 0
+  const indent = depth * 24
+
+  return (
+    <>
+      <div
+        className="flex items-center gap-2 px-4 py-3 hover:bg-gray-50 group"
+        style={{ paddingLeft: `${16 + indent}px` }}
+      >
+        {/* Toggle expansion */}
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className={`w-5 h-5 flex items-center justify-center rounded text-gray-400 hover:text-gray-600 flex-shrink-0 ${
+            !hasChildren ? 'invisible' : ''
+          }`}
+        >
+          <svg
+            className={`w-3 h-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path
+              fillRule="evenodd"
+              d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+
+        {/* Icono carpeta */}
+        <svg className="w-4 h-4 text-yellow-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" />
+        </svg>
+
+        {/* Label + descripción */}
+        <div className="flex-1 min-w-0">
+          <span className="text-sm font-medium text-gray-900">{node.label}</span>
+          {node.description && (
+            <span className="ml-2 text-xs text-gray-400 truncate">{node.description}</span>
+          )}
+        </div>
+
+        {/* Badge ID */}
+        <span className="text-xs text-gray-400 font-mono flex-shrink-0">#{node.id}</span>
+
+        {/* Acciones — visibles en hover */}
+        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
+          <button
+            onClick={() => onAddChild(node.id)}
+            title="Añadir subcategoría"
+            className="px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 rounded"
+          >
+            + Sub
+          </button>
+          <button
+            onClick={() => onEdit(node)}
+            title="Editar"
+            className="px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 rounded"
+          >
+            Editar
+          </button>
+          <button
+            onClick={() => onDelete(node)}
+            title="Eliminar"
+            className="px-2 py-1 text-xs text-red-600 hover:bg-red-50 rounded"
+          >
+            Eliminar
+          </button>
+        </div>
+      </div>
+
+      {/* Hijos */}
+      {hasChildren && expanded && (
+        <>
+          {node.children.map((child) => (
+            <CategoryNode
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              onAddChild={onAddChild}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))}
+        </>
+      )}
+    </>
+  )
+}
+
+// ── Modal crear categoría ──────────────────────────────────────────────────
+
+interface CreateCategoryModalProps {
+  type: string
+  parentId: number | string | null
+  onClose: () => void
+  onSuccess: () => void
+}
+
+function CreateCategoryModal({ type, parentId, onClose, onSuccess }: CreateCategoryModalProps) {
+  const [label, setLabel] = useState('')
+  const [description, setDescription] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async () => {
+    if (!label.trim()) {
+      setError('El nombre es obligatorio.')
+      return
+    }
+    try {
+      setSubmitting(true)
+      setError(null)
+      await createDolibarrCategory(label.trim(), type, parentId, description.trim())
+      onSuccess()
+    } catch (err) {
+      setError((err as Error).message ?? 'Error creando categoría')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const title = parentId != null ? 'Nueva subcategoría' : 'Nueva categoría raíz'
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-md">
+        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">
+            &times;
+          </button>
+        </div>
+
+        <div className="px-6 py-4 space-y-4">
+          {parentId != null && (
+            <p className="text-xs text-gray-500">
+              Subcategoría de ID <span className="font-mono font-semibold">#{parentId}</span>
+            </p>
+          )}
+
+          <div>
+            <label className={LABEL_CLS}>
+              Nombre <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="Ej: Electrónica"
+              className={INPUT_CLS}
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <label className={LABEL_CLS}>Descripción</label>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Descripción opcional"
+              className={INPUT_CLS}
+            />
+          </div>
+        </div>
+
+        <div className="px-6 py-4 border-t border-gray-200 space-y-3">
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              className="flex-1 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={submitting}
+              className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
+            >
+              {submitting ? 'Creando...' : 'Crear'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Modal editar categoría ─────────────────────────────────────────────────
+
+interface EditCategoryModalProps {
+  category: DolibarrCategoryTree
+  onClose: () => void
+  onSuccess: () => void
+}
+
+function EditCategoryModal({ category, onClose, onSuccess }: EditCategoryModalProps) {
+  const [label, setLabel] = useState(category.label)
+  const [description, setDescription] = useState(category.description ?? '')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async () => {
+    if (!label.trim()) {
+      setError('El nombre es obligatorio.')
+      return
+    }
+    try {
+      setSubmitting(true)
+      setError(null)
+      await updateDolibarrCategory(category.id, {
+        label: label.trim(),
+        description: description.trim(),
+      })
+      onSuccess()
+    } catch (err) {
+      setError((err as Error).message ?? 'Error actualizando categoría')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-md">
+        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900">Editar categoría</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">
+            &times;
+          </button>
+        </div>
+
+        <div className="px-6 py-4 space-y-4">
+          <p className="text-xs text-gray-500 font-mono">ID #{category.id}</p>
+
+          <div>
+            <label className={LABEL_CLS}>
+              Nombre <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              className={INPUT_CLS}
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <label className={LABEL_CLS}>Descripción</label>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className={INPUT_CLS}
+            />
+          </div>
+        </div>
+
+        <div className="px-6 py-4 border-t border-gray-200 space-y-3">
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              className="flex-1 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={submitting}
+              className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
+            >
+              {submitting ? 'Guardando...' : 'Guardar cambios'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/dolibarr/DolibarrPanel.tsx
+++ b/frontend/src/components/dolibarr/DolibarrPanel.tsx
@@ -14,8 +14,9 @@ import DolibarrInvoices from './DolibarrInvoices'
 import DolibarrStocks from './DolibarrStocks'
 import DolibarrConfig from './DolibarrConfig'
 import DolibarrExtraFields from './DolibarrExtraFields'
+import DolibarrCategories from './DolibarrCategories'
 
-type DolibarrTab = 'productos' | 'terceros' | 'pedidos' | 'facturas' | 'stock' | 'campos-extra' | 'config'
+type DolibarrTab = 'productos' | 'categorias' | 'terceros' | 'pedidos' | 'facturas' | 'stock' | 'campos-extra' | 'config'
 
 interface Props {
   className?: string
@@ -126,6 +127,7 @@ export default function DolibarrPanel({ className = '' }: Props) {
           {(
             [
               { id: 'productos', label: 'Productos' },
+              { id: 'categorias', label: 'Categorías' },
               { id: 'terceros', label: 'Terceros' },
               { id: 'pedidos', label: 'Pedidos' },
               { id: 'facturas', label: 'Facturas' },
@@ -154,6 +156,7 @@ export default function DolibarrPanel({ className = '' }: Props) {
         {/* Contenido del tab */}
         <div className="p-6">
           {tab === 'productos' && <DolibarrProducts />}
+          {tab === 'categorias' && <DolibarrCategories />}
           {tab === 'terceros' && <DolibarrThirdparties />}
           {tab === 'pedidos' && <DolibarrOrders />}
           {tab === 'facturas' && <DolibarrInvoices />}

--- a/frontend/src/components/dolibarr/DolibarrProducts.tsx
+++ b/frontend/src/components/dolibarr/DolibarrProducts.tsx
@@ -16,6 +16,8 @@ import {
   getDolibarrProductFields,
   previewDolibarrCsv,
   importDolibarrCsv,
+  getDolibarrImportStatus,
+  listDolibarrCategories,
 } from '@/api/client'
 import {
   type DolibarrProduct,
@@ -24,6 +26,7 @@ import {
   type DolibarrFieldOption,
   type CsvImportPreview,
   type CsvImportResponse,
+  type DolibarrCategory,
 } from '@/types/dolibarr'
 
 export default function DolibarrProducts() {
@@ -472,12 +475,18 @@ function CreateProductModal({ onClose, onSuccess }: CreateProductModalProps) {
   const [values, setValues] = useState<Record<string, string>>({})
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [categories, setCategories] = useState<DolibarrCategory[]>([])
+  const [selectedCategory, setSelectedCategory] = useState('')
 
   useEffect(() => {
-    getDolibarrProductFields()
-      .then((f) => {
+    Promise.all([
+      getDolibarrProductFields(),
+      listDolibarrCategories('product', 200, 0).catch(() => ({ items: [] as DolibarrCategory[], total: 0, limit: 200, offset: 0, has_more: false })),
+    ])
+      .then(([f, cats]) => {
         setFields(f)
         setValues(initEmpty(f))
+        setCategories(cats.items)
       })
       .catch((err) => setError((err as Error).message ?? 'Error cargando campos'))
       .finally(() => setFieldsLoading(false))
@@ -494,10 +503,12 @@ function CreateProductModal({ onClose, onSuccess }: CreateProductModalProps) {
     try {
       setSubmitting(true)
       setError(null)
-      await createDolibarrProduct(buildPayload(values, fields) as Partial<DolibarrProduct>)
+      const payload = buildPayload(values, fields) as Record<string, unknown>
+      if (selectedCategory) payload.category_name = selectedCategory
+      await createDolibarrProduct(payload as Partial<DolibarrProduct>)
       onSuccess()
     } catch (err) {
-      setError((err as Error).message ?? 'Error creando producto')
+      setError((err as { message?: string }).message ?? 'Error creando producto')
     } finally {
       setSubmitting(false)
     }
@@ -515,13 +526,31 @@ function CreateProductModal({ onClose, onSuccess }: CreateProductModalProps) {
             &times;
           </button>
         </div>
-        <div className="overflow-y-auto flex-1 px-6 py-4">
+        <div className="overflow-y-auto flex-1 px-6 py-4 space-y-4">
           {fieldsLoading ? (
             <div className="flex items-center justify-center py-12 text-gray-500 text-sm">
               Cargando campos de esta instancia Dolibarr...
             </div>
           ) : (
-            <DynamicProductForm fields={fields} values={values} onChange={handleChange} />
+            <>
+              <DynamicProductForm fields={fields} values={values} onChange={handleChange} />
+              <div className="border border-amber-200 bg-amber-50 rounded-lg p-4 space-y-3">
+                <p className="text-xs font-semibold text-amber-800 uppercase tracking-wide">Categoría (opcional)</p>
+                <p className="text-xs text-amber-700">
+                  La categoría debe existir previamente en Dolibarr. El nombre debe coincidir exactamente.
+                </p>
+                <select
+                  value={selectedCategory}
+                  onChange={(e) => setSelectedCategory(e.target.value)}
+                  className="w-full px-3 py-2 border border-amber-300 rounded-lg text-sm focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white"
+                >
+                  <option value="">— Sin categoría —</option>
+                  {categories.map((c) => (
+                    <option key={c.id} value={c.label}>{c.label}</option>
+                  ))}
+                </select>
+              </div>
+            </>
           )}
         </div>
         <div className="px-6 py-4 border-t border-gray-200 space-y-3 flex-shrink-0">
@@ -561,12 +590,18 @@ function EditProductModal({ product, onClose, onSuccess }: EditProductModalProps
   const [values, setValues] = useState<Record<string, string>>({})
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [categories, setCategories] = useState<DolibarrCategory[]>([])
+  const [selectedCategory, setSelectedCategory] = useState('')
 
   useEffect(() => {
-    getDolibarrProductFields()
-      .then((f) => {
+    Promise.all([
+      getDolibarrProductFields(),
+      listDolibarrCategories('product', 200, 0).catch(() => ({ items: [] as DolibarrCategory[], total: 0, limit: 200, offset: 0, has_more: false })),
+    ])
+      .then(([f, cats]) => {
         setFields(f)
         setValues(initFromProduct(product, f))
+        setCategories(cats.items)
       })
       .catch((err) => setError((err as Error).message ?? 'Error cargando campos'))
       .finally(() => setFieldsLoading(false))
@@ -583,13 +618,12 @@ function EditProductModal({ product, onClose, onSuccess }: EditProductModalProps
     try {
       setSubmitting(true)
       setError(null)
-      await updateDolibarrProduct(
-        product.id,
-        buildPayload(values, fields) as Partial<DolibarrProduct>,
-      )
+      const payload = buildPayload(values, fields) as Record<string, unknown>
+      if (selectedCategory) payload.category_name = selectedCategory
+      await updateDolibarrProduct(product.id, payload as Partial<DolibarrProduct>)
       onSuccess()
     } catch (err) {
-      setError((err as Error).message ?? 'Error actualizando producto')
+      setError((err as { message?: string }).message ?? 'Error actualizando producto')
     } finally {
       setSubmitting(false)
     }
@@ -609,13 +643,31 @@ function EditProductModal({ product, onClose, onSuccess }: EditProductModalProps
             &times;
           </button>
         </div>
-        <div className="overflow-y-auto flex-1 px-6 py-4">
+        <div className="overflow-y-auto flex-1 px-6 py-4 space-y-4">
           {fieldsLoading ? (
             <div className="flex items-center justify-center py-12 text-gray-500 text-sm">
               Cargando campos de esta instancia Dolibarr...
             </div>
           ) : (
-            <DynamicProductForm fields={fields} values={values} onChange={handleChange} />
+            <>
+              <DynamicProductForm fields={fields} values={values} onChange={handleChange} />
+              <div className="border border-amber-200 bg-amber-50 rounded-lg p-4 space-y-3">
+                <p className="text-xs font-semibold text-amber-800 uppercase tracking-wide">Asignar a categoría (opcional)</p>
+                <p className="text-xs text-amber-700">
+                  La categoría debe existir previamente en Dolibarr. El nombre debe coincidir exactamente. Si el producto ya pertenece a una categoría, se añadirá a esta además.
+                </p>
+                <select
+                  value={selectedCategory}
+                  onChange={(e) => setSelectedCategory(e.target.value)}
+                  className="w-full px-3 py-2 border border-amber-300 rounded-lg text-sm focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white"
+                >
+                  <option value="">— Sin cambiar —</option>
+                  {categories.map((c) => (
+                    <option key={c.id} value={c.label}>{c.label}</option>
+                  ))}
+                </select>
+              </div>
+            </>
           )}
         </div>
         <div className="px-6 py-4 border-t border-gray-200 space-y-3 flex-shrink-0">
@@ -667,10 +719,20 @@ function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps) {
   const [fields, setFields] = useState<DolibarrFieldSchema[]>([])
   const [mapping, setMapping] = useState<Record<string, string>>({})
   const [overwrite, setOverwrite] = useState(false)
+  const [categoryColumn, setCategoryColumn] = useState('')
   const [result, setResult] = useState<CsvImportResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  const [importProgress, setImportProgress] = useState<{ processed: number; total: number }>({ processed: 0, total: 0 })
+  const [importMessage, setImportMessage] = useState('')
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current)
+    }
+  }, [])
 
   useEffect(() => {
     getDolibarrProductFields()
@@ -712,14 +774,38 @@ function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps) {
     }
     if (!file) return
     setError(null)
+    setImportProgress({ processed: 0, total: 0 })
+    setImportMessage('')
     setStep('importing')
+
     try {
-      const res = await importDolibarrCsv(file, activeMapping, overwrite)
-      setResult(res)
-      setStep('results')
-      if (res.created > 0 || res.updated > 0) onSuccess()
+      const task = await importDolibarrCsv(file, activeMapping, overwrite, categoryColumn || undefined)
+
+      pollRef.current = setInterval(async () => {
+        try {
+          const status = await getDolibarrImportStatus(task.task_id)
+          setImportProgress(status.progress)
+          setImportMessage(status.message)
+
+          if (status.status === 'completed' && status.results) {
+            clearInterval(pollRef.current!)
+            pollRef.current = null
+            setResult(status.results)
+            setStep('results')
+            if (status.results.created > 0 || status.results.updated > 0) onSuccess()
+          } else if (status.status === 'failed') {
+            clearInterval(pollRef.current!)
+            pollRef.current = null
+            setError(status.message)
+            setStep('mapping')
+          }
+        } catch {
+          // Network blip — mantener polling
+        }
+      }, 2000)
+
     } catch (err) {
-      setError((err as { message?: string }).message ?? 'Error durante la importación')
+      setError((err as { message?: string }).message ?? 'Error iniciando importación')
       setStep('mapping')
     }
   }
@@ -875,6 +961,27 @@ function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps) {
                 </div>
               </div>
 
+              {/* Category column selector */}
+              <div className="border border-amber-200 bg-amber-50 rounded-lg p-4 space-y-3">
+                <p className="text-xs font-semibold text-amber-800 uppercase tracking-wide">Categoría (opcional)</p>
+                <p className="text-xs text-amber-700">
+                  ⚠ La categoría debe existir previamente en Dolibarr y el nombre del CSV debe coincidir <strong>exactamente</strong>. Si alguna no existe, la importación se bloqueará con la lista de categorías faltantes.
+                </p>
+                <div className="flex items-center gap-3">
+                  <span className="text-sm text-amber-800 shrink-0">Columna de categoría:</span>
+                  <select
+                    value={categoryColumn}
+                    onChange={(e) => setCategoryColumn(e.target.value)}
+                    className="flex-1 px-2 py-1.5 border border-amber-300 rounded text-sm focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white"
+                  >
+                    <option value="">— No asignar categoría —</option>
+                    {preview?.headers.map((h) => (
+                      <option key={h} value={h}>{h}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
               {!refMapped && (
                 <p className="text-xs text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
                   Asigna al menos una columna al campo <strong>Referencia (ref)</strong> para poder importar.
@@ -891,10 +998,32 @@ function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps) {
 
           {/* ── Step 3: Importing ── */}
           {step === 'importing' && (
-            <div className="flex flex-col items-center justify-center py-16 space-y-4">
+            <div className="flex flex-col items-center justify-center py-16 space-y-5">
               <div className="w-10 h-10 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
-              <p className="text-gray-600 text-sm">Importando {preview?.total_rows ?? '...'} productos a Dolibarr...</p>
-              <p className="text-gray-400 text-xs">Esto puede tardar varios minutos para catálogos grandes.</p>
+              {importProgress.total > 0 ? (
+                <>
+                  <p className="text-gray-700 text-sm font-medium">
+                    {importProgress.processed} / {importProgress.total} productos
+                  </p>
+                  <div className="w-full max-w-xs bg-gray-200 rounded-full h-2.5">
+                    <div
+                      className="bg-blue-600 h-2.5 rounded-full transition-all duration-500"
+                      style={{ width: `${Math.round((importProgress.processed / importProgress.total) * 100)}%` }}
+                    />
+                  </div>
+                  <p className="text-xs text-gray-500">
+                    {Math.round((importProgress.processed / importProgress.total) * 100)}% completado
+                  </p>
+                  {importMessage && (
+                    <p className="text-xs text-gray-400 max-w-xs text-center">{importMessage}</p>
+                  )}
+                </>
+              ) : (
+                <>
+                  <p className="text-gray-600 text-sm">Iniciando importación en segundo plano...</p>
+                  <p className="text-gray-400 text-xs">Las importaciones grandes pueden tardar más de una hora.</p>
+                </>
+              )}
             </div>
           )}
 
@@ -934,6 +1063,15 @@ function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps) {
                         </div>
                       ))}
                   </div>
+                </div>
+              )}
+
+              {categoryColumn && result.results.some((r) => r.category_assigned) && (
+                <div>
+                  <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Categorías asignadas</p>
+                  <p className="text-xs text-gray-600">
+                    {result.results.filter((r) => r.category_assigned).length} productos asignados a categoría correctamente.
+                  </p>
                 </div>
               )}
             </div>

--- a/frontend/src/types/dolibarr.ts
+++ b/frontend/src/types/dolibarr.ts
@@ -174,6 +174,25 @@ export interface DolibarrExtraFieldCreate {
   fielddefault: string
 }
 
+export interface DolibarrCategory {
+  id: number | string
+  label: string
+  description: string
+  type: string | number
+  fk_parent: number | string | null
+}
+
+export interface DolibarrCategoryTree extends DolibarrCategory {
+  children: DolibarrCategoryTree[]
+}
+
+export interface DolibarrCategoryCreate {
+  label: string
+  type: string
+  parent_id?: number | null
+  description?: string
+}
+
 export interface CsvImportPreview {
   headers: string[]
   preview: Record<string, string>[]
@@ -186,6 +205,7 @@ export interface CsvImportRowResult {
   action: 'created' | 'updated' | 'skipped' | 'error'
   dolibarr_id: number | null
   error: string | null
+  category_assigned: string | null
 }
 
 export interface CsvImportResponse {
@@ -195,4 +215,12 @@ export interface CsvImportResponse {
   skipped: number
   errors: number
   results: CsvImportRowResult[]
+}
+
+export interface DolibarrImportTask {
+  task_id: string
+  status: 'pending' | 'running' | 'completed' | 'failed'
+  progress: { processed: number; total: number }
+  message: string
+  results: CsvImportResponse | null
 }

--- a/services/integrations/dolibarr/categories.py
+++ b/services/integrations/dolibarr/categories.py
@@ -6,9 +6,18 @@ Soporta categorías de producto, cliente y proveedor.
 :version: 1.0.0
 """
 
+import json
 from typing import Literal
 
-from services.integrations.base import IntegrationClient
+import aiomysql
+import redis.asyncio as aioredis
+from loguru import logger
+
+from api.core.config import get_settings
+from services.integrations.base import IntegrationError
+from services.integrations.dolibarr.client import DolibarrClient
+
+_REDIS_DB_CONFIG_KEY = "integration:dolibarr:db_config"
 
 
 CATEGORY_TYPES = Literal["product", "customer", "supplier", "member"]
@@ -24,7 +33,7 @@ class DolibarrCategoryService:
     :author: Carlitos6712
     """
 
-    def __init__(self, client: IntegrationClient) -> None:
+    def __init__(self, client: DolibarrClient) -> None:
         """
         Inicializa servicio con cliente Dolibarr.
 
@@ -97,16 +106,23 @@ class DolibarrCategoryService:
                 break
             offset += limit
 
-        # Construir árbol en memoria
-        categories_by_id = {cat["id"]: {**cat, "children": []} for cat in all_categories}
+        # Dolibarr returns id as string, fk_parent as int — normalize both to int for lookup.
+        categories_by_id: dict[int, dict] = {
+            int(cat["id"]): {**cat, "children": []} for cat in all_categories
+        }
         roots = []
 
         for cat in all_categories:
-            parent_id = cat.get("fk_parent", None)
+            raw_parent = cat.get("fk_parent", None)
+            try:
+                parent_id = int(raw_parent) if raw_parent is not None else None
+            except (ValueError, TypeError):
+                parent_id = None
+            node_id = int(cat["id"])
             if parent_id is None or parent_id == 0 or parent_id not in categories_by_id:
-                roots.append(categories_by_id[cat["id"]])
+                roots.append(categories_by_id[node_id])
             else:
-                categories_by_id[parent_id]["children"].append(categories_by_id[cat["id"]])
+                categories_by_id[parent_id]["children"].append(categories_by_id[node_id])
 
         return roots
 
@@ -175,8 +191,7 @@ class DolibarrCategoryService:
     ) -> bool:
         """
         Asigna un producto a una categoría.
-        Dolibarr endpoint: POST /categories/{id}/objects
-        Body: { "type": "product", "id": product_id }
+        Dolibarr endpoint: POST /categories/{id}/objects/{objectid}?type=product
 
         Args:
             category_id: ID de la categoría.
@@ -184,13 +199,127 @@ class DolibarrCategoryService:
 
         Returns:
             True si éxito.
+
+        Raises:
+            IntegrationError: si Dolibarr devuelve un error al asignar.
         """
-        data = {"type": "product", "id": product_id}
-        result = await self._client.create(
-            f"{_DOLIBARR_CATEGORIES_RESOURCE}/{category_id}/{_DOLIBARR_CATEGORY_OBJECTS_RESOURCE}",
-            data,
+        # Intentar vía REST API primero.
+        try:
+            response = await self._client._request(
+                "POST",
+                f"{_DOLIBARR_CATEGORIES_RESOURCE}/{category_id}/{_DOLIBARR_CATEGORY_OBJECTS_RESOURCE}/{product_id}",
+                params={"type": "product"},
+            )
+            if response.status_code < 400:
+                logger.info(
+                    "Categoría asignada via REST",
+                    extra={"category_id": category_id, "product_id": product_id},
+                )
+                return True
+            logger.warning(
+                "REST assign_product falló, intentando DB directa",
+                extra={
+                    "category_id": category_id,
+                    "product_id": product_id,
+                    "http_status": response.status_code,
+                    "dolibarr_response": response.text[:300],
+                },
+            )
+        except Exception as exc:
+            logger.warning(
+                "REST assign_product excepción, intentando DB directa",
+                exc_info=exc,
+                extra={"category_id": category_id, "product_id": product_id},
+            )
+
+        # Fallback: INSERT directo en llx_categorie_product.
+        return await self._assign_product_db(category_id, product_id)
+
+    async def _assign_product_db(self, category_id: int, product_id: int) -> bool:
+        """
+        Inserta la relación categoría-producto directamente en la BD.
+
+        Fallback cuando el endpoint REST no funciona en la versión de Dolibarr.
+        Lee las credenciales de BD desde Redis (config UI) con fallback a .env.
+
+        Args:
+            category_id: ID de la categoría.
+            product_id:  ID del producto.
+
+        Returns:
+            True si la inserción fue exitosa.
+
+        Raises:
+            IntegrationError: si la BD no está configurada o falla la inserción.
+        """
+        settings = get_settings()
+        host = db_name = user = password = prefix = ""
+        port = 3306
+
+        # Leer config desde Redis primero (configurada via UI), luego .env.
+        redis_client: aioredis.Redis | None = None
+        try:
+            redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+            stored = await redis_client.get(_REDIS_DB_CONFIG_KEY)
+            if stored:
+                cfg = json.loads(stored)
+                host = cfg.get("host", "").strip()
+                port = int(cfg.get("port") or 3306)
+                db_name = cfg.get("db_name", "").strip()
+                user = cfg.get("user", "").strip()
+                password = cfg.get("password", "")
+                prefix = cfg.get("prefix", "llx_").strip()
+        except Exception:
+            pass
+        finally:
+            if redis_client:
+                await redis_client.aclose()
+
+        # Fallback a variables de entorno si Redis no tenía config.
+        if not host:
+            host = settings.dolibarr_db_host or ""
+            port = settings.dolibarr_db_port
+            db_name = settings.dolibarr_db_name or ""
+            user = settings.dolibarr_db_user or ""
+            password = settings.dolibarr_db_pass or ""
+            prefix = settings.dolibarr_db_prefix or "llx_"
+
+        if not host or not db_name or not user:
+            raise IntegrationError(
+                "REST falló y BD de Dolibarr no configurada. "
+                "Configura DOLIBARR_DB_* en .env o en la interfaz gráfica.",
+                platform="dolibarr",
+            )
+
+        table = f"{prefix.strip()}categorie_product"
+
+        conn: aiomysql.Connection = await aiomysql.connect(
+            host=host,
+            port=port,
+            db=db_name,
+            user=user,
+            password=password,
+            autocommit=True,
+            charset="utf8mb4",
         )
-        return bool(result)
+        try:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    f"INSERT IGNORE INTO `{table}` (fk_categorie, fk_product) VALUES (%s, %s)",
+                    (category_id, product_id),
+                )
+            logger.info(
+                "Categoría asignada via BD directa",
+                extra={"category_id": category_id, "product_id": product_id, "table": table},
+            )
+            return True
+        except Exception as exc:
+            raise IntegrationError(
+                f"Error asignando categoría {category_id} a producto {product_id} via BD: {exc}",
+                platform="dolibarr",
+            ) from exc
+        finally:
+            conn.close()
 
     async def remove_product(
         self,
@@ -207,9 +336,50 @@ class DolibarrCategoryService:
 
         Returns:
             True si éxito.
+
+        Raises:
+            IntegrationError: si Dolibarr devuelve un error al eliminar.
         """
-        resource = f"{_DOLIBARR_CATEGORIES_RESOURCE}/{category_id}/{_DOLIBARR_CATEGORY_OBJECTS_RESOURCE}/{product_id}"
-        return await self._client.delete(resource, None)
+        response = await self._client._request(
+            "DELETE",
+            f"{_DOLIBARR_CATEGORIES_RESOURCE}/{category_id}/{_DOLIBARR_CATEGORY_OBJECTS_RESOURCE}/{product_id}",
+            params={"type": "product"},
+        )
+        if response.status_code in (200, 204):
+            return True
+        raise IntegrationError(
+            f"Error eliminando producto {product_id} de categoría {category_id}: HTTP {response.status_code}",
+            platform="dolibarr",
+            status_code=response.status_code,
+        )
+
+    async def find_category_by_name(
+        self,
+        name: str,
+        type: str = "product",
+    ) -> dict | None:
+        """
+        Busca una categoría por nombre exacto paginando hasta agotarlas.
+
+        Args:
+            name: Nombre exacto de la categoría (sensible a mayúsculas).
+            type: Tipo de categoría.
+
+        Returns:
+            Dict de la categoría si existe, None si no se encuentra.
+        """
+        offset = 0
+        limit = 100
+        while True:
+            batch = await self.list_categories(type=type, limit=limit, offset=offset)
+            if not batch:
+                return None
+            for cat in batch:
+                if str(cat.get("label", "")) == name:
+                    return cat
+            if len(batch) < limit:
+                return None
+            offset += limit
 
     async def list_products_in_category(
         self,

--- a/services/integrations/dolibarr/client.py
+++ b/services/integrations/dolibarr/client.py
@@ -118,12 +118,8 @@ class DolibarrClient(IntegrationClient):
                     last_status = response.status_code
                     last_exc = None
                     logger.warning(
-                        "Reintentando Dolibarr",
-                        extra={
-                            "attempt": attempt,
-                            "path": path,
-                            "dolibarr_error": response.text[:400],
-                        },
+                        f"Reintentando Dolibarr [{method} {path}] intento {attempt+1}/{_MAX_RETRIES} "
+                        f"HTTP {response.status_code}: {response.text[:400]}",
                     )
                     await asyncio.sleep(2 ** attempt)
                     continue

--- a/services/integrations/dolibarr/products.py
+++ b/services/integrations/dolibarr/products.py
@@ -14,6 +14,7 @@ import base64
 import csv
 import io
 import json
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -23,6 +24,7 @@ from services.integrations.base import IntegrationError
 from services.integrations.dolibarr.client import DolibarrClient
 
 if TYPE_CHECKING:
+    from services.integrations.dolibarr.categories import DolibarrCategoryService
     from services.storage_service import StorageService
 
 _DOLIBARR_PRODUCTS_RESOURCE = "products"
@@ -298,6 +300,11 @@ class DolibarrProductService:
         payload = dict(data)
         array_options = payload.pop("array_options", None)
 
+        # Activar venta y compra por defecto si no se especifica lo contrario.
+        # Dolibarr deja tosell/tobuy a 0 si no se envían, lo que oculta el producto.
+        payload.setdefault("tosell", 1)
+        payload.setdefault("tobuy", 1)
+
         raw = await self._client.create(_DOLIBARR_PRODUCTS_RESOURCE, payload)
 
         product_id: int | None = None
@@ -309,16 +316,27 @@ class DolibarrProductService:
             except (ValueError, TypeError):
                 pass
 
-        if product_id and array_options:
+        if product_id:
+            # Activar explícitamente tosell/tobuy via PUT. Algunos Dolibarr ignoran
+            # estos campos en el POST inicial y requieren actualización posterior.
+            # Incluir ref y label (requeridos por Dolibarr) para evitar HTTP 400.
+            update_payload: dict[str, Any] = {
+                "tosell": 1,
+                "tobuy": 1,
+                "ref": data.get("ref", ""),
+                "label": data.get("label", data.get("ref", "")),
+            }
+            if array_options:
+                update_payload["array_options"] = array_options
             try:
                 await self._client.update(
                     _DOLIBARR_PRODUCTS_RESOURCE,
                     product_id,
-                    {"array_options": array_options},
+                    update_payload,
                 )
             except Exception as exc:
                 logger.warning(
-                    "Extrafields no guardados en producto creado",
+                    "PUT post-creación no aplicado",
                     exc_info=exc,
                     extra={"product_id": product_id},
                 )
@@ -559,6 +577,10 @@ class DolibarrProductService:
         content: bytes,
         mapping: dict[str, str],
         overwrite: bool = False,
+        category_col: str | None = None,
+        category_svc: "DolibarrCategoryService | None" = None,
+        category_name_to_id: dict[str, int] | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[dict[str, Any]]:
         """
         Importa productos en masa a Dolibarr desde un CSV con mapeo de columnas.
@@ -570,18 +592,39 @@ class DolibarrProductService:
         Campos cuya clave Dolibarr empiece por ``options_`` se tratan como
         extrafields y se agrupan en ``array_options``.
 
+        Si se proporcionan ``category_col``, ``category_svc`` y
+        ``category_name_to_id``, tras crear/actualizar cada producto se asigna
+        la categoría correspondiente. Las categorías deben haber sido validadas
+        previamente (el endpoint comprueba su existencia antes de llamar aquí).
+
+        Si se proporciona ``progress_callback``, se llama cada 10 filas y al
+        terminar con ``(procesados, total)`` para que la tarea Celery pueda
+        actualizar Redis con el progreso en tiempo real.
+
         Args:
-            content:  contenido raw del archivo CSV.
-            mapping:  dict que mapea nombre_columna_csv → campo_dolibarr.
-            overwrite: si True, actualiza productos existentes (busca por ref).
+            content:              contenido raw del archivo CSV.
+            mapping:              dict que mapea nombre_columna_csv → campo_dolibarr.
+            overwrite:            si True, actualiza productos existentes (busca por ref).
+            category_col:         nombre de la columna CSV que contiene el nombre de categoría.
+            category_svc:         servicio de categorías para asignar el producto.
+            category_name_to_id:  mapa nombre_categoría → ID ya validado.
+            progress_callback:    función opcional ``(procesados, total) → None``.
 
         Returns:
-            Lista de dicts con row, ref, action, dolibarr_id y error.
+            Lista de dicts con row, ref, action, dolibarr_id, error y category_assigned.
         """
         text = _decode_csv(content)
         delimiter = _detect_delimiter(text)
+
+        # Contar filas totales para progreso (parse rápido extra si hay callback)
+        total_rows = 0
+        if progress_callback:
+            counter_reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
+            total_rows = sum(1 for _ in counter_reader)
+
         reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
         results: list[dict[str, Any]] = []
+        processed_count = 0
 
         for row_num, row in enumerate(reader, start=2):
             payload: dict[str, Any] = {}
@@ -603,6 +646,7 @@ class DolibarrProductService:
                 "action": None,
                 "dolibarr_id": None,
                 "error": None,
+                "category_assigned": None,
             }
 
             if not ref:
@@ -610,6 +654,10 @@ class DolibarrProductService:
                 result["error"] = "Columna 'ref' vacía o no mapeada."
                 results.append(result)
                 continue
+
+            # Garantizar que los productos importados queden activos en venta y compra.
+            payload.setdefault("tosell", 1)
+            payload.setdefault("tobuy", 1)
 
             if array_options:
                 payload["array_options"] = array_options
@@ -643,6 +691,24 @@ class DolibarrProductService:
 
                 result["dolibarr_id"] = dolibarr_id
 
+                if category_col and category_svc and category_name_to_id:
+                    cat_name = (row.get(category_col) or "").strip()
+                    cat_id = category_name_to_id.get(cat_name)
+                    if cat_id:
+                        try:
+                            await category_svc.assign_product(cat_id, dolibarr_id)
+                            result["category_assigned"] = cat_name
+                            logger.info(
+                                "Categoría asignada via CSV import",
+                                extra={"ref": ref, "category": cat_name, "dolibarr_id": dolibarr_id},
+                            )
+                        except Exception as cat_exc:
+                            logger.warning(
+                                "Error asignando categoría en CSV import",
+                                exc_info=cat_exc,
+                                extra={"ref": ref, "category": cat_name},
+                            )
+
             except Exception as exc:
                 logger.error(
                     "Error importando fila CSV a Dolibarr",
@@ -653,6 +719,13 @@ class DolibarrProductService:
                 result["error"] = str(exc)
 
             results.append(result)
+            processed_count += 1
+
+            if progress_callback and (processed_count % 10 == 0 or processed_count == total_rows):
+                progress_callback(processed_count, total_rows)
+
+        if progress_callback and total_rows > 0 and processed_count != total_rows:
+            progress_callback(processed_count, total_rows)
 
         return results
 

--- a/workers/tasks.py
+++ b/workers/tasks.py
@@ -10,6 +10,8 @@ del estado del job en Redis.
 :version: 1.0.0
 """
 
+import asyncio
+import base64
 import json
 import uuid
 from datetime import datetime
@@ -546,6 +548,144 @@ def ejecutar_scraping(
         job_status.mensaje = "El trabajo falló tras varios intentos."
         job_status.actualizado_en = datetime.utcnow()
         _actualizar_estado(redis_client, job_status)
+        return {"error": str(exc)}
+
+    finally:
+        redis_client.close()
+
+
+_DOLIBARR_IMPORT_KEY = "dolibarr_import:{task_id}"
+_DOLIBARR_IMPORT_TTL = 86400  # 24 horas
+
+
+@celery_app.task(
+    bind=True,
+    name="workers.tasks.importar_productos_dolibarr",
+)
+def importar_productos_dolibarr(
+    self,
+    task_id: str,
+    csv_b64: str,
+    mapping: dict,
+    overwrite: bool,
+    category_column: str,
+    category_name_to_id: dict,
+    dolibarr_url: str,
+    dolibarr_api_key: str,
+) -> dict:
+    """
+    Tarea Celery que importa productos en masa a Dolibarr desde un CSV.
+
+    Se ejecuta de forma asíncrona para soportar importaciones que duran horas.
+    Actualiza el progreso en Redis cada 10 filas para que el frontend pueda
+    consultarlo mediante polling.
+
+    Args:
+        self:                instancia de la tarea (bind=True).
+        task_id:             UUID de la tarea, usado como clave Redis.
+        csv_b64:             contenido del CSV codificado en base64.
+        mapping:             dict columna_csv → campo_dolibarr.
+        overwrite:           si True, actualiza productos existentes.
+        category_column:     nombre de la columna CSV con la categoría (vacío si no aplica).
+        category_name_to_id: mapa nombre_categoría → ID Dolibarr (ya validado).
+        dolibarr_url:        URL base de la API Dolibarr.
+        dolibarr_api_key:    clave API Dolibarr.
+
+    Returns:
+        Dict con resumen de la importación o ``{"error": str}`` si falla.
+
+    :author: BenjaminDTS
+    """
+    settings = get_settings()
+    redis_client = _get_redis_client()
+
+    def _set_state(state: dict) -> None:
+        redis_client.set(
+            _DOLIBARR_IMPORT_KEY.format(task_id=task_id),
+            json.dumps(state, ensure_ascii=False),
+            ex=_DOLIBARR_IMPORT_TTL,
+        )
+
+    def _progress(processed: int, total: int) -> None:
+        _set_state({
+            "task_id": task_id,
+            "status": "running",
+            "progress": {"processed": processed, "total": total},
+            "message": f"Importando {processed} de {total} productos...",
+            "results": None,
+        })
+
+    _set_state({
+        "task_id": task_id,
+        "status": "running",
+        "progress": {"processed": 0, "total": 0},
+        "message": "Iniciando importación...",
+        "results": None,
+    })
+
+    logger.info("Importación Dolibarr iniciada", extra={"task_id": task_id})
+
+    async def _run() -> list[dict]:
+        from services.integrations.dolibarr.categories import DolibarrCategoryService  # noqa: PLC0415
+        from services.integrations.dolibarr.client import DolibarrClient  # noqa: PLC0415
+        from services.integrations.dolibarr.products import DolibarrProductService  # noqa: PLC0415
+
+        client = DolibarrClient(settings, override_url=dolibarr_url, override_api_key=dolibarr_api_key)
+        svc = DolibarrProductService(client)
+        cat_svc = DolibarrCategoryService(client) if category_column else None
+
+        content = base64.b64decode(csv_b64.encode())
+
+        return await svc.import_from_csv(
+            content=content,
+            mapping=mapping,
+            overwrite=overwrite,
+            category_col=category_column or None,
+            category_svc=cat_svc,
+            category_name_to_id=category_name_to_id or None,
+            progress_callback=_progress,
+        )
+
+    try:
+        rows = asyncio.run(_run())
+
+        created = sum(1 for r in rows if r.get("action") == "created")
+        updated = sum(1 for r in rows if r.get("action") == "updated")
+        skipped = sum(1 for r in rows if r.get("action") == "skipped")
+        errors = sum(1 for r in rows if r.get("action") == "error")
+
+        results = {
+            "total": len(rows),
+            "created": created,
+            "updated": updated,
+            "skipped": skipped,
+            "errors": errors,
+            "results": rows,
+        }
+
+        _set_state({
+            "task_id": task_id,
+            "status": "completed",
+            "progress": {"processed": len(rows), "total": len(rows)},
+            "message": f"Completado: {created} creados, {updated} actualizados, {errors} errores.",
+            "results": results,
+        })
+
+        logger.info(
+            "Importación Dolibarr completada",
+            extra={"task_id": task_id, "total": len(rows), "created": created, "errors": errors},
+        )
+        return results
+
+    except Exception as exc:
+        logger.error("Error en importación Dolibarr", exc_info=exc, extra={"task_id": task_id})
+        _set_state({
+            "task_id": task_id,
+            "status": "failed",
+            "progress": {"processed": 0, "total": 0},
+            "message": f"Error: {exc}",
+            "results": None,
+        })
         return {"error": str(exc)}
 
     finally:


### PR DESCRIPTION
## Summary

- **Fix tosell/tobuy=0 bug**: products created via bulk import were always saved with `tosell=0, tobuy=0` because the PUT post-creation only sent `{"tosell":1,"tobuy":1}` — Dolibarr rejected it (missing required `ref`/`label`). Now the PUT includes those fields.
- **Async import**: POST `/dolibarr/products/import` now returns HTTP 202 + `task_id` immediately. Frontend polls `GET /import/{task_id}/status` for real-time progress every 2s via Celery + Redis.
- **Category assignment during import**: supports a `category_column` param; categories pre-validated before enqueue. REST endpoint used first; DB direct INSERT via `aiomysql` as fallback (some Dolibarr versions block the REST assign endpoint).
- **DolibarrCategories component**: full CRUD + hierarchical tree view, new tab in DolibarrPanel.

## Fix for existing products with tosell=0/tobuy=0

Re-import the same CSV with `overwrite: true` — the payload already sets `tosell=1, tobuy=1` via `setdefault`, so all existing products will be updated.

## Test plan

- [ ] Import CSV without category column → products appear in Dolibarr with `tosell=1, tobuy=1`
- [ ] Import CSV with category column → products assigned to correct category
- [ ] Import with `overwrite=true` fixes existing products with 0/0
- [ ] Progress bar updates during large import
- [ ] Category tree renders correctly in DolibarrPanel > Categorías tab
- [ ] DB fallback triggers when REST assign returns non-2xx