### PR TITLE
feat: category/subcategory unified selector for Dolibarr and Odoo + fix subcategory assignment bug

### DIFF
--- a/api/v1/endpoints/dolibarr.py
+++ b/api/v1/endpoints/dolibarr.py
@@ -1155,6 +1155,11 @@ async def import_from_csv(
                     subcat = await cat_svc.find_or_create_subcategory(parent_name, subcat_name)
                     subcateg_pair_to_id[f"{parent_name}||{subcat_name}"] = int(subcat["id"])
                 except Exception as exc:
+                    logger.warning(
+                        "Error resolviendo subcategoría en pre-importación",
+                        exc_info=exc,
+                        extra={"parent": parent_name, "subcat": subcat_name},
+                    )
                     if parent_name not in missing_parents and "no existe" in str(exc):
                         missing_parents.append(parent_name)
             if missing_parents:

--- a/api/v1/endpoints/dolibarr.py
+++ b/api/v1/endpoints/dolibarr.py
@@ -1073,6 +1073,7 @@ async def import_from_csv(
     mapping: str = Form(...),
     overwrite: bool = Form(default=False),
     category_column: str = Form(default=""),
+    subcategory_column: str = Form(default=""),
 ) -> JSONResponse:
     """
     Inicia la importación masiva de productos desde CSV como tarea Celery asíncrona.
@@ -1083,10 +1084,13 @@ async def import_from_csv(
     el progreso y obtener los resultados cuando la tarea termine.
 
     Args:
-        file:            CSV de productos (multipart).
-        mapping:         JSON string con el mapeo columna → campo Dolibarr.
-        overwrite:       si True, actualiza productos que ya existen en Dolibarr.
-        category_column: nombre de la columna CSV que contiene el nombre de categoría.
+        file:               CSV de productos (multipart).
+        mapping:            JSON string con el mapeo columna → campo Dolibarr.
+        overwrite:          si True, actualiza productos que ya existen en Dolibarr.
+        category_column:    nombre de la columna CSV con la categoría padre.
+        subcategory_column: nombre de la columna CSV con la subcategoría (opcional).
+                            Si se indica, la subcategoría se crea automáticamente bajo
+                            la categoría padre y el producto se asigna a ella.
 
     Returns:
         HTTP 202 con ``{task_id, status: "pending"}``.
@@ -1115,11 +1119,13 @@ async def import_from_csv(
         )
 
     cat_col = category_column.strip()
+    subcat_col = subcategory_column.strip()
     _, cat_svc = await _get_services_async()
 
-    # Pre-validar categorías de forma síncrona antes de encolar
     category_name_to_id: dict[str, int] = {}
-    if cat_col:
+    subcateg_pair_to_id: dict[str, int] = {}  # clave: "padre||hijo"
+
+    if cat_col or subcat_col:
         try:
             text = content.decode("utf-8-sig")
         except UnicodeDecodeError:
@@ -1134,29 +1140,57 @@ async def import_from_csv(
             delimiter = best if counts[best] > 0 else ","
 
         reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
-        unique_names: set[str] = set()
-        for row in reader:
-            name = (row.get(cat_col) or "").strip()
-            if name:
-                unique_names.add(name)
+        rows_csv = list(reader)
 
-        missing: list[str] = []
-        for name in unique_names:
-            cat = await cat_svc.find_category_by_name(name)
-            if cat is None:
-                missing.append(name)
-            else:
-                category_name_to_id[name] = int(cat["id"])
+        if subcat_col and cat_col:
+            # Modo subcategoría: validar padres y resolver/crear subcategorías automáticamente
+            unique_pairs: set[tuple[str, str]] = {
+                ((row.get(cat_col) or "").strip(), (row.get(subcat_col) or "").strip())
+                for row in rows_csv
+                if (row.get(cat_col) or "").strip() and (row.get(subcat_col) or "").strip()
+            }
+            missing_parents: list[str] = []
+            for parent_name, subcat_name in unique_pairs:
+                try:
+                    subcat = await cat_svc.find_or_create_subcategory(parent_name, subcat_name)
+                    subcateg_pair_to_id[f"{parent_name}||{subcat_name}"] = int(subcat["id"])
+                except Exception as exc:
+                    if parent_name not in missing_parents and "no existe" in str(exc):
+                        missing_parents.append(parent_name)
+            if missing_parents:
+                missing_list = ", ".join(f"'{p}'" for p in sorted(missing_parents))
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        f"Categorías padre no encontradas en Dolibarr: {missing_list}. "
+                        "Créalas primero desde el módulo de Categorías."
+                    ),
+                )
+        elif cat_col:
+            # Modo categoría simple: validar que todas las categorías existen
+            unique_names: set[str] = set()
+            for row in rows_csv:
+                name = (row.get(cat_col) or "").strip()
+                if name:
+                    unique_names.add(name)
 
-        if missing:
-            missing_list = ", ".join(f"'{c}'" for c in sorted(missing))
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=(
-                    f"Categorías no encontradas en Dolibarr: {missing_list}. "
-                    "Créalas primero desde el módulo de Categorías con el nombre exacto."
-                ),
-            )
+            missing: list[str] = []
+            for name in unique_names:
+                cat = await cat_svc.find_category_by_name(name)
+                if cat is None:
+                    missing.append(name)
+                else:
+                    category_name_to_id[name] = int(cat["id"])
+
+            if missing:
+                missing_list = ", ".join(f"'{c}'" for c in sorted(missing))
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        f"Categorías no encontradas en Dolibarr: {missing_list}. "
+                        "Créalas primero desde el módulo de Categorías con el nombre exacto."
+                    ),
+                )
 
     dolibarr_url, dolibarr_api_key = await _get_dolibarr_credentials()
 
@@ -1185,6 +1219,8 @@ async def import_from_csv(
         category_name_to_id,
         dolibarr_url,
         dolibarr_api_key,
+        subcat_col,
+        subcateg_pair_to_id,
     )
 
     logger.info(

--- a/api/v1/endpoints/odoo.py
+++ b/api/v1/endpoints/odoo.py
@@ -421,19 +421,46 @@ async def csv_import_products(
 
     client = await _build_client()
 
-    # ── Validación previa de categorías ──────────────────────────────────────
-    # Identificar qué columna CSV mapea a categ_id
+    # ── Validación previa de categorías y subcategorías ─────────────────────
     categ_csv_col = next((col for col, field in col_mapping.items() if field == "categ_id"), None)
+    subcateg_csv_col = next((col for col, field in col_mapping.items() if field == "subcateg_id"), None)
     categ_name_to_id: dict[str, int] = {}
+    subcateg_pair_to_id: dict[str, int] = {}  # clave: "padre||hijo"
 
-    if categ_csv_col:
+    cat_svc = OooCategoryService(client)
+
+    if subcateg_csv_col and categ_csv_col:
+        # Modo subcategoría: validar padres y resolver/crear subcategorías
+        unique_pairs: set[tuple[str, str]] = {
+            (row.get(categ_csv_col, "").strip(), row.get(subcateg_csv_col, "").strip())
+            for row in rows
+            if row.get(categ_csv_col, "").strip() and row.get(subcateg_csv_col, "").strip()
+        }
+        missing_parents: list[str] = []
+        for parent_name, subcat_name in unique_pairs:
+            try:
+                subcat = await cat_svc.find_or_create_subcategory(parent_name, subcat_name)
+                subcateg_pair_to_id[f"{parent_name}||{subcat_name}"] = int(subcat["id"])
+            except Exception as exc:
+                msg = str(exc)
+                if parent_name not in missing_parents and "no existe" in msg:
+                    missing_parents.append(parent_name)
+        if missing_parents:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"Categorías padre no encontradas en Odoo: {missing_parents}. "
+                    "Créalas primero en la pestaña Categorías."
+                ),
+            )
+    elif categ_csv_col:
+        # Modo categoría simple: validar que todas existen
         unique_cat_names: set[str] = {
             row[categ_csv_col].strip()
             for row in rows
             if row.get(categ_csv_col, "").strip()
         }
         if unique_cat_names:
-            cat_svc = OooCategoryService(client)
             missing_cats: list[str] = []
             for cat_name in unique_cat_names:
                 found = await cat_svc.find_category_by_name(cat_name)
@@ -454,7 +481,11 @@ async def csv_import_products(
     svc = OdooProductService(client)
     try:
         result = await svc.bulk_upsert_products(
-            rows, col_mapping, overwrite=overwrite, categ_name_to_id=categ_name_to_id or None
+            rows,
+            col_mapping,
+            overwrite=overwrite,
+            categ_name_to_id=categ_name_to_id or None,
+            subcateg_pair_to_id=subcateg_pair_to_id or None,
         )
         msg = (
             f"{result['created']} creados, {result['updated']} actualizados, "

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -935,12 +935,14 @@ export async function importDolibarrCsv(
   mapping: Record<string, string>,
   overwrite: boolean,
   categoryColumn?: string,
+  subcategoryColumn?: string,
 ): Promise<DolibarrImportTask> {
   const form = new FormData()
   form.append('file', file)
   form.append('mapping', JSON.stringify(mapping))
   form.append('overwrite', String(overwrite))
   if (categoryColumn) form.append('category_column', categoryColumn)
+  if (subcategoryColumn) form.append('subcategory_column', subcategoryColumn)
   const response = await apiClient.post<ApiResponse<DolibarrImportTask>>(
     '/dolibarr/products/import',
     form,

--- a/frontend/src/components/dolibarr/DolibarrCategories.tsx
+++ b/frontend/src/components/dolibarr/DolibarrCategories.tsx
@@ -212,6 +212,9 @@ function CategoryNode({ node, depth, onAddChild, onEdit, onDelete }: CategoryNod
           {node.description && (
             <span className="ml-2 text-xs text-gray-400 truncate">{node.description}</span>
           )}
+          {node.children.length > 0 && (
+            <span className="ml-2 text-xs text-gray-300">({node.children.length})</span>
+          )}
         </div>
 
         {/* Badge ID */}

--- a/frontend/src/components/dolibarr/DolibarrProducts.tsx
+++ b/frontend/src/components/dolibarr/DolibarrProducts.tsx
@@ -750,6 +750,7 @@ function CreateProductModal({ onClose, onSuccess }: CreateProductModalProps): Re
   const [error, setError] = useState<string | null>(null)
   const [categories, setCategories] = useState<DolibarrCategory[]>([])
   const [selectedCategory, setSelectedCategory] = useState('')
+  const [selectedSubcategory, setSelectedSubcategory] = useState('')
 
   useEffect(() => {
     Promise.all([
@@ -765,6 +766,14 @@ function CreateProductModal({ onClose, onSuccess }: CreateProductModalProps): Re
       .finally(() => setFieldsLoading(false))
   }, [])
 
+  const selectedCatObj = categories.find((c) => c.label === selectedCategory)
+  const subcategoriesCreate = selectedCatObj
+    ? categories.filter((c) => {
+        try { return parseInt(String(c.fk_parent)) === parseInt(String(selectedCatObj.id)) }
+        catch { return false }
+      })
+    : []
+
   const handleChange = (key: string, value: string) =>
     setValues((prev) => ({ ...prev, [key]: value }))
 
@@ -777,7 +786,11 @@ function CreateProductModal({ onClose, onSuccess }: CreateProductModalProps): Re
       setSubmitting(true)
       setError(null)
       const payload = buildPayload(values, fields) as Record<string, unknown>
-      if (selectedCategory) payload.category_name = selectedCategory
+      if (selectedSubcategory) {
+        payload.category_name = selectedSubcategory
+      } else if (selectedCategory) {
+        payload.category_name = selectedCategory
+      }
       await createDolibarrProduct(payload as Partial<DolibarrProduct>)
       onSuccess()
     } catch (err) {
@@ -810,11 +823,11 @@ function CreateProductModal({ onClose, onSuccess }: CreateProductModalProps): Re
               <div className="border border-amber-200 bg-amber-50 rounded-lg p-4 space-y-3">
                 <p className="text-xs font-semibold text-amber-800 uppercase tracking-wide">Categoría (opcional)</p>
                 <p className="text-xs text-amber-700">
-                  La categoría debe existir previamente en Dolibarr. El nombre debe coincidir exactamente.
+                  La categoría debe existir previamente en Dolibarr. Si se elige subcategoría, el producto quedará asignado a ella.
                 </p>
                 <select
                   value={selectedCategory}
-                  onChange={(e) => setSelectedCategory(e.target.value)}
+                  onChange={(e) => { setSelectedCategory(e.target.value); setSelectedSubcategory('') }}
                   className="w-full px-3 py-2 border border-amber-300 rounded-lg text-sm focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white"
                 >
                   <option value="">— Sin categoría —</option>
@@ -822,6 +835,18 @@ function CreateProductModal({ onClose, onSuccess }: CreateProductModalProps): Re
                     <option key={c.id} value={c.label}>{c.label}</option>
                   ))}
                 </select>
+                {subcategoriesCreate.length > 0 && (
+                  <select
+                    value={selectedSubcategory}
+                    onChange={(e) => setSelectedSubcategory(e.target.value)}
+                    className="w-full px-3 py-2 border border-amber-300 rounded-lg text-sm focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white"
+                  >
+                    <option value="">— Usar categoría padre —</option>
+                    {subcategoriesCreate.map((c) => (
+                      <option key={c.id} value={c.label}>{c.label}</option>
+                    ))}
+                  </select>
+                )}
               </div>
             </>
           )}
@@ -866,6 +891,7 @@ function EditProductModal({ product, onClose, onSuccess }: EditProductModalProps
   const [wpSync, setWpSync] = useState<{ synced: boolean; reason?: string; wc_id?: number } | null>(null)
   const [categories, setCategories] = useState<DolibarrCategory[]>([])
   const [selectedCategory, setSelectedCategory] = useState('')
+  const [selectedSubcategory, setSelectedSubcategory] = useState('')
 
   useEffect(() => {
     Promise.all([
@@ -881,6 +907,14 @@ function EditProductModal({ product, onClose, onSuccess }: EditProductModalProps
       .finally(() => setFieldsLoading(false))
   }, [product])
 
+  const selectedCatObjEdit = categories.find((c) => c.label === selectedCategory)
+  const subcategoriesEdit = selectedCatObjEdit
+    ? categories.filter((c) => {
+        try { return parseInt(String(c.fk_parent)) === parseInt(String(selectedCatObjEdit.id)) }
+        catch { return false }
+      })
+    : []
+
   const handleChange = (key: string, value: string) =>
     setValues((prev) => ({ ...prev, [key]: value }))
 
@@ -894,7 +928,11 @@ function EditProductModal({ product, onClose, onSuccess }: EditProductModalProps
       setError(null)
       setWpSync(null)
       const payload = buildPayload(values, fields) as Record<string, unknown>
-      if (selectedCategory) payload.category_name = selectedCategory
+      if (selectedSubcategory) {
+        payload.category_name = selectedSubcategory
+      } else if (selectedCategory) {
+        payload.category_name = selectedCategory
+      }
       const result = await updateDolibarrProduct(product.id, payload as Partial<DolibarrProduct>)
       if (result.wordpress_sync) setWpSync(result.wordpress_sync)
       onSuccess()
@@ -930,11 +968,11 @@ function EditProductModal({ product, onClose, onSuccess }: EditProductModalProps
               <div className="border border-amber-200 bg-amber-50 rounded-lg p-4 space-y-3">
                 <p className="text-xs font-semibold text-amber-800 uppercase tracking-wide">Asignar a categoría (opcional)</p>
                 <p className="text-xs text-amber-700">
-                  La categoría debe existir previamente en Dolibarr. El nombre debe coincidir exactamente. Si el producto ya pertenece a una categoría, se añadirá a esta además.
+                  La categoría debe existir en Dolibarr. Si se elige subcategoría, el producto quedará asignado a ella. Si ya pertenece a una categoría, se añadirá además.
                 </p>
                 <select
                   value={selectedCategory}
-                  onChange={(e) => setSelectedCategory(e.target.value)}
+                  onChange={(e) => { setSelectedCategory(e.target.value); setSelectedSubcategory('') }}
                   className="w-full px-3 py-2 border border-amber-300 rounded-lg text-sm focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white"
                 >
                   <option value="">— Sin cambiar —</option>
@@ -942,6 +980,18 @@ function EditProductModal({ product, onClose, onSuccess }: EditProductModalProps
                     <option key={c.id} value={c.label}>{c.label}</option>
                   ))}
                 </select>
+                {subcategoriesEdit.length > 0 && (
+                  <select
+                    value={selectedSubcategory}
+                    onChange={(e) => setSelectedSubcategory(e.target.value)}
+                    className="w-full px-3 py-2 border border-amber-300 rounded-lg text-sm focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white"
+                  >
+                    <option value="">— Usar categoría padre —</option>
+                    {subcategoriesEdit.map((c) => (
+                      <option key={c.id} value={c.label}>{c.label}</option>
+                    ))}
+                  </select>
+                )}
               </div>
             </>
           )}
@@ -1001,6 +1051,7 @@ function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps): React.Reac
   const [mapping, setMapping] = useState<Record<string, string>>({})
   const [overwrite, setOverwrite] = useState(false)
   const [categoryColumn, setCategoryColumn] = useState('')
+  const [subcategoryColumn, setSubcategoryColumn] = useState('')
   const [result, setResult] = useState<DolibarrImportTask['results'] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -1060,7 +1111,7 @@ function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps): React.Reac
     setStep('importing')
 
     try {
-      const task = await importDolibarrCsv(file, activeMapping, overwrite, categoryColumn || undefined)
+      const task = await importDolibarrCsv(file, activeMapping, overwrite, categoryColumn || undefined, subcategoryColumn || undefined)
 
       pollRef.current = setInterval(async () => {
         try {
@@ -1242,17 +1293,17 @@ function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps): React.Reac
                 </div>
               </div>
 
-              {/* Category column selector */}
+              {/* Category + Subcategory column selectors */}
               <div className="border border-amber-200 bg-amber-50 rounded-lg p-4 space-y-3">
-                <p className="text-xs font-semibold text-amber-800 uppercase tracking-wide">Categoría (opcional)</p>
+                <p className="text-xs font-semibold text-amber-800 uppercase tracking-wide">Categorías (opcional)</p>
                 <p className="text-xs text-amber-700">
-                  ⚠ La categoría debe existir previamente en Dolibarr y el nombre del CSV debe coincidir <strong>exactamente</strong>. Si alguna no existe, la importación se bloqueará con la lista de categorías faltantes.
+                  ⚠ La categoría debe existir previamente en Dolibarr. Si se indica subcategoría, se creará automáticamente bajo la categoría padre si no existe. El producto quedará asignado a la subcategoría.
                 </p>
                 <div className="flex items-center gap-3">
-                  <span className="text-sm text-amber-800 shrink-0">Columna de categoría:</span>
+                  <span className="text-sm text-amber-800 shrink-0 w-36">Columna categoría:</span>
                   <select
                     value={categoryColumn}
-                    onChange={(e) => setCategoryColumn(e.target.value)}
+                    onChange={(e) => { setCategoryColumn(e.target.value); if (!e.target.value) setSubcategoryColumn('') }}
                     className="flex-1 px-2 py-1.5 border border-amber-300 rounded text-sm focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white"
                   >
                     <option value="">— No asignar categoría —</option>
@@ -1261,6 +1312,21 @@ function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps): React.Reac
                     ))}
                   </select>
                 </div>
+                {categoryColumn && (
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm text-amber-800 shrink-0 w-36">Columna subcategoría:</span>
+                    <select
+                      value={subcategoryColumn}
+                      onChange={(e) => setSubcategoryColumn(e.target.value)}
+                      className="flex-1 px-2 py-1.5 border border-amber-300 rounded text-sm focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white"
+                    >
+                      <option value="">— Sin subcategoría —</option>
+                      {preview?.headers.map((h) => (
+                        <option key={h} value={h}>{h}</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
               </div>
 
               {!refMapped && (

--- a/frontend/src/components/odoo/OdooCategories.tsx
+++ b/frontend/src/components/odoo/OdooCategories.tsx
@@ -190,6 +190,9 @@ function CategoryNode({ node, depth, onAddChild, onEdit, onDelete }: CategoryNod
           {node.complete_name && node.complete_name !== node.name && (
             <span className="ml-2 text-xs text-gray-400 truncate">{node.complete_name}</span>
           )}
+          {node.children.length > 0 && (
+            <span className="ml-2 text-xs text-gray-300">({node.children.length})</span>
+          )}
         </div>
 
         {/* Badge ID */}

--- a/frontend/src/components/odoo/OdooCsvImport.tsx
+++ b/frontend/src/components/odoo/OdooCsvImport.tsx
@@ -20,6 +20,7 @@ const FIELD_LABELS: Record<string, string> = {
   detailed_type: 'Tipo (consu/service/product)',
   tracking: 'Seguimiento (none/lot/serial)',
   categ_id: 'Categoría (nombre)',
+  subcateg_id: 'Subcategoría (nombre)',
   list_price: 'Precio de venta',
   compare_list_price: 'Precio comparativo',
   standard_price: 'Coste',
@@ -258,6 +259,17 @@ export default function OdooCsvImport({ onClose, onSuccess }: Props) {
                   ))}
                 </div>
               </div>
+
+              {/* Aviso subcategoría cuando ambos campos están mapeados */}
+              {Object.values(mapping).includes('categ_id') && Object.values(mapping).includes('subcateg_id') && (
+                <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-800">
+                  <p className="font-semibold mb-1">Modo Categoría + Subcategoría activo</p>
+                  <p className="text-xs text-amber-700">
+                    Cada subcategoría se creará automáticamente bajo su categoría padre si no existe en Odoo.
+                    La categoría padre <strong>debe existir</strong> previamente. El producto quedará asignado a la subcategoría.
+                  </p>
+                </div>
+              )}
             </div>
           )}
 

--- a/frontend/src/components/odoo/OdooProducts.tsx
+++ b/frontend/src/components/odoo/OdooProducts.tsx
@@ -535,6 +535,7 @@ function buildPayload(values: FormValues): Partial<OdooProduct> {
 function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
   const isCreate = product === null
   const [values, setValues] = useState<FormValues>(() => initValues(product))
+  const [subcategId, setSubcategId] = useState('')
   const [categories, setCategories] = useState<OdooCategory[]>([])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -545,6 +546,14 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
       .then((r) => setCategories(Array.isArray(r?.items) ? r.items : []))
       .catch(() => {})
   }, [])
+
+  // Subcategorías: hijos de la categoría seleccionada
+  const subcategories = values.categ_id
+    ? categories.filter((c) => {
+        if (!c.parent_id) return false
+        return c.parent_id[0] === parseInt(values.categ_id, 10)
+      })
+    : []
 
   const set = (key: string, value: string) =>
     setValues((prev) => ({ ...prev, [key]: value }))
@@ -561,8 +570,11 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
     setError(null)
     setSubmitting(true)
     try {
+      const payload = buildPayload(values)
+      // Si hay subcategoría seleccionada, sobreescribe categ_id con la subcategoría
+      if (subcategId) payload.categ_id = parseInt(subcategId, 10) as unknown as typeof payload.categ_id
       if (isCreate) {
-        const created = await createOdooProduct(buildPayload(values))
+        const created = await createOdooProduct(payload)
         if (pendingProperties.length > 0) {
           try {
             await setOdooProductProperties(created.id, pendingProperties)
@@ -571,7 +583,7 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
           }
         }
       } else {
-        await updateOdooProduct(product.id, buildPayload(values))
+        await updateOdooProduct(product.id, payload)
         if (pendingProperties.length > 0) {
           try {
             await setOdooProductProperties(product.id, pendingProperties)
@@ -656,13 +668,32 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
               </div>
               <div>
                 <label className={LABEL_CLS}>Categoría</label>
-                <select value={values.categ_id} onChange={(e) => set('categ_id', e.target.value)} className={INPUT_CLS}>
+                <select
+                  value={values.categ_id}
+                  onChange={(e) => { set('categ_id', e.target.value); setSubcategId('') }}
+                  className={INPUT_CLS}
+                >
                   <option value="">— Sin cambio —</option>
                   {categories.map((c) => (
                     <option key={c.id} value={String(c.id)}>{c.complete_name || c.name}</option>
                   ))}
                 </select>
               </div>
+              {subcategories.length > 0 && (
+                <div>
+                  <label className={LABEL_CLS}>Subcategoría</label>
+                  <select
+                    value={subcategId}
+                    onChange={(e) => setSubcategId(e.target.value)}
+                    className={INPUT_CLS}
+                  >
+                    <option value="">— Usar categoría padre —</option>
+                    {subcategories.map((c) => (
+                      <option key={c.id} value={String(c.id)}>{c.name}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
               <div>
                 <label className={LABEL_CLS}>HS Code</label>
                 <input type="text" value={values.hs_code} onChange={(e) => set('hs_code', e.target.value)} placeholder="p.ej. 8471300000" className={INPUT_CLS} />

--- a/services/integrations/dolibarr/categories.py
+++ b/services/integrations/dolibarr/categories.py
@@ -381,6 +381,81 @@ class DolibarrCategoryService:
                 return None
             offset += limit
 
+    async def find_category_by_name_and_parent(
+        self,
+        name: str,
+        parent_id: int,
+        type: str = "product",
+    ) -> dict | None:
+        """
+        Busca categoría por nombre exacto bajo un padre específico.
+
+        Args:
+            name:      nombre exacto de la categoría (sensible a mayúsculas).
+            parent_id: ID de la categoría padre.
+            type:      tipo de categoría Dolibarr.
+
+        Returns:
+            Dict de la categoría si existe, None si no.
+        """
+        offset = 0
+        limit = 100
+        while True:
+            batch = await self.list_categories(type=type, limit=limit, offset=offset)
+            if not batch:
+                return None
+            for cat in batch:
+                try:
+                    cat_parent_id = int(cat.get("fk_parent") or 0)
+                except (ValueError, TypeError):
+                    cat_parent_id = 0
+                if str(cat.get("label", "")) == name and cat_parent_id == parent_id:
+                    return cat
+            if len(batch) < limit:
+                return None
+            offset += limit
+
+    async def find_or_create_subcategory(
+        self,
+        parent_name: str,
+        subcat_name: str,
+        type: str = "product",
+    ) -> dict:
+        """
+        Busca subcategoría bajo un padre por nombre, o la crea automáticamente si no existe.
+
+        Args:
+            parent_name: nombre exacto de la categoría padre.
+            subcat_name: nombre exacto de la subcategoría.
+            type:        tipo de categoría Dolibarr.
+
+        Returns:
+            Dict con id, label de la subcategoría.
+
+        Raises:
+            IntegrationError: si el padre no existe o falla la creación.
+        """
+        parent = await self.find_category_by_name(parent_name, type=type)
+        if not parent:
+            raise IntegrationError(
+                f"Categoría padre '{parent_name}' no existe en Dolibarr. Créala primero.",
+                platform="dolibarr",
+            )
+        parent_id = int(parent["id"])
+        existing = await self.find_category_by_name_and_parent(subcat_name, parent_id, type=type)
+        if existing:
+            logger.debug(
+                "Subcategoría Dolibarr encontrada",
+                extra={"name": subcat_name, "parent_id": parent_id},
+            )
+            return existing
+        created = await self.create_category(subcat_name, type=type, parent_id=parent_id)
+        logger.info(
+            "Subcategoría Dolibarr creada automáticamente",
+            extra={"name": subcat_name, "parent_name": parent_name},
+        )
+        return created
+
     async def list_products_in_category(
         self,
         category_id: int,

--- a/services/integrations/dolibarr/categories.py
+++ b/services/integrations/dolibarr/categories.py
@@ -153,7 +153,12 @@ class DolibarrCategoryService:
         if parent_id is not None:
             data["fk_parent"] = parent_id
 
-        return await self._client.create(_DOLIBARR_CATEGORIES_RESOURCE, data)
+        raw = await self._client.create(_DOLIBARR_CATEGORIES_RESOURCE, data)
+        # Dolibarr returns the new category ID as a plain integer — normalize to dict
+        # so callers can always do result["id"] safely.
+        if isinstance(raw, (int, str)):
+            return {"id": int(raw), "label": label, "fk_parent": parent_id, "type": type}
+        return raw
 
     async def update_category(
         self,

--- a/services/integrations/dolibarr/products.py
+++ b/services/integrations/dolibarr/products.py
@@ -608,6 +608,8 @@ class DolibarrProductService:
         category_col: str | None = None,
         category_svc: "DolibarrCategoryService | None" = None,
         category_name_to_id: dict[str, int] | None = None,
+        subcategory_col: str | None = None,
+        subcateg_pair_to_id: dict[str, int] | None = None,
         progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[dict[str, Any]]:
         """
@@ -625,6 +627,9 @@ class DolibarrProductService:
         la categoría correspondiente. Las categorías deben haber sido validadas
         previamente (el endpoint comprueba su existencia antes de llamar aquí).
 
+        Si además se proporcionan ``subcategory_col`` y ``subcateg_pair_to_id``,
+        el producto se asigna a la subcategoría (ya resuelta/creada por el endpoint).
+
         Si se proporciona ``progress_callback``, se llama cada 10 filas y al
         terminar con ``(procesados, total)`` para que la tarea Celery pueda
         actualizar Redis con el progreso en tiempo real.
@@ -633,9 +638,11 @@ class DolibarrProductService:
             content:              contenido raw del archivo CSV.
             mapping:              dict que mapea nombre_columna_csv → campo_dolibarr.
             overwrite:            si True, actualiza productos existentes (busca por ref).
-            category_col:         nombre de la columna CSV que contiene el nombre de categoría.
+            category_col:         nombre de la columna CSV con la categoría padre.
             category_svc:         servicio de categorías para asignar el producto.
             category_name_to_id:  mapa nombre_categoría → ID ya validado.
+            subcategory_col:      nombre de la columna CSV con la subcategoría (opcional).
+            subcateg_pair_to_id:  mapa "padre||hijo" → ID subcategoría ya resuelto.
             progress_callback:    función opcional ``(procesados, total) → None``.
 
         Returns:
@@ -719,7 +726,28 @@ class DolibarrProductService:
 
                 result["dolibarr_id"] = dolibarr_id
 
-                if category_col and category_svc and category_name_to_id:
+                # Asignar subcategoría si se proporcionó columna de subcategoría
+                if subcategory_col and category_col and category_svc and subcateg_pair_to_id:
+                    parent_name = (row.get(category_col) or "").strip()
+                    subcat_name = (row.get(subcategory_col) or "").strip()
+                    pair_key = f"{parent_name}||{subcat_name}"
+                    cat_id = subcateg_pair_to_id.get(pair_key)
+                    if cat_id:
+                        try:
+                            await category_svc.assign_product(cat_id, dolibarr_id)
+                            result["category_assigned"] = f"{parent_name} > {subcat_name}"
+                            logger.info(
+                                "Subcategoría asignada via CSV import",
+                                extra={"ref": ref, "subcategory": subcat_name, "parent": parent_name, "dolibarr_id": dolibarr_id},
+                            )
+                        except Exception as cat_exc:
+                            logger.warning(
+                                "Error asignando subcategoría en CSV import",
+                                exc_info=cat_exc,
+                                extra={"ref": ref, "subcategory": subcat_name},
+                            )
+                elif category_col and category_svc and category_name_to_id:
+                    # Asignar categoría simple (sin subcategoría)
                     cat_name = (row.get(category_col) or "").strip()
                     cat_id = category_name_to_id.get(cat_name)
                     if cat_id:

--- a/services/integrations/odoo/categories.py
+++ b/services/integrations/odoo/categories.py
@@ -218,3 +218,66 @@ class OooCategoryService:
         if not isinstance(self._client, OdooClient):
             return 0
         return await self._client.search_count("product.category")
+
+    async def find_category_by_name_and_parent(self, name: str, parent_id: int) -> dict | None:
+        """
+        Busca categoría por nombre exacto bajo un padre específico.
+
+        Args:
+            name:      nombre exacto de la categoría.
+            parent_id: ID de la categoría padre.
+
+        Returns:
+            Dict de la categoría si existe, None si no.
+        """
+        try:
+            results = await self._client.list(
+                "product.category",
+                limit=1,
+                filters={
+                    "domain": [("name", "=", name), ("parent_id", "=", parent_id)],
+                    "fields": ["id", "name", "complete_name"],
+                },
+            )
+            return results[0] if results else None
+        except Exception as exc:
+            logger.warning(
+                "Error buscando subcategoría Odoo por nombre y padre",
+                exc_info=exc,
+                extra={"name": name, "parent_id": parent_id},
+            )
+            return None
+
+    async def find_or_create_subcategory(self, parent_name: str, subcat_name: str) -> dict:
+        """
+        Busca subcategoría bajo un padre por nombre, o la crea automáticamente si no existe.
+
+        Args:
+            parent_name: nombre exacto de la categoría padre.
+            subcat_name: nombre exacto de la subcategoría.
+
+        Returns:
+            Dict con id, name, complete_name de la subcategoría.
+
+        Raises:
+            IntegrationError: si el padre no existe en Odoo o falla la creación.
+        """
+        parent = await self.find_category_by_name(parent_name)
+        if not parent:
+            raise IntegrationError(
+                f"Categoría padre '{parent_name}' no existe en Odoo. Créala primero."
+            )
+        parent_id = int(parent["id"])
+        existing = await self.find_category_by_name_and_parent(subcat_name, parent_id)
+        if existing:
+            logger.debug(
+                "Subcategoría Odoo encontrada",
+                extra={"name": subcat_name, "parent_id": parent_id},
+            )
+            return existing
+        created = await self.create_category(subcat_name, parent_id=parent_id)
+        logger.info(
+            "Subcategoría Odoo creada automáticamente",
+            extra={"name": subcat_name, "parent_name": parent_name, "id": created.get("id")},
+        )
+        return created

--- a/services/integrations/odoo/products.py
+++ b/services/integrations/odoo/products.py
@@ -291,6 +291,8 @@ class OdooProductService:
         "website_meta_description": "str",
         "website_meta_keywords": "str",
         "description": "str",
+        # Campo virtual: nombre de subcategoría — resuelto antes de enviar a Odoo
+        "subcateg_id": "str",
     }
 
     @classmethod
@@ -331,6 +333,7 @@ class OdooProductService:
         concurrency: int = 10,
         batch_size: int = 100,
         categ_name_to_id: dict[str, int] | None = None,
+        subcateg_pair_to_id: dict[str, int] | None = None,
     ) -> dict:
         """
         Importa múltiples productos desde CSV con upsert por default_code.
@@ -342,12 +345,14 @@ class OdooProductService:
           4. Actualización concurrente de existentes (N llamadas, sin búsqueda previa).
 
         Args:
-            rows:              lista de dicts {columna_csv: valor_string}.
-            mapping:           dict {columna_csv: campo_odoo}. Columnas mapeadas a "" se ignoran.
-            overwrite:         si True, actualiza productos existentes; si False, los omite.
-            concurrency:       máximo de actualizaciones simultáneas contra Odoo.
-            batch_size:        tamaño del lote para búsquedas masivas y creaciones.
-            categ_name_to_id:  mapa {nombre_categoría: id_odoo} pre-validado en el endpoint.
+            rows:                 lista de dicts {columna_csv: valor_string}.
+            mapping:              dict {columna_csv: campo_odoo}. Columnas mapeadas a "" se ignoran.
+            overwrite:            si True, actualiza productos existentes; si False, los omite.
+            concurrency:          máximo de actualizaciones simultáneas contra Odoo.
+            batch_size:           tamaño del lote para búsquedas masivas y creaciones.
+            categ_name_to_id:     mapa {nombre_categoría: id_odoo} pre-validado en el endpoint.
+            subcateg_pair_to_id:  mapa {"padre||hijo": id_odoo} de subcategorías resueltas.
+                                  Si presente, sobreescribe categ_id con el ID de la subcategoría.
 
         Returns:
             Dict con claves: created (int), updated (int), skipped (int),
@@ -367,8 +372,16 @@ class OdooProductService:
                 if coerced is not False:
                     product_data[odoo_field] = coerced
 
-            # Resolver nombre de categoría a ID Odoo
-            if "categ_id" in product_data and categ_name_to_id:
+            # Resolver subcategoría — si hay par (padre||hijo) usa el ID de la subcategoría
+            if "subcateg_id" in product_data and subcateg_pair_to_id:
+                parent_name = str(product_data.get("categ_id", "")).strip()
+                subcat_name = str(product_data["subcateg_id"]).strip()
+                pair_key = f"{parent_name}||{subcat_name}"
+                if pair_key in subcateg_pair_to_id:
+                    product_data["categ_id"] = subcateg_pair_to_id[pair_key]
+                del product_data["subcateg_id"]
+            elif "categ_id" in product_data and categ_name_to_id:
+                # Sin subcategoría: resolver categoría principal por nombre
                 cat_name = str(product_data["categ_id"]).strip()
                 if cat_name in categ_name_to_id:
                     product_data["categ_id"] = categ_name_to_id[cat_name]

--- a/workers/tasks.py
+++ b/workers/tasks.py
@@ -572,6 +572,8 @@ def importar_productos_dolibarr(
     category_name_to_id: dict,
     dolibarr_url: str,
     dolibarr_api_key: str,
+    subcategory_column: str = "",
+    subcateg_pair_to_id: dict | None = None,
 ) -> dict:
     """
     Tarea Celery que importa productos en masa a Dolibarr desde un CSV.
@@ -581,15 +583,17 @@ def importar_productos_dolibarr(
     consultarlo mediante polling.
 
     Args:
-        self:                instancia de la tarea (bind=True).
-        task_id:             UUID de la tarea, usado como clave Redis.
-        csv_b64:             contenido del CSV codificado en base64.
-        mapping:             dict columna_csv → campo_dolibarr.
-        overwrite:           si True, actualiza productos existentes.
-        category_column:     nombre de la columna CSV con la categoría (vacío si no aplica).
-        category_name_to_id: mapa nombre_categoría → ID Dolibarr (ya validado).
-        dolibarr_url:        URL base de la API Dolibarr.
-        dolibarr_api_key:    clave API Dolibarr.
+        self:                 instancia de la tarea (bind=True).
+        task_id:              UUID de la tarea, usado como clave Redis.
+        csv_b64:              contenido del CSV codificado en base64.
+        mapping:              dict columna_csv → campo_dolibarr.
+        overwrite:            si True, actualiza productos existentes.
+        category_column:      nombre de la columna CSV con la categoría padre.
+        category_name_to_id:  mapa nombre_categoría → ID Dolibarr (ya validado).
+        dolibarr_url:         URL base de la API Dolibarr.
+        dolibarr_api_key:     clave API Dolibarr.
+        subcategory_column:   nombre de la columna CSV con la subcategoría (opcional).
+        subcateg_pair_to_id:  mapa "padre||hijo" → ID Dolibarr de la subcategoría.
 
     Returns:
         Dict con resumen de la importación o ``{"error": str}`` si falla.
@@ -632,7 +636,8 @@ def importar_productos_dolibarr(
 
         client = DolibarrClient(settings, override_url=dolibarr_url, override_api_key=dolibarr_api_key)
         svc = DolibarrProductService(client)
-        cat_svc = DolibarrCategoryService(client) if category_column else None
+        needs_cat_svc = bool(category_column or subcategory_column)
+        cat_svc = DolibarrCategoryService(client) if needs_cat_svc else None
 
         content = base64.b64decode(csv_b64.encode())
 
@@ -643,6 +648,8 @@ def importar_productos_dolibarr(
             category_col=category_column or None,
             category_svc=cat_svc,
             category_name_to_id=category_name_to_id or None,
+            subcategory_col=subcategory_column or None,
+            subcateg_pair_to_id=subcateg_pair_to_id or None,
             progress_callback=_progress,
         )
 


### PR DESCRIPTION
## Summary

- Add subcategory column selector to Dolibarr and Odoo CSV import flows and single-product modals
- Build `subcateg_pair_to_id` map in endpoint before launching Celery task, resolving/creating subcategories eagerly
- **Fix Dolibarr subcategory assignment bug**: `POST /categories` returns a bare integer ID — `create_category` now normalizes the response to a dict so callers can safely access `result["id"]`; previously the `TypeError` was silently swallowed, leaving `subcateg_pair_to_id` empty and skipping all product-category assignments
- Add `logger.warning` in pre-import exception handler so future resolution failures are visible in logs
- Unify category tree node child count badge style across Dolibarr and Odoo panels

## Root cause (Dolibarr bug)

`DolibarrCategoryService.create_category` returned the raw Dolibarr response directly. Dolibarr's REST API returns a plain integer for `POST /categories`, not a dict. Every caller that did `result["id"]` raised `TypeError: 'int' object is not subscriptable`, which was caught silently → `subcateg_pair_to_id = {}` → passed as `None` to the Celery task → assignment condition was falsy → zero products assigned to subcategories.

## Test plan

- [ ] Dolibarr CSV import with category + subcategory columns: products assigned to correct subcategories
- [ ] New subcategories auto-created if missing, then products assigned
- [ ] Odoo CSV import with subcategory column: products assigned (was already working, verify no regression)
- [ ] Single-product modal in both platforms: subcategory selector saves correctly