### PR TITLE
feat(dolibarr): brands management — list, create, and assign brands in products and CSV import

### DIFF
--- a/api/v1/endpoints/dolibarr.py
+++ b/api/v1/endpoints/dolibarr.py
@@ -726,6 +726,7 @@ async def create_product(data: dict) -> JSONResponse:
     """
     array_options: dict = data.pop("array_options", None) or {}
     category_name: str = (data.pop("category_name", None) or "").strip()
+    brand_name: str = (data.pop("brand_name", None) or "").strip()
 
     svc, cat_svc = await _get_services_async()
 
@@ -742,6 +743,17 @@ async def create_product(data: dict) -> JSONResponse:
                 ),
             )
         category_id = int(cat["id"])
+
+    brand_id: int | None = None
+    if brand_name:
+        try:
+            brand_cat = await cat_svc.find_or_create_brand(brand_name)
+            brand_id = int(brand_cat["id"])
+        except IntegrationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(exc),
+            )
 
     try:
         created = await svc.create_product(data)
@@ -784,6 +796,20 @@ async def create_product(data: dict) -> JSONResponse:
                 extra={"product_id": product_id, "category": category_name},
             )
 
+    if brand_id and product_id:
+        try:
+            await cat_svc.assign_product(brand_id, product_id)
+            logger.info(
+                "Marca asignada a producto creado",
+                extra={"product_id": product_id, "brand": brand_name},
+            )
+        except Exception as exc:
+            logger.warning(
+                "Error asignando marca tras crear producto",
+                exc_info=exc,
+                extra={"product_id": product_id, "brand": brand_name},
+            )
+
     return JSONResponse(
         content=_ok(created, "Producto creado."),
         status_code=status.HTTP_201_CREATED,
@@ -812,6 +838,7 @@ async def update_product(product_id: int, data: dict) -> JSONResponse:
     """
     array_options: dict = data.pop("array_options", None) or {}
     category_name: str = (data.pop("category_name", None) or "").strip()
+    brand_name: str = (data.pop("brand_name", None) or "").strip()
 
     svc, cat_svc = await _get_services_async()
 
@@ -828,6 +855,17 @@ async def update_product(product_id: int, data: dict) -> JSONResponse:
                 ),
             )
         category_id = int(cat["id"])
+
+    brand_id: int | None = None
+    if brand_name:
+        try:
+            brand_cat = await cat_svc.find_or_create_brand(brand_name)
+            brand_id = int(brand_cat["id"])
+        except IntegrationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(exc),
+            )
 
     try:
         updated = await svc.update_product(product_id, data)
@@ -866,6 +904,20 @@ async def update_product(product_id: int, data: dict) -> JSONResponse:
                 "Error asignando categoría tras actualizar producto",
                 exc_info=exc,
                 extra={"product_id": product_id, "category": category_name},
+            )
+
+    if brand_id:
+        try:
+            await cat_svc.assign_product(brand_id, product_id)
+            logger.info(
+                "Marca asignada a producto actualizado",
+                extra={"product_id": product_id, "brand": brand_name},
+            )
+        except Exception as exc:
+            logger.warning(
+                "Error asignando marca tras actualizar producto",
+                exc_info=exc,
+                extra={"product_id": product_id, "brand": brand_name},
             )
 
     # ── Sync Dolibarr → WordPress ─────────────────────────────────────────────
@@ -1074,6 +1126,7 @@ async def import_from_csv(
     overwrite: bool = Form(default=False),
     category_column: str = Form(default=""),
     subcategory_column: str = Form(default=""),
+    brand_column: str = Form(default=""),
 ) -> JSONResponse:
     """
     Inicia la importación masiva de productos desde CSV como tarea Celery asíncrona.
@@ -1120,12 +1173,14 @@ async def import_from_csv(
 
     cat_col = category_column.strip()
     subcat_col = subcategory_column.strip()
+    brand_col = brand_column.strip()
     _, cat_svc = await _get_services_async()
 
     category_name_to_id: dict[str, int] = {}
     subcateg_pair_to_id: dict[str, int] = {}  # clave: "padre||hijo"
+    brand_name_to_id: dict[str, int] = {}
 
-    if cat_col or subcat_col:
+    if cat_col or subcat_col or brand_col:
         try:
             text = content.decode("utf-8-sig")
         except UnicodeDecodeError:
@@ -1197,6 +1252,36 @@ async def import_from_csv(
                     ),
                 )
 
+        if brand_col:
+            # Resolver marcas bajo la categoría padre "Marcas"
+            unique_brands: set[str] = {
+                (row.get(brand_col) or "").strip()
+                for row in rows_csv
+                if (row.get(brand_col) or "").strip()
+            }
+            missing_brands_parent = False
+            for brand_name in unique_brands:
+                try:
+                    brand_cat = await cat_svc.find_or_create_brand(brand_name, brands_parent=_BRANDS_PARENT)
+                    brand_name_to_id[brand_name] = int(brand_cat["id"])
+                except IntegrationError as exc:
+                    if "no existe" in str(exc):
+                        missing_brands_parent = True
+                        break
+                    logger.warning(
+                        "Error resolviendo marca en pre-importación",
+                        exc_info=exc,
+                        extra={"brand": brand_name},
+                    )
+            if missing_brands_parent:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        f"La categoría '{_BRANDS_PARENT}' no existe en Dolibarr. "
+                        "Créala primero en la pestaña Categorías antes de importar marcas."
+                    ),
+                )
+
     dolibarr_url, dolibarr_api_key = await _get_dolibarr_credentials()
 
     task_id = str(uuid.uuid4())
@@ -1226,6 +1311,8 @@ async def import_from_csv(
         dolibarr_api_key,
         subcat_col,
         subcateg_pair_to_id,
+        brand_col,
+        brand_name_to_id,
     )
 
     logger.info(
@@ -1340,6 +1427,7 @@ async def sync_from_job(request: SyncFromJobRequest) -> JSONResponse:
 
 
 categories_router = APIRouter(prefix="/dolibarr/categories", tags=["dolibarr-categories"])
+brands_router = APIRouter(prefix="/dolibarr/brands", tags=["dolibarr-brands"])
 
 
 async def _get_category_service() -> DolibarrCategoryService:
@@ -1616,6 +1704,77 @@ async def list_products_in_category(
         offset=offset,
         has_more=len(items) == limit,
     ).model_dump()))
+
+
+# ── Marcas ────────────────────────────────────────────────────────
+
+_BRANDS_PARENT = "Marcas"
+
+
+@brands_router.get("")
+async def list_brands(
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> JSONResponse:
+    """
+    Lista las marcas (subcategorías bajo la categoría 'Marcas' de tipo producto).
+
+    La categoría padre 'Marcas' debe existir previamente en Dolibarr.
+
+    Args:
+        limit:  máximo de resultados.
+        offset: desplazamiento para paginación.
+
+    Returns:
+        PaginatedResponse con las marcas disponibles.
+    """
+    svc = await _get_category_service()
+    try:
+        items = await svc.list_brands(brands_parent=_BRANDS_PARENT, limit=limit, offset=offset)
+    except IntegrationError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+    return JSONResponse(content=_ok(PaginatedResponse(
+        items=items,
+        total=len(items),
+        limit=limit,
+        offset=offset,
+        has_more=len(items) == limit,
+    ).model_dump()))
+
+
+@brands_router.post("", status_code=status.HTTP_201_CREATED)
+async def create_brand(
+    name: str = Body(..., embed=True),
+) -> JSONResponse:
+    """
+    Crea una nueva marca como subcategoría bajo la categoría 'Marcas' en Dolibarr.
+
+    La categoría padre 'Marcas' debe existir previamente en Dolibarr.
+    Si la marca ya existe, la devuelve sin crear duplicados.
+
+    Args:
+        name: nombre de la nueva marca.
+
+    Returns:
+        Dict con los datos de la marca creada o existente.
+
+    Raises:
+        HTTPException 422: si la categoría 'Marcas' no existe en Dolibarr.
+    """
+    svc = await _get_category_service()
+    try:
+        brand = await svc.find_or_create_brand(name.strip(), brands_parent=_BRANDS_PARENT)
+    except IntegrationError as exc:
+        if "no existe" in str(exc):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"La categoría '{_BRANDS_PARENT}' no existe en Dolibarr. Créala primero en la pestaña Categorías.",
+            )
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+    return JSONResponse(
+        content=_ok(brand, "Marca creada."),
+        status_code=status.HTTP_201_CREATED,
+    )
 
 
 # ── Terceros ─────────────────────────────────────────────────────

--- a/api/v1/router.py
+++ b/api/v1/router.py
@@ -13,6 +13,7 @@ Cualquier nuevo recurso de v1 se registra aquí.
 from fastapi import APIRouter
 
 from api.v1.endpoints.dolibarr import (
+    brands_router as dolibarr_brands_router,
     categories_router,
     extrafields_router,
     invoices_router,
@@ -54,6 +55,7 @@ router.include_router(history_router)
 router.include_router(dolibarr_router_main)
 router.include_router(dolibarr_router_products)
 router.include_router(categories_router)
+router.include_router(dolibarr_brands_router)
 router.include_router(thirdparties_router)
 router.include_router(orders_router)
 router.include_router(invoices_router)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -936,6 +936,7 @@ export async function importDolibarrCsv(
   overwrite: boolean,
   categoryColumn?: string,
   subcategoryColumn?: string,
+  brandColumn?: string,
 ): Promise<DolibarrImportTask> {
   const form = new FormData()
   form.append('file', file)
@@ -943,6 +944,7 @@ export async function importDolibarrCsv(
   form.append('overwrite', String(overwrite))
   if (categoryColumn) form.append('category_column', categoryColumn)
   if (subcategoryColumn) form.append('subcategory_column', subcategoryColumn)
+  if (brandColumn) form.append('brand_column', brandColumn)
   const response = await apiClient.post<ApiResponse<DolibarrImportTask>>(
     '/dolibarr/products/import',
     form,
@@ -1051,6 +1053,38 @@ export async function updateDolibarrCategory(
  */
 export async function deleteDolibarrCategory(id: number | string): Promise<void> {
   await apiClient.delete(`/dolibarr/categories/${id}`)
+}
+
+// ─── Marcas Dolibarr ──────────────────────────────────────────────────────────
+
+/**
+ * Lista las marcas de Dolibarr (subcategorías bajo "Marcas").
+ *
+ * @author BenjaminDTS
+ * @param limit  - Máximo de resultados.
+ * @param offset - Desplazamiento.
+ */
+export async function listDolibarrBrands(
+  limit = 100,
+  offset = 0,
+): Promise<{ items: DolibarrCategory[]; total: number; limit: number; offset: number; has_more: boolean }> {
+  const response = await apiClient.get<ApiResponse<{ items: DolibarrCategory[]; total: number; limit: number; offset: number; has_more: boolean }>>(
+    '/dolibarr/brands',
+    { params: { limit, offset } },
+  )
+  return response.data.data
+}
+
+/**
+ * Crea una nueva marca en Dolibarr bajo la categoría "Marcas".
+ * Si ya existe, devuelve la existente.
+ *
+ * @author BenjaminDTS
+ * @param name - Nombre de la marca.
+ */
+export async function createDolibarrBrand(name: string): Promise<DolibarrCategory> {
+  const response = await apiClient.post<ApiResponse<DolibarrCategory>>('/dolibarr/brands', { name })
+  return response.data.data
 }
 
 /**

--- a/frontend/src/components/dolibarr/DolibarrBrands.tsx
+++ b/frontend/src/components/dolibarr/DolibarrBrands.tsx
@@ -1,0 +1,183 @@
+/**
+ * Panel de gestión de marcas en Dolibarr.
+ * Las marcas se almacenan como subcategorías bajo la categoría padre "Marcas"
+ * (tipo producto). La categoría padre debe existir previamente en Dolibarr.
+ *
+ * @author BenjaminDTS
+ */
+import { useEffect, useState } from 'react'
+import { listDolibarrBrands, createDolibarrBrand, deleteDolibarrCategory } from '@/api/client'
+import type { DolibarrCategory } from '@/types/dolibarr'
+
+const INPUT_CLS =
+  'w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm'
+
+export default function DolibarrBrands() {
+  const [brands, setBrands] = useState<DolibarrCategory[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [parentMissing, setParentMissing] = useState(false)
+  const [showCreate, setShowCreate] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
+
+  const load = async () => {
+    setLoading(true)
+    setError(null)
+    setParentMissing(false)
+    try {
+      const data = await listDolibarrBrands(200, 0)
+      setBrands(data.items)
+    } catch (err) {
+      const msg = (err as Error).message ?? 'Error cargando marcas'
+      setError(msg)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { load() }, [])
+
+  const handleDelete = async (brand: DolibarrCategory) => {
+    if (!confirm(`¿Eliminar la marca "${brand.label}"?`)) return
+    try {
+      await deleteDolibarrCategory(brand.id)
+      load()
+    } catch (err) {
+      setError((err as Error).message ?? 'Error eliminando marca')
+    }
+  }
+
+  const handleCreate = async () => {
+    if (!newName.trim()) { setCreateError('El nombre es obligatorio.'); return }
+    setCreating(true)
+    setCreateError(null)
+    try {
+      await createDolibarrBrand(newName.trim())
+      setNewName('')
+      setShowCreate(false)
+      load()
+    } catch (err) {
+      const msg = (err as Error).message ?? 'Error creando marca'
+      if (msg.includes("'Marcas'") || msg.includes('no existe')) {
+        setParentMissing(true)
+        setShowCreate(false)
+      } else {
+        setCreateError(msg)
+      }
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Aviso categoría padre faltante */}
+      {parentMissing && (
+        <div className="bg-amber-50 border border-amber-300 rounded-lg p-4 text-sm text-amber-800">
+          <p className="font-semibold mb-1">Categoría "Marcas" no existe en Dolibarr</p>
+          <p className="text-xs text-amber-700">
+            Para gestionar marcas, crea primero una categoría de tipo <strong>Producto</strong> llamada
+            exactamente <strong>"Marcas"</strong> desde la pestaña <strong>Categorías</strong>.
+            Las marcas se almacenan como subcategorías bajo ella.
+          </p>
+        </div>
+      )}
+
+      {/* Aviso informativo siempre visible */}
+      {!parentMissing && (
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 text-xs text-blue-700">
+          Las marcas son subcategorías bajo la categoría <strong>"Marcas"</strong> (tipo Producto).
+          Si esa categoría no existe, créala primero en la pestaña <strong>Categorías</strong>.
+        </div>
+      )}
+
+      {/* Barra superior */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-700">Marcas ({brands.length})</h3>
+        <button
+          onClick={() => { setShowCreate(true); setCreateError(null) }}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+        >
+          + Nueva marca
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border-l-4 border-red-400 p-3 rounded text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {/* Lista de marcas */}
+      <div className="border border-gray-200 rounded-lg overflow-hidden">
+        {loading ? (
+          <div className="px-6 py-10 text-center text-gray-500 text-sm">Cargando marcas...</div>
+        ) : brands.length === 0 ? (
+          <div className="px-6 py-10 text-center text-gray-500 text-sm">
+            No hay marcas. Crea la primera arriba.
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {brands.map((brand) => (
+              <div
+                key={brand.id}
+                className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 group"
+              >
+                <div className="w-2 h-2 rounded-full bg-blue-400 flex-shrink-0" />
+                <span className="flex-1 text-sm font-medium text-gray-900">{brand.label}</span>
+                <span className="text-xs text-gray-400 font-mono flex-shrink-0">#{brand.id}</span>
+                <button
+                  onClick={() => handleDelete(brand)}
+                  className="px-2 py-1 text-xs text-red-600 hover:bg-red-50 rounded opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+                >
+                  Eliminar
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Modal crear marca */}
+      {showCreate && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg shadow-lg w-full max-w-sm">
+            <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-gray-900">Nueva marca</h3>
+              <button onClick={() => setShowCreate(false)} className="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
+            </div>
+            <div className="px-6 py-4 space-y-3">
+              <input
+                type="text"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="Ej: Nike"
+                className={INPUT_CLS}
+                autoFocus
+                onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+              />
+              {createError && <p className="text-xs text-red-600">{createError}</p>}
+            </div>
+            <div className="px-6 py-4 border-t border-gray-200 flex gap-3">
+              <button
+                onClick={() => setShowCreate(false)}
+                className="flex-1 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handleCreate}
+                disabled={creating}
+                className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
+              >
+                {creating ? 'Creando...' : 'Crear'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/dolibarr/DolibarrPanel.tsx
+++ b/frontend/src/components/dolibarr/DolibarrPanel.tsx
@@ -14,9 +14,10 @@ import DolibarrInvoices from './DolibarrInvoices'
 import DolibarrStocks from './DolibarrStocks'
 import DolibarrConfig from './DolibarrConfig'
 import DolibarrExtraFields from './DolibarrExtraFields'
+import DolibarrBrands from './DolibarrBrands'
 import DolibarrCategories from './DolibarrCategories'
 
-type DolibarrTab = 'productos' | 'categorias' | 'terceros' | 'pedidos' | 'facturas' | 'stock' | 'campos-extra' | 'config'
+type DolibarrTab = 'productos' | 'categorias' | 'marcas' | 'terceros' | 'pedidos' | 'facturas' | 'stock' | 'campos-extra' | 'config'
 
 interface Props {
   className?: string
@@ -128,6 +129,7 @@ export default function DolibarrPanel({ className = '' }: Props) {
             [
               { id: 'productos', label: 'Productos' },
               { id: 'categorias', label: 'Categorías' },
+              { id: 'marcas', label: 'Marcas' },
               { id: 'terceros', label: 'Terceros' },
               { id: 'pedidos', label: 'Pedidos' },
               { id: 'facturas', label: 'Facturas' },
@@ -157,6 +159,7 @@ export default function DolibarrPanel({ className = '' }: Props) {
         <div className="p-6">
           {tab === 'productos' && <DolibarrProducts />}
           {tab === 'categorias' && <DolibarrCategories />}
+          {tab === 'marcas' && <DolibarrBrands />}
           {tab === 'terceros' && <DolibarrThirdparties />}
           {tab === 'pedidos' && <DolibarrOrders />}
           {tab === 'facturas' && <DolibarrInvoices />}

--- a/frontend/src/components/dolibarr/DolibarrProducts.tsx
+++ b/frontend/src/components/dolibarr/DolibarrProducts.tsx
@@ -19,6 +19,7 @@ import {
   getDolibarrImportStatus,
   deleteDolibarrProducts,
   listDolibarrCategories,
+  listDolibarrBrands,
 } from '@/api/client'
 import {
   type DolibarrProduct,
@@ -749,18 +750,22 @@ function CreateProductModal({ onClose, onSuccess }: CreateProductModalProps): Re
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [categories, setCategories] = useState<DolibarrCategory[]>([])
+  const [brands, setBrands] = useState<DolibarrCategory[]>([])
   const [selectedCategory, setSelectedCategory] = useState('')
   const [selectedSubcategory, setSelectedSubcategory] = useState('')
+  const [selectedBrand, setSelectedBrand] = useState('')
 
   useEffect(() => {
     Promise.all([
       getDolibarrProductFields(),
       listDolibarrCategories('product', 200, 0).catch(() => ({ items: [] as DolibarrCategory[], total: 0, limit: 200, offset: 0, has_more: false })),
+      listDolibarrBrands(200, 0).catch(() => ({ items: [] as DolibarrCategory[], total: 0, limit: 200, offset: 0, has_more: false })),
     ])
-      .then(([f, cats]) => {
+      .then(([f, cats, brnds]) => {
         setFields(f)
         setValues(initEmpty(f))
         setCategories(cats.items)
+        setBrands(brnds.items)
       })
       .catch((err) => setError((err as Error).message ?? 'Error cargando campos'))
       .finally(() => setFieldsLoading(false))
@@ -786,6 +791,9 @@ function CreateProductModal({ onClose, onSuccess }: CreateProductModalProps): Re
       setSubmitting(true)
       setError(null)
       const payload = buildPayload(values, fields) as Record<string, unknown>
+      if (selectedBrand) {
+        payload.brand_name = selectedBrand
+      }
       if (selectedSubcategory) {
         payload.category_name = selectedSubcategory
       } else if (selectedCategory) {
@@ -820,6 +828,21 @@ function CreateProductModal({ onClose, onSuccess }: CreateProductModalProps): Re
           ) : (
             <>
               <DynamicProductForm fields={fields} values={values} onChange={handleChange} />
+              {brands.length > 0 && (
+                <div className="border border-blue-200 bg-blue-50 rounded-lg p-4 space-y-2">
+                  <p className="text-xs font-semibold text-blue-800 uppercase tracking-wide">Marca (opcional)</p>
+                  <select
+                    value={selectedBrand}
+                    onChange={(e) => setSelectedBrand(e.target.value)}
+                    className="w-full px-3 py-2 border border-blue-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-400 focus:border-transparent bg-white"
+                  >
+                    <option value="">— Sin marca —</option>
+                    {brands.map((b) => (
+                      <option key={b.id} value={b.label}>{b.label}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
               <div className="border border-amber-200 bg-amber-50 rounded-lg p-4 space-y-3">
                 <p className="text-xs font-semibold text-amber-800 uppercase tracking-wide">Categoría (opcional)</p>
                 <p className="text-xs text-amber-700">
@@ -890,18 +913,22 @@ function EditProductModal({ product, onClose, onSuccess }: EditProductModalProps
   const [error, setError] = useState<string | null>(null)
   const [wpSync, setWpSync] = useState<{ synced: boolean; reason?: string; wc_id?: number } | null>(null)
   const [categories, setCategories] = useState<DolibarrCategory[]>([])
+  const [brands, setBrands] = useState<DolibarrCategory[]>([])
   const [selectedCategory, setSelectedCategory] = useState('')
   const [selectedSubcategory, setSelectedSubcategory] = useState('')
+  const [selectedBrand, setSelectedBrand] = useState('')
 
   useEffect(() => {
     Promise.all([
       getDolibarrProductFields(),
       listDolibarrCategories('product', 200, 0).catch(() => ({ items: [] as DolibarrCategory[], total: 0, limit: 200, offset: 0, has_more: false })),
+      listDolibarrBrands(200, 0).catch(() => ({ items: [] as DolibarrCategory[], total: 0, limit: 200, offset: 0, has_more: false })),
     ])
-      .then(([f, cats]) => {
+      .then(([f, cats, brnds]) => {
         setFields(f)
         setValues(initFromProduct(product, f))
         setCategories(cats.items)
+        setBrands(brnds.items)
       })
       .catch((err) => setError((err as Error).message ?? 'Error cargando campos'))
       .finally(() => setFieldsLoading(false))
@@ -928,6 +955,9 @@ function EditProductModal({ product, onClose, onSuccess }: EditProductModalProps
       setError(null)
       setWpSync(null)
       const payload = buildPayload(values, fields) as Record<string, unknown>
+      if (selectedBrand) {
+        payload.brand_name = selectedBrand
+      }
       if (selectedSubcategory) {
         payload.category_name = selectedSubcategory
       } else if (selectedCategory) {
@@ -965,6 +995,21 @@ function EditProductModal({ product, onClose, onSuccess }: EditProductModalProps
           ) : (
             <>
               <DynamicProductForm fields={fields} values={values} onChange={handleChange} />
+              {brands.length > 0 && (
+                <div className="border border-blue-200 bg-blue-50 rounded-lg p-4 space-y-2">
+                  <p className="text-xs font-semibold text-blue-800 uppercase tracking-wide">Marca (opcional)</p>
+                  <select
+                    value={selectedBrand}
+                    onChange={(e) => setSelectedBrand(e.target.value)}
+                    className="w-full px-3 py-2 border border-blue-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-400 focus:border-transparent bg-white"
+                  >
+                    <option value="">— Sin cambiar —</option>
+                    {brands.map((b) => (
+                      <option key={b.id} value={b.label}>{b.label}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
               <div className="border border-amber-200 bg-amber-50 rounded-lg p-4 space-y-3">
                 <p className="text-xs font-semibold text-amber-800 uppercase tracking-wide">Asignar a categoría (opcional)</p>
                 <p className="text-xs text-amber-700">
@@ -1052,6 +1097,7 @@ function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps): React.Reac
   const [overwrite, setOverwrite] = useState(false)
   const [categoryColumn, setCategoryColumn] = useState('')
   const [subcategoryColumn, setSubcategoryColumn] = useState('')
+  const [brandColumn, setBrandColumn] = useState('')
   const [result, setResult] = useState<DolibarrImportTask['results'] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -1111,7 +1157,7 @@ function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps): React.Reac
     setStep('importing')
 
     try {
-      const task = await importDolibarrCsv(file, activeMapping, overwrite, categoryColumn || undefined, subcategoryColumn || undefined)
+      const task = await importDolibarrCsv(file, activeMapping, overwrite, categoryColumn || undefined, subcategoryColumn || undefined, brandColumn || undefined)
 
       pollRef.current = setInterval(async () => {
         try {
@@ -1290,6 +1336,28 @@ function CsvImportModal({ onClose, onSuccess }: CsvImportModalProps): React.Reac
                       </select>
                     </div>
                   ))}
+                </div>
+              </div>
+
+              {/* Brand column selector */}
+              <div className="border border-blue-200 bg-blue-50 rounded-lg p-4 space-y-3">
+                <p className="text-xs font-semibold text-blue-800 uppercase tracking-wide">Marca (opcional)</p>
+                <p className="text-xs text-blue-700">
+                  Mapea una columna del CSV a la marca del producto. Cada valor se creará automáticamente como subcategoría bajo <strong>"Marcas"</strong> si no existe.
+                  La categoría padre <strong>"Marcas"</strong> debe existir previamente en Dolibarr.
+                </p>
+                <div className="flex items-center gap-3">
+                  <span className="text-sm text-blue-800 shrink-0 w-36">Columna marca:</span>
+                  <select
+                    value={brandColumn}
+                    onChange={(e) => setBrandColumn(e.target.value)}
+                    className="flex-1 px-2 py-1.5 border border-blue-300 rounded text-sm focus:ring-2 focus:ring-blue-400 focus:border-transparent bg-white"
+                  >
+                    <option value="">— No asignar marca —</option>
+                    {preview?.headers.map((h) => (
+                      <option key={h} value={h}>{h}</option>
+                    ))}
+                  </select>
                 </div>
               </div>
 

--- a/services/integrations/dolibarr/categories.py
+++ b/services/integrations/dolibarr/categories.py
@@ -461,6 +461,54 @@ class DolibarrCategoryService:
         )
         return created
 
+    async def list_brands(
+        self,
+        brands_parent: str = "Marcas",
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict]:
+        """
+        Lista las marcas (subcategorías bajo la categoría padre ``brands_parent``).
+
+        Args:
+            brands_parent: nombre exacto de la categoría padre de marcas.
+            limit:         máximo de resultados.
+            offset:        desplazamiento para paginación.
+
+        Returns:
+            Lista de dicts de subcategorías (marcas) bajo ``brands_parent``.
+            Lista vacía si el padre no existe.
+        """
+        parent = await self.find_category_by_name(brands_parent, type="product")
+        if not parent:
+            return []
+        parent_id = int(parent["id"])
+        all_cats = await self.list_categories(type="product", limit=500, offset=0)
+        return [
+            c for c in all_cats
+            if int(c.get("fk_parent") or 0) == parent_id
+        ][offset: offset + limit]
+
+    async def find_or_create_brand(
+        self,
+        brand_name: str,
+        brands_parent: str = "Marcas",
+    ) -> dict:
+        """
+        Busca una marca bajo ``brands_parent``, o la crea si no existe.
+
+        Args:
+            brand_name:    nombre exacto de la marca (subcategoría).
+            brands_parent: nombre exacto de la categoría padre de marcas.
+
+        Returns:
+            Dict de la subcategoría (marca) resuelta o creada.
+
+        Raises:
+            IntegrationError: si la categoría padre no existe en Dolibarr.
+        """
+        return await self.find_or_create_subcategory(brands_parent, brand_name, type="product")
+
     async def list_products_in_category(
         self,
         category_id: int,

--- a/services/integrations/dolibarr/products.py
+++ b/services/integrations/dolibarr/products.py
@@ -610,6 +610,8 @@ class DolibarrProductService:
         category_name_to_id: dict[str, int] | None = None,
         subcategory_col: str | None = None,
         subcateg_pair_to_id: dict[str, int] | None = None,
+        brand_col: str | None = None,
+        brand_name_to_id: dict[str, int] | None = None,
         progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[dict[str, Any]]:
         """
@@ -643,6 +645,8 @@ class DolibarrProductService:
             category_name_to_id:  mapa nombre_categoría → ID ya validado.
             subcategory_col:      nombre de la columna CSV con la subcategoría (opcional).
             subcateg_pair_to_id:  mapa "padre||hijo" → ID subcategoría ya resuelto.
+            brand_col:            nombre de la columna CSV con la marca (opcional).
+            brand_name_to_id:     mapa nombre_marca → ID Dolibarr de la marca ya resuelta.
             progress_callback:    función opcional ``(procesados, total) → None``.
 
         Returns:
@@ -726,7 +730,24 @@ class DolibarrProductService:
 
                 result["dolibarr_id"] = dolibarr_id
 
-                # Asignar subcategoría si se proporcionó columna de subcategoría
+                # Asignar marca (independiente de categoría)
+                if brand_col and category_svc and brand_name_to_id:
+                    brand_name = (row.get(brand_col) or "").strip()
+                    brand_cat_id = brand_name_to_id.get(brand_name)
+                    if brand_cat_id:
+                        try:
+                            await category_svc.assign_product(brand_cat_id, dolibarr_id)
+                            logger.info(
+                                "Marca asignada via CSV import",
+                                extra={"ref": ref, "brand": brand_name, "dolibarr_id": dolibarr_id},
+                            )
+                        except Exception as cat_exc:
+                            logger.warning(
+                                "Error asignando marca en CSV import",
+                                exc_info=cat_exc,
+                                extra={"ref": ref, "brand": brand_name},
+                            )
+                # Asignar subcategoría o categoría (independiente de marca)
                 if subcategory_col and category_col and category_svc and subcateg_pair_to_id:
                     parent_name = (row.get(category_col) or "").strip()
                     subcat_name = (row.get(subcategory_col) or "").strip()
@@ -747,7 +768,6 @@ class DolibarrProductService:
                                 extra={"ref": ref, "subcategory": subcat_name},
                             )
                 elif category_col and category_svc and category_name_to_id:
-                    # Asignar categoría simple (sin subcategoría)
                     cat_name = (row.get(category_col) or "").strip()
                     cat_id = category_name_to_id.get(cat_name)
                     if cat_id:

--- a/workers/tasks.py
+++ b/workers/tasks.py
@@ -575,6 +575,8 @@ def importar_productos_dolibarr(
     dolibarr_api_key: str,
     subcategory_column: str = "",
     subcateg_pair_to_id: dict | None = None,
+    brand_column: str = "",
+    brand_name_to_id: dict | None = None,
 ) -> dict:
     """
     Tarea Celery que importa productos en masa a Dolibarr desde un CSV.
@@ -595,6 +597,8 @@ def importar_productos_dolibarr(
         dolibarr_api_key:     clave API Dolibarr.
         subcategory_column:   nombre de la columna CSV con la subcategoría (opcional).
         subcateg_pair_to_id:  mapa "padre||hijo" → ID Dolibarr de la subcategoría.
+        brand_column:         nombre de la columna CSV con la marca (opcional).
+        brand_name_to_id:     mapa nombre_marca → ID Dolibarr de la marca ya resuelta.
 
     Returns:
         Dict con resumen de la importación o ``{"error": str}`` si falla.
@@ -637,7 +641,7 @@ def importar_productos_dolibarr(
 
         client = DolibarrClient(settings, override_url=dolibarr_url, override_api_key=dolibarr_api_key)
         svc = DolibarrProductService(client)
-        needs_cat_svc = bool(category_column or subcategory_column)
+        needs_cat_svc = bool(category_column or subcategory_column or brand_column)
         cat_svc = DolibarrCategoryService(client) if needs_cat_svc else None
 
         content = base64.b64decode(csv_b64.encode())
@@ -651,6 +655,8 @@ def importar_productos_dolibarr(
             category_name_to_id=category_name_to_id or None,
             subcategory_col=subcategory_column or None,
             subcateg_pair_to_id=subcateg_pair_to_id or None,
+            brand_col=brand_column or None,
+            brand_name_to_id=brand_name_to_id or None,
             progress_callback=_progress,
         )
 


### PR DESCRIPTION
## Summary

- Adds `list_brands` / `find_or_create_brand` to `DolibarrCategoryService` (brands are subcategories under a parent \"Marcas\" category in `product` type)
- Wires `brand_col` / `brand_name_to_id` into `DolibarrProductService.bulk_import_products` and the `importar_productos_dolibarr` Celery task
- New `brands_router` (`GET /dolibarr/brands`, `POST /dolibarr/brands`); `brand_name` field in single product create and update endpoints
- New `DolibarrBrands.tsx` panel with brand list + create; new **Marcas** tab in `DolibarrPanel`
- Brand selector in `CreateProductModal` (same UX as categories); `brand_column` field in CSV bulk import

## Test plan

- [ ] Create parent category \"Marcas\" in Dolibarr, then create brands via the new panel
- [ ] Create a product with a brand via the modal — verify category assignment in Dolibarr
- [ ] CSV import with `brand_column` mapped — verify brands resolved and assigned
- [ ] CSV import with missing \"Marcas\" parent — verify 422 error with clear message