### PR TITLE
feat(odoo): eCommerce categories tree, brand always-visible in modal, field ordering by priority

### DIFF
--- a/api/v1/endpoints/odoo.py
+++ b/api/v1/endpoints/odoo.py
@@ -109,6 +109,8 @@ def _detect_csv_delimiter(text: str) -> str:
 router_main = APIRouter(prefix="/odoo", tags=["odoo"])
 router_products = APIRouter(prefix="/odoo/products", tags=["odoo-products"])
 router_categories = APIRouter(prefix="/odoo/categories", tags=["odoo-categories"])
+router_ecommerce_categories = APIRouter(prefix="/odoo/ecommerce/categories", tags=["odoo-ecommerce"])
+router_brands = APIRouter(prefix="/odoo/brands", tags=["odoo-brands"])
 router_partners = APIRouter(prefix="/odoo/partners", tags=["odoo-partners"])
 router_purchases = APIRouter(prefix="/odoo/purchases", tags=["odoo-purchases"])
 router_sales = APIRouter(prefix="/odoo/sales", tags=["odoo-sales"])
@@ -421,11 +423,13 @@ async def csv_import_products(
 
     client = await _build_client()
 
-    # ── Validación previa de categorías y subcategorías ─────────────────────
+    # ── Validación previa de categorías, subcategorías y marcas ─────────────
     categ_csv_col = next((col for col, field in col_mapping.items() if field == "categ_id"), None)
     subcateg_csv_col = next((col for col, field in col_mapping.items() if field == "subcateg_id"), None)
+    brand_csv_col = next((col for col, field in col_mapping.items() if field == "brand_id"), None)
     categ_name_to_id: dict[str, int] = {}
     subcateg_pair_to_id: dict[str, int] = {}  # clave: "padre||hijo"
+    brand_name_to_id: dict[str, int] = {}
 
     cat_svc = OooCategoryService(client)
 
@@ -478,6 +482,84 @@ async def csv_import_products(
                     ),
                 )
 
+    if brand_csv_col:
+        # Resolver marcas bajo "Marcas" en product.public.category → IDs para public_categ_ids
+        unique_brands: set[str] = {
+            row.get(brand_csv_col, "").strip()
+            for row in rows
+            if row.get(brand_csv_col, "").strip()
+        }
+        for brand_name in unique_brands:
+            try:
+                brand_cat = await cat_svc.find_or_create_brand_public(brand_name, brands_parent=_BRANDS_PARENT)
+                brand_name_to_id[brand_name] = int(brand_cat["id"])
+            except IntegrationError as exc:
+                if "no existe" in str(exc):
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail=(
+                            f"La categoría '{_BRANDS_PARENT}' no existe en las categorías públicas de Odoo. "
+                            "Créala desde Odoo en eCommerce → Categorías de producto antes de importar marcas."
+                        ),
+                    )
+                logger.warning(
+                    "Error resolviendo marca en pre-importación Odoo",
+                    exc_info=exc,
+                    extra={"brand": brand_name},
+                )
+
+    # ── Validación previa de categorías eCommerce (public_categ_id / public_subcateg_id) ─
+    pub_categ_csv_col = next((col for col, field in col_mapping.items() if field == "public_categ_id"), None)
+    pub_subcateg_csv_col = next((col for col, field in col_mapping.items() if field == "public_subcateg_id"), None)
+    public_categ_name_to_id: dict[str, int] = {}
+    public_subcateg_pair_to_id: dict[str, int] = {}
+
+    if pub_subcateg_csv_col and pub_categ_csv_col:
+        unique_pub_pairs: set[tuple[str, str]] = {
+            (row.get(pub_categ_csv_col, "").strip(), row.get(pub_subcateg_csv_col, "").strip())
+            for row in rows
+            if row.get(pub_categ_csv_col, "").strip() and row.get(pub_subcateg_csv_col, "").strip()
+        }
+        missing_pub_parents: list[str] = []
+        for pub_parent_name, pub_sub_name in unique_pub_pairs:
+            try:
+                pub_sub = await cat_svc.find_or_create_public_subcategory(pub_parent_name, pub_sub_name)
+                public_subcateg_pair_to_id[f"{pub_parent_name}||{pub_sub_name}"] = int(pub_sub["id"])
+            except Exception as exc:
+                msg = str(exc)
+                if pub_parent_name not in missing_pub_parents and "no existe" in msg:
+                    missing_pub_parents.append(pub_parent_name)
+        if missing_pub_parents:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"Categorías eCommerce padre no encontradas en Odoo: {missing_pub_parents}. "
+                    "Créalas primero en la pestaña Categorías web."
+                ),
+            )
+    elif pub_categ_csv_col:
+        unique_pub_cats: set[str] = {
+            row[pub_categ_csv_col].strip()
+            for row in rows
+            if row.get(pub_categ_csv_col, "").strip()
+        }
+        if unique_pub_cats:
+            missing_pub_cats: list[str] = []
+            for pub_cat_name in unique_pub_cats:
+                found = await cat_svc._find_public_category_by_name(pub_cat_name)  # noqa: SLF001
+                if found:
+                    public_categ_name_to_id[pub_cat_name] = int(found["id"])
+                else:
+                    missing_pub_cats.append(pub_cat_name)
+            if missing_pub_cats:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        f"Categorías eCommerce no encontradas en Odoo: {missing_pub_cats}. "
+                        "Créalas primero en la pestaña Categorías web."
+                    ),
+                )
+
     svc = OdooProductService(client)
     try:
         result = await svc.bulk_upsert_products(
@@ -486,6 +568,9 @@ async def csv_import_products(
             overwrite=overwrite,
             categ_name_to_id=categ_name_to_id or None,
             subcateg_pair_to_id=subcateg_pair_to_id or None,
+            brand_name_to_id=brand_name_to_id or None,
+            public_categ_name_to_id=public_categ_name_to_id or None,
+            public_subcateg_pair_to_id=public_subcateg_pair_to_id or None,
         )
         msg = (
             f"{result['created']} creados, {result['updated']} actualizados, "
@@ -667,6 +752,193 @@ async def delete_category(category_id: int) -> dict[str, Any]:
     try:
         await svc.delete_category(category_id)
         return _ok(None, "Categoría eliminada.")
+    except IntegrationError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+
+# ── Categorías eCommerce (product.public.category) ──────────────────────────
+
+
+@router_ecommerce_categories.get("", response_model=dict)
+async def list_ecommerce_categories(
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> dict[str, Any]:
+    """Lista categorías eCommerce Odoo (product.public.category) con paginación."""
+    client = await _build_client()
+    svc = OooCategoryService(client)
+    try:
+        items = await svc.list_public_categories(limit=limit, offset=offset)
+        total = await svc.count_public_categories()
+        return _ok(_paginated(items, total, limit, offset).model_dump())
+    except IntegrationError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+
+@router_ecommerce_categories.get("/tree", response_model=dict)
+async def get_ecommerce_category_tree() -> dict[str, Any]:
+    """Devuelve árbol jerárquico completo de categorías eCommerce Odoo."""
+    client = await _build_client()
+    svc = OooCategoryService(client)
+    try:
+        tree = await svc.get_public_category_tree()
+        return _ok(tree)
+    except IntegrationError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+
+@router_ecommerce_categories.get("/{category_id}", response_model=dict)
+async def get_ecommerce_category(category_id: int) -> dict[str, Any]:
+    """Obtiene una categoría eCommerce Odoo por ID."""
+    client = await _build_client()
+    try:
+        items = await client.list(
+            "product.public.category",
+            limit=1,
+            filters={
+                "domain": [("id", "=", category_id)],
+                "fields": ["id", "name", "parent_id", "child_id"],
+            },
+        )
+        if not items:
+            raise IntegrationError(f"Categoría eCommerce {category_id} no encontrada")
+        return _ok(items[0])
+    except IntegrationError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+
+@router_ecommerce_categories.post("", response_model=dict, status_code=status.HTTP_201_CREATED)
+async def create_ecommerce_category(body: dict) -> dict[str, Any]:
+    """Crea una categoría eCommerce en Odoo (product.public.category)."""
+    name = (body.get("name") or "").strip()
+    if not name:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="El campo 'name' es obligatorio.",
+        )
+    client = await _build_client()
+    svc = OooCategoryService(client)
+    try:
+        return _ok(
+            await svc.create_public_category(name, body.get("parent_id")),
+            "Categoría eCommerce creada.",
+        )
+    except IntegrationError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+
+@router_ecommerce_categories.put("/{category_id}", response_model=dict)
+async def update_ecommerce_category(category_id: int, body: dict) -> dict[str, Any]:
+    """Actualiza una categoría eCommerce Odoo."""
+    client = await _build_client()
+    svc = OooCategoryService(client)
+    try:
+        return _ok(await svc.update_public_category(category_id, body), "Categoría eCommerce actualizada.")
+    except IntegrationError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+
+@router_ecommerce_categories.delete("/{category_id}", response_model=dict)
+async def delete_ecommerce_category(category_id: int) -> dict[str, Any]:
+    """Elimina una categoría eCommerce Odoo."""
+    client = await _build_client()
+    svc = OooCategoryService(client)
+    try:
+        await svc.delete_public_category(category_id)
+        return _ok(None, "Categoría eCommerce eliminada.")
+    except IntegrationError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+
+# ── Marcas ────────────────────────────────────────────────────────────────────
+
+_BRANDS_PARENT = "Marcas"
+
+
+@router_brands.get("", response_model=dict)
+async def list_odoo_brands(
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> dict[str, Any]:
+    """
+    Lista las marcas (subcategorías bajo 'Marcas' en product.public.category) en Odoo.
+
+    La categoría padre 'Marcas' debe existir en product.public.category previamente.
+
+    Args:
+        limit:  máximo de resultados.
+        offset: desplazamiento para paginación.
+
+    Returns:
+        PaginatedResponse con las marcas disponibles.
+    """
+    client = await _build_client()
+    svc = OooCategoryService(client)
+    try:
+        items = await svc.list_brands_public(brands_parent=_BRANDS_PARENT, limit=limit, offset=offset)
+        return _ok(_paginated(items, len(items), limit, offset).model_dump())
+    except IntegrationError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+
+@router_brands.post("", response_model=dict, status_code=status.HTTP_201_CREATED)
+async def create_odoo_brand(body: dict) -> dict[str, Any]:
+    """
+    Crea una nueva marca en product.public.category bajo 'Marcas' en Odoo.
+
+    La categoría padre 'Marcas' debe existir previamente en product.public.category.
+    Si la marca ya existe, la devuelve sin crear duplicados.
+
+    Args:
+        body: dict con campo ``name`` (nombre de la marca).
+
+    Returns:
+        Dict con los datos de la marca creada o existente.
+
+    Raises:
+        HTTPException 422: si la categoría padre 'Marcas' no existe.
+    """
+    name = (body.get("name") or "").strip()
+    if not name:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="El campo 'name' es obligatorio.",
+        )
+    client = await _build_client()
+    svc = OooCategoryService(client)
+    try:
+        brand = await svc.find_or_create_brand_public(name, brands_parent=_BRANDS_PARENT)
+        return _ok(brand, "Marca creada.")
+    except IntegrationError as exc:
+        if "no existe" in str(exc):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"La categoría '{_BRANDS_PARENT}' no existe en las categorías públicas de Odoo. "
+                    "Créala desde Odoo en eCommerce → Categorías de producto y nómbrala exactamente 'Marcas'."
+                ),
+            )
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+
+@router_brands.delete("/{brand_id}", response_model=dict)
+async def delete_odoo_brand(brand_id: int) -> dict[str, Any]:
+    """
+    Elimina una marca de product.public.category en Odoo.
+
+    Args:
+        brand_id: ID de la marca en product.public.category.
+
+    Returns:
+        Confirmación de eliminación.
+    """
+    client = await _build_client()
+    svc = OooCategoryService(client)
+    try:
+        await svc.delete_brand_public(brand_id)
+        return _ok(None, "Marca eliminada.")
     except IntegrationError as exc:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
 

--- a/api/v1/router.py
+++ b/api/v1/router.py
@@ -27,15 +27,17 @@ from api.v1.endpoints.files import router as files_router
 from api.v1.endpoints.history import router as history_router
 from api.v1.endpoints.jobs import router as jobs_router
 from api.v1.endpoints.odoo import (
-    router_main as odoo_router_main,
-    router_products as odoo_router_products,
+    router_brands as odoo_router_brands,
     router_categories as odoo_router_categories,
+    router_ecommerce_categories as odoo_router_ecommerce_categories,
+    router_inventory as odoo_router_inventory,
+    router_invoices as odoo_router_invoices,
+    router_main as odoo_router_main,
     router_partners as odoo_router_partners,
+    router_products as odoo_router_products,
+    router_properties as odoo_router_properties,
     router_purchases as odoo_router_purchases,
     router_sales as odoo_router_sales,
-    router_invoices as odoo_router_invoices,
-    router_inventory as odoo_router_inventory,
-    router_properties as odoo_router_properties,
 )
 from api.v1.endpoints.wordpress import (
     router_main as wordpress_router_main,
@@ -64,6 +66,8 @@ router.include_router(extrafields_router)
 router.include_router(odoo_router_main)
 router.include_router(odoo_router_products)
 router.include_router(odoo_router_categories)
+router.include_router(odoo_router_ecommerce_categories)
+router.include_router(odoo_router_brands)
 router.include_router(odoo_router_partners)
 router.include_router(odoo_router_purchases)
 router.include_router(odoo_router_sales)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1327,6 +1327,115 @@ export async function deleteOdooCategory(id: number): Promise<void> {
   await apiClient.delete(`/odoo/categories/${id}`)
 }
 
+// ─── Categorías eCommerce Odoo (product.public.category) ─────────────────────
+
+/**
+ * Lista categorías eCommerce Odoo (product.public.category) con paginación.
+ *
+ * @author BenjaminDTS
+ */
+export async function listOdooPublicCategories(
+  limit = 100,
+  offset = 0,
+): Promise<PaginatedResponse<OdooCategory>> {
+  const response = await apiClient.get<ApiResponse<PaginatedResponse<OdooCategory>>>(
+    '/odoo/ecommerce/categories',
+    { params: { limit, offset } },
+  )
+  return response.data.data
+}
+
+/**
+ * Devuelve árbol jerárquico completo de categorías eCommerce Odoo.
+ *
+ * @author BenjaminDTS
+ */
+export async function getOdooPublicCategoryTree(): Promise<OooCategoryTree[]> {
+  const response = await apiClient.get<ApiResponse<OooCategoryTree[]>>('/odoo/ecommerce/categories/tree')
+  return response.data.data
+}
+
+/**
+ * Crea una categoría eCommerce en Odoo (product.public.category).
+ *
+ * @author BenjaminDTS
+ * @param name     - Nombre de la categoría.
+ * @param parentId - ID del padre (opcional).
+ */
+export async function createOdooPublicCategory(name: string, parentId?: number): Promise<OdooCategory> {
+  const body: Record<string, unknown> = { name }
+  if (parentId !== undefined) body.parent_id = parentId
+  const response = await apiClient.post<ApiResponse<OdooCategory>>('/odoo/ecommerce/categories', body)
+  return response.data.data
+}
+
+/**
+ * Actualiza una categoría eCommerce Odoo.
+ *
+ * @author BenjaminDTS
+ * @param id   - ID de la categoría.
+ * @param data - Campos a actualizar.
+ */
+export async function updateOdooPublicCategory(
+  id: number,
+  data: Record<string, unknown>,
+): Promise<OdooCategory> {
+  const response = await apiClient.put<ApiResponse<OdooCategory>>(`/odoo/ecommerce/categories/${id}`, data)
+  return response.data.data
+}
+
+/**
+ * Elimina una categoría eCommerce Odoo.
+ *
+ * @author BenjaminDTS
+ * @param id - ID de la categoría.
+ */
+export async function deleteOdooPublicCategory(id: number): Promise<void> {
+  await apiClient.delete(`/odoo/ecommerce/categories/${id}`)
+}
+
+// ─── Marcas Odoo ──────────────────────────────────────────────────────────────
+
+/**
+ * Lista las marcas de Odoo (subcategorías bajo "Marcas").
+ *
+ * @author BenjaminDTS
+ * @param limit  - Máximo de resultados.
+ * @param offset - Desplazamiento.
+ */
+export async function listOdooBrands(
+  limit = 100,
+  offset = 0,
+): Promise<{ items: OdooCategory[]; total: number; limit: number; offset: number; has_more: boolean }> {
+  const response = await apiClient.get<ApiResponse<{ items: OdooCategory[]; total: number; limit: number; offset: number; has_more: boolean }>>(
+    '/odoo/brands',
+    { params: { limit, offset } },
+  )
+  return response.data.data
+}
+
+/**
+ * Crea una nueva marca en Odoo bajo la categoría "Marcas".
+ * Si ya existe, devuelve la existente.
+ *
+ * @author BenjaminDTS
+ * @param name - Nombre de la marca.
+ */
+export async function createOdooBrand(name: string): Promise<OdooCategory> {
+  const response = await apiClient.post<ApiResponse<OdooCategory>>('/odoo/brands', { name })
+  return response.data.data
+}
+
+/**
+ * Elimina una marca de product.public.category en Odoo.
+ *
+ * @author BenjaminDTS
+ * @param id - ID de la marca en product.public.category.
+ */
+export async function deleteOdooBrand(id: number): Promise<void> {
+  await apiClient.delete(`/odoo/brands/${id}`)
+}
+
 /**
  * Lista partners Odoo (clientes / proveedores / todos).
  *

--- a/frontend/src/components/odoo/OdooBrands.tsx
+++ b/frontend/src/components/odoo/OdooBrands.tsx
@@ -1,0 +1,157 @@
+/**
+ * Panel de gestión de marcas en Odoo.
+ * Las marcas se almacenan como subcategorías (product.public.category) bajo la categoría
+ * padre "Marcas", que se crea automáticamente si no existe.
+ *
+ * @author BenjaminDTS
+ */
+import { useEffect, useState } from 'react'
+import { listOdooBrands, createOdooBrand, deleteOdooBrand } from '@/api/client'
+import type { OdooCategory } from '@/types/odoo'
+
+const INPUT_CLS =
+  'w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm'
+
+export default function OdooBrands() {
+  const [brands, setBrands] = useState<OdooCategory[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showCreate, setShowCreate] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
+
+  const load = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await listOdooBrands(200, 0)
+      setBrands(data.items)
+    } catch (err) {
+      setError((err as Error).message ?? 'Error cargando marcas')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { load() }, [])
+
+  const handleDelete = async (brand: OdooCategory) => {
+    if (!confirm(`¿Eliminar la marca "${brand.name}"?`)) return
+    try {
+      await deleteOdooBrand(brand.id)
+      load()
+    } catch (err) {
+      setError((err as Error).message ?? 'Error eliminando marca')
+    }
+  }
+
+  const handleCreate = async () => {
+    if (!newName.trim()) { setCreateError('El nombre es obligatorio.'); return }
+    setCreating(true)
+    setCreateError(null)
+    try {
+      await createOdooBrand(newName.trim())
+      setNewName('')
+      setShowCreate(false)
+      load()
+    } catch (err) {
+      setCreateError((err as Error).message ?? 'Error creando marca')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Barra superior */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-700">Marcas ({brands.length})</h3>
+        <button
+          onClick={() => { setShowCreate(true); setCreateError(null) }}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+        >
+          + Nueva marca
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border-l-4 border-red-400 p-3 rounded text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {/* Lista de marcas */}
+      <div className="border border-gray-200 rounded-lg overflow-hidden">
+        {loading ? (
+          <div className="px-6 py-10 text-center text-gray-500 text-sm">Cargando marcas...</div>
+        ) : brands.length === 0 ? (
+          <div className="px-6 py-10 text-center text-gray-500 text-sm">
+            No hay marcas. Crea la primera arriba.
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {brands.map((brand) => (
+              <div
+                key={brand.id}
+                className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 group"
+              >
+                <div className="w-2 h-2 rounded-full bg-blue-400 flex-shrink-0" />
+                <span className="flex-1 text-sm font-medium text-gray-900">{brand.name}</span>
+                {brand.complete_name && brand.complete_name !== brand.name && (
+                  <span className="text-xs text-gray-400 truncate max-w-[200px]">{brand.complete_name}</span>
+                )}
+                <span className="text-xs text-gray-400 font-mono flex-shrink-0">#{brand.id}</span>
+                <button
+                  onClick={() => handleDelete(brand)}
+                  className="px-2 py-1 text-xs text-red-600 hover:bg-red-50 rounded opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+                >
+                  Eliminar
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Modal crear marca */}
+      {showCreate && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg shadow-lg w-full max-w-sm">
+            <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-gray-900">Nueva marca</h3>
+              <button onClick={() => setShowCreate(false)} className="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
+            </div>
+            <div className="px-6 py-4 space-y-3">
+              <input
+                type="text"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="Ej: Nike"
+                className={INPUT_CLS}
+                autoFocus
+                onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+              />
+              {createError && <p className="text-xs text-red-600">{createError}</p>}
+            </div>
+            <div className="px-6 py-4 border-t border-gray-200 flex gap-3">
+              <button
+                onClick={() => setShowCreate(false)}
+                className="flex-1 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handleCreate}
+                disabled={creating}
+                className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
+              >
+                {creating ? 'Creando...' : 'Crear'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/odoo/OdooCsvImport.tsx
+++ b/frontend/src/components/odoo/OdooCsvImport.tsx
@@ -12,33 +12,45 @@ interface Props {
   onSuccess: () => void
 }
 
+// Ordenado por prioridad: identificación → clasificación → precios → ventas → compras → eCommerce → logística → otros
 const FIELD_LABELS: Record<string, string> = {
+  // Identificación (obligatorios)
   name: 'Nombre *',
   default_code: 'Referencia interna *',
-  active: 'Activo (1/0)',
-  priority: 'Favorito (0/1)',
   detailed_type: 'Tipo (consu/service/product)',
-  tracking: 'Seguimiento (none/lot/serial)',
-  categ_id: 'Categoría (nombre)',
-  subcateg_id: 'Subcategoría (nombre)',
+  active: 'Activo (1/0)',
+  // Clasificación
+  categ_id: 'Categoría interna (nombre)',
+  subcateg_id: 'Subcategoría interna (nombre)',
+  public_categ_id: 'Categoría eCommerce (nombre)',
+  public_subcateg_id: 'Subcategoría eCommerce (nombre)',
+  brand_id: 'Marca (bajo "Marcas")',
+  // Precios
   list_price: 'Precio de venta',
   compare_list_price: 'Precio comparativo',
   standard_price: 'Coste',
-  weight: 'Peso (kg)',
-  volume: 'Volumen (m³)',
-  sale_delay: 'Plazo cliente (días)',
-  hs_code: 'HS Code',
+  // Ventas
   sale_ok: 'Se puede vender (1/0)',
   invoice_policy: 'Política facturación (order/delivery)',
   description_sale: 'Descripción ventas',
+  // Compras
   purchase_ok: 'Se puede comprar (1/0)',
   purchase_method: 'Control compra (purchase/receive)',
   description_purchase: 'Descripción compras',
+  // eCommerce
   is_published: 'Publicado web (1/0)',
   available_in_pos: 'Disponible POS (1/0)',
   website_meta_title: 'Meta título (SEO)',
   website_meta_description: 'Meta descripción (SEO)',
   website_meta_keywords: 'Meta palabras clave',
+  // Logística
+  tracking: 'Seguimiento (none/lot/serial)',
+  weight: 'Peso (kg)',
+  volume: 'Volumen (m³)',
+  sale_delay: 'Plazo cliente (días)',
+  hs_code: 'HS Code',
+  // Otros
+  priority: 'Favorito (0/1)',
   description: 'Descripción interna',
 }
 
@@ -261,12 +273,47 @@ export default function OdooCsvImport({ onClose, onSuccess }: Props) {
               </div>
 
               {/* Aviso subcategoría cuando ambos campos están mapeados */}
-              {Object.values(mapping).includes('categ_id') && Object.values(mapping).includes('subcateg_id') && (
+              {Object.values(mapping).includes('categ_id') && Object.values(mapping).includes('subcateg_id') && !Object.values(mapping).includes('brand_id') && (
                 <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-800">
                   <p className="font-semibold mb-1">Modo Categoría + Subcategoría activo</p>
                   <p className="text-xs text-amber-700">
                     Cada subcategoría se creará automáticamente bajo su categoría padre si no existe en Odoo.
                     La categoría padre <strong>debe existir</strong> previamente. El producto quedará asignado a la subcategoría.
+                  </p>
+                </div>
+              )}
+
+              {/* Aviso: categoría eCommerce + subcategoría eCommerce */}
+              {Object.values(mapping).includes('public_categ_id') && Object.values(mapping).includes('public_subcateg_id') && (
+                <div className="bg-purple-50 border border-purple-200 rounded-lg p-4 text-sm text-purple-800">
+                  <p className="font-semibold mb-1">Categoría eCommerce + Subcategoría eCommerce activo</p>
+                  <p className="text-xs text-purple-700">
+                    Cada subcategoría se creará automáticamente bajo su categoría padre si no existe.
+                    La categoría padre <strong>debe existir</strong> en la pestaña <em>Categorías web</em>.
+                    El producto quedará asignado a la subcategoría en <code>public_categ_ids</code>.
+                  </p>
+                </div>
+              )}
+
+              {/* Aviso informativo cuando marca y categoría están mapeadas simultáneamente */}
+              {Object.values(mapping).includes('brand_id') && (Object.values(mapping).includes('categ_id') || Object.values(mapping).includes('subcateg_id')) && (
+                <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-sm text-green-800">
+                  <p className="font-semibold mb-1">Categoría + Marca — campos independientes</p>
+                  <p className="text-xs text-green-700">
+                    La <strong>Marca</strong> se asignará en <em>Categorías del sitio web</em> (<code>public_categ_ids</code>)
+                    y la <strong>Categoría interna</strong> en <code>categ_id</code>. Ambos campos son independientes.
+                    La categoría padre <strong>"Marcas"</strong> debe existir en eCommerce → Categorías de producto de Odoo.
+                  </p>
+                </div>
+              )}
+
+              {/* Aviso: marca + categoría eCommerce activos juntos */}
+              {Object.values(mapping).includes('brand_id') && (Object.values(mapping).includes('public_categ_id') || Object.values(mapping).includes('public_subcateg_id')) && (
+                <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-800">
+                  <p className="font-semibold mb-1">Marca + Categoría eCommerce — se asignan juntas</p>
+                  <p className="text-xs text-blue-700">
+                    Marca y categoría eCommerce se añadirán ambas a <code>public_categ_ids</code> del producto.
+                    Son campos compatibles y no se excluyen entre sí.
                   </p>
                 </div>
               )}

--- a/frontend/src/components/odoo/OdooEcommerceCategories.tsx
+++ b/frontend/src/components/odoo/OdooEcommerceCategories.tsx
@@ -1,0 +1,424 @@
+/**
+ * Panel de gestión de categorías de eCommerce en Odoo (product.public.category).
+ * Árbol jerárquico con soporte para crear, editar y eliminar categorías padre e hija.
+ * Estas categorías son las visibles en la tienda online de Odoo (website/eCommerce).
+ *
+ * @author BenjaminDTS
+ */
+import { useEffect, useState } from 'react'
+import {
+  getOdooPublicCategoryTree,
+  createOdooPublicCategory,
+  updateOdooPublicCategory,
+  deleteOdooPublicCategory,
+} from '@/api/client'
+import type { OooCategoryTree } from '@/types/odoo'
+
+const INPUT_CLS =
+  'w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm'
+const LABEL_CLS = 'block text-xs font-medium text-gray-700 mb-1'
+
+// ── Componente principal ───────────────────────────────────────────────────
+
+export default function OdooEcommerceCategories() {
+  const [tree, setTree] = useState<OooCategoryTree[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showCreateModal, setShowCreateModal] = useState(false)
+  const [createParentId, setCreateParentId] = useState<number | null>(null)
+  const [editTarget, setEditTarget] = useState<OooCategoryTree | null>(null)
+
+  const loadTree = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await getOdooPublicCategoryTree()
+      setTree(data)
+    } catch (err) {
+      setError((err as Error).message ?? 'Error cargando categorías eCommerce')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadTree()
+  }, [])
+
+  const handleDelete = async (node: OooCategoryTree) => {
+    const hasChildren = node.children.length > 0
+    const msg = hasChildren
+      ? `¿Eliminar "${node.name}" y todas sus subcategorías? Esta acción no se puede deshacer.`
+      : `¿Eliminar la categoría "${node.name}"?`
+    if (!confirm(msg)) return
+    try {
+      await deleteOdooPublicCategory(node.id)
+      loadTree()
+    } catch (err) {
+      setError((err as Error).message ?? 'Error eliminando categoría eCommerce')
+    }
+  }
+
+  const handleAddChild = (parentId: number) => {
+    setCreateParentId(parentId)
+    setShowCreateModal(true)
+  }
+
+  const handleAddRoot = () => {
+    setCreateParentId(null)
+    setShowCreateModal(true)
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Barra superior */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700">Categorías eCommerce</h3>
+          <p className="text-xs text-gray-400 mt-0.5">
+            Categorías visibles en la tienda online de Odoo (<code>product.public.category</code>).
+            También se usan para asignar marcas.
+          </p>
+        </div>
+        <button
+          onClick={handleAddRoot}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+        >
+          + Nueva categoría raíz
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border-l-4 border-red-400 p-4 rounded text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {/* Árbol */}
+      <div className="border border-gray-200 rounded-lg overflow-hidden">
+        {loading ? (
+          <div className="px-6 py-10 text-center text-gray-500 text-sm">
+            Cargando categorías eCommerce...
+          </div>
+        ) : tree.length === 0 ? (
+          <div className="px-6 py-10 text-center text-gray-500 text-sm">
+            No hay categorías eCommerce. Crea la primera arriba.
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {tree.map((node) => (
+              <CategoryNode
+                key={node.id}
+                node={node}
+                depth={0}
+                onAddChild={handleAddChild}
+                onEdit={setEditTarget}
+                onDelete={handleDelete}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {showCreateModal && (
+        <CreateCategoryModal
+          parentId={createParentId}
+          onClose={() => setShowCreateModal(false)}
+          onSuccess={() => {
+            setShowCreateModal(false)
+            loadTree()
+          }}
+        />
+      )}
+
+      {editTarget && (
+        <EditCategoryModal
+          category={editTarget}
+          onClose={() => setEditTarget(null)}
+          onSuccess={() => {
+            setEditTarget(null)
+            loadTree()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+// ── Nodo del árbol ─────────────────────────────────────────────────────────
+
+interface CategoryNodeProps {
+  node: OooCategoryTree
+  depth: number
+  onAddChild: (parentId: number) => void
+  onEdit: (node: OooCategoryTree) => void
+  onDelete: (node: OooCategoryTree) => void
+}
+
+function CategoryNode({ node, depth, onAddChild, onEdit, onDelete }: CategoryNodeProps) {
+  const [expanded, setExpanded] = useState(true)
+  const hasChildren = node.children.length > 0
+  const indent = depth * 24
+
+  return (
+    <>
+      <div
+        className="flex items-center gap-2 px-4 py-3 hover:bg-gray-50 group"
+        style={{ paddingLeft: `${16 + indent}px` }}
+      >
+        {/* Toggle expansion */}
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className={`w-5 h-5 flex items-center justify-center rounded text-gray-400 hover:text-gray-600 flex-shrink-0 ${
+            !hasChildren ? 'invisible' : ''
+          }`}
+        >
+          <svg
+            className={`w-3 h-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path
+              fillRule="evenodd"
+              d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+
+        {/* Icono globo (eCommerce) */}
+        <svg className="w-4 h-4 text-purple-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+          <path
+            fillRule="evenodd"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zM4.332 8.027a6.012 6.012 0 011.912-2.706C6.512 5.73 6.974 6 7.5 6A1.5 1.5 0 019 7.5V8a2 2 0 004 0 2 2 0 011.523-1.943A5.977 5.977 0 0116 10c0 .34-.028.675-.083 1H15a2 2 0 00-2 2v2.197A5.973 5.973 0 0110 16v-2a2 2 0 00-2-2 2 2 0 01-2-2 2 2 0 00-1.668-1.973z"
+            clipRule="evenodd"
+          />
+        </svg>
+
+        {/* Nombre */}
+        <div className="flex-1 min-w-0">
+          <span className="text-sm font-medium text-gray-900">{node.name}</span>
+          {node.complete_name && node.complete_name !== node.name && (
+            <span className="ml-2 text-xs text-gray-400 truncate">{node.complete_name}</span>
+          )}
+          {node.children.length > 0 && (
+            <span className="ml-2 text-xs text-gray-300">({node.children.length})</span>
+          )}
+        </div>
+
+        {/* Badge ID */}
+        <span className="text-xs text-gray-400 font-mono flex-shrink-0">#{node.id}</span>
+
+        {/* Acciones */}
+        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
+          <button
+            onClick={() => onAddChild(node.id)}
+            title="Añadir subcategoría"
+            className="px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 rounded"
+          >
+            + Sub
+          </button>
+          <button
+            onClick={() => onEdit(node)}
+            title="Editar"
+            className="px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 rounded"
+          >
+            Editar
+          </button>
+          <button
+            onClick={() => onDelete(node)}
+            title="Eliminar"
+            className="px-2 py-1 text-xs text-red-600 hover:bg-red-50 rounded"
+          >
+            Eliminar
+          </button>
+        </div>
+      </div>
+
+      {/* Hijos */}
+      {hasChildren && expanded && (
+        <>
+          {node.children.map((child) => (
+            <CategoryNode
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              onAddChild={onAddChild}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))}
+        </>
+      )}
+    </>
+  )
+}
+
+// ── Modal crear categoría ──────────────────────────────────────────────────
+
+interface CreateCategoryModalProps {
+  parentId: number | null
+  onClose: () => void
+  onSuccess: () => void
+}
+
+function CreateCategoryModal({ parentId, onClose, onSuccess }: CreateCategoryModalProps) {
+  const [name, setName] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async () => {
+    if (!name.trim()) {
+      setError('El nombre es obligatorio.')
+      return
+    }
+    try {
+      setSubmitting(true)
+      setError(null)
+      await createOdooPublicCategory(name.trim(), parentId ?? undefined)
+      onSuccess()
+    } catch (err) {
+      setError((err as Error).message ?? 'Error creando categoría eCommerce')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const title = parentId != null ? 'Nueva subcategoría eCommerce' : 'Nueva categoría eCommerce raíz'
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-md">
+        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">
+            &times;
+          </button>
+        </div>
+
+        <div className="px-6 py-4 space-y-4">
+          {parentId != null && (
+            <p className="text-xs text-gray-500">
+              Subcategoría de ID <span className="font-mono font-semibold">#{parentId}</span>
+            </p>
+          )}
+
+          <div>
+            <label className={LABEL_CLS}>
+              Nombre <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Ej: Electrónica"
+              className={INPUT_CLS}
+              autoFocus
+              onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+            />
+          </div>
+        </div>
+
+        <div className="px-6 py-4 border-t border-gray-200 space-y-3">
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              className="flex-1 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={submitting}
+              className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
+            >
+              {submitting ? 'Creando...' : 'Crear'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Modal editar categoría ─────────────────────────────────────────────────
+
+interface EditCategoryModalProps {
+  category: OooCategoryTree
+  onClose: () => void
+  onSuccess: () => void
+}
+
+function EditCategoryModal({ category, onClose, onSuccess }: EditCategoryModalProps) {
+  const [name, setName] = useState(category.name)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async () => {
+    if (!name.trim()) {
+      setError('El nombre es obligatorio.')
+      return
+    }
+    try {
+      setSubmitting(true)
+      setError(null)
+      await updateOdooPublicCategory(category.id, { name: name.trim() })
+      onSuccess()
+    } catch (err) {
+      setError((err as Error).message ?? 'Error actualizando categoría eCommerce')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-md">
+        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900">Editar categoría eCommerce</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">
+            &times;
+          </button>
+        </div>
+
+        <div className="px-6 py-4 space-y-4">
+          <p className="text-xs text-gray-500 font-mono">ID #{category.id}</p>
+
+          <div>
+            <label className={LABEL_CLS}>
+              Nombre <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className={INPUT_CLS}
+              autoFocus
+              onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+            />
+          </div>
+        </div>
+
+        <div className="px-6 py-4 border-t border-gray-200 space-y-3">
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              className="flex-1 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={submitting}
+              className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
+            >
+              {submitting ? 'Guardando...' : 'Guardar cambios'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/odoo/OdooPanel.tsx
+++ b/frontend/src/components/odoo/OdooPanel.tsx
@@ -15,9 +15,11 @@ import OdooSales from './OdooSales'
 import OdooInvoices from './OdooInvoices'
 import OdooInventory from './OdooInventory'
 import OdooCamposExtra from './OdooCamposExtra'
+import OdooBrands from './OdooBrands'
 import OdooCategories from './OdooCategories'
+import OdooEcommerceCategories from './OdooEcommerceCategories'
 
-type OdooTab = 'productos' | 'categorias' | 'partners' | 'compras' | 'ventas' | 'facturas' | 'inventario' | 'campos_extra' | 'config'
+type OdooTab = 'productos' | 'categorias' | 'categorias_web' | 'marcas' | 'partners' | 'compras' | 'ventas' | 'facturas' | 'inventario' | 'campos_extra' | 'config'
 
 interface Props {
   className?: string
@@ -129,6 +131,8 @@ export default function OdooPanel({ className = '' }: Props) {
             [
               { id: 'productos', label: 'Productos' },
               { id: 'categorias', label: 'Categorías' },
+              { id: 'categorias_web', label: 'Categorías web' },
+              { id: 'marcas', label: 'Marcas' },
               { id: 'partners', label: 'Partners' },
               { id: 'compras', label: 'Compras' },
               { id: 'ventas', label: 'Ventas' },
@@ -159,6 +163,8 @@ export default function OdooPanel({ className = '' }: Props) {
         <div className="p-6">
           {tab === 'productos' && configured && <OdooProducts />}
           {tab === 'categorias' && configured && <OdooCategories />}
+          {tab === 'categorias_web' && configured && <OdooEcommerceCategories />}
+          {tab === 'marcas' && configured && <OdooBrands />}
           {tab === 'partners' && configured && <OdooPartners />}
           {tab === 'compras' && configured && <OooPurchases />}
           {tab === 'ventas' && configured && <OdooSales />}

--- a/frontend/src/components/odoo/OdooProducts.tsx
+++ b/frontend/src/components/odoo/OdooProducts.tsx
@@ -4,7 +4,7 @@
  * @author Carlitos6712
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { listOdooProducts, deleteOdooProduct, updateOdooProduct, createOdooProduct, listOdooCategories, setOdooProductProperties, deleteOdooProducts } from '@/api/client'
+import { listOdooProducts, deleteOdooProduct, updateOdooProduct, createOdooProduct, listOdooCategories, setOdooProductProperties, deleteOdooProducts, listOdooBrands, listOdooPublicCategories } from '@/api/client'
 import type { OdooProduct, OdooCategory, OdooPropertyValue } from '@/types/odoo'
 import OdooCsvImport from './OdooCsvImport'
 import OdooProductProperties from './OdooProductProperties'
@@ -443,18 +443,12 @@ function initValues(p: OdooProduct | null): FormValues {
     return {
       name: '',
       default_code: '',
-      active: '1',
-      priority: '0',
       detailed_type: 'product',
-      tracking: 'none',
+      active: '1',
       categ_id: '',
       list_price: '0',
       compare_list_price: '',
       standard_price: '0',
-      weight: '',
-      volume: '',
-      sale_delay: '',
-      hs_code: '',
       sale_ok: '1',
       invoice_policy: 'order',
       description_sale: '',
@@ -466,24 +460,24 @@ function initValues(p: OdooProduct | null): FormValues {
       website_meta_title: '',
       website_meta_description: '',
       website_meta_keywords: '',
+      tracking: 'none',
+      weight: '',
+      volume: '',
+      sale_delay: '',
+      hs_code: '',
+      priority: '0',
       description: '',
     }
   }
   return {
     name: p.name,
     default_code: str(p.default_code),
-    active: p.active ? '1' : '0',
-    priority: str(p.priority),
     detailed_type: p.detailed_type ?? p.type ?? 'product',
-    tracking: p.tracking ?? 'none',
+    active: p.active ? '1' : '0',
     categ_id: p.categ_id ? String(p.categ_id[0]) : '',
     list_price: str(p.list_price),
     compare_list_price: str(p.compare_list_price),
     standard_price: str(p.standard_price),
-    weight: str(p.weight),
-    volume: str(p.volume),
-    sale_delay: str(p.sale_delay),
-    hs_code: str(p.hs_code),
     sale_ok: p.sale_ok ? '1' : '0',
     invoice_policy: str(p.invoice_policy) || 'order',
     description_sale: str(p.description_sale),
@@ -495,6 +489,12 @@ function initValues(p: OdooProduct | null): FormValues {
     website_meta_title: str(p.website_meta_title),
     website_meta_description: str(p.website_meta_description),
     website_meta_keywords: str(p.website_meta_keywords),
+    tracking: p.tracking ?? 'none',
+    weight: str(p.weight),
+    volume: str(p.volume),
+    sale_delay: str(p.sale_delay),
+    hs_code: str(p.hs_code),
+    priority: str(p.priority),
     description: str(p.description),
   }
 }
@@ -504,18 +504,12 @@ function buildPayload(values: FormValues): Partial<OdooProduct> {
 
   payload.name = values.name.trim()
   payload.default_code = values.default_code.trim() || false
-  payload.active = values.active === '1'
-  payload.priority = values.priority || '0'
   payload.detailed_type = values.detailed_type
-  payload.tracking = values.tracking
+  payload.active = values.active === '1'
   if (values.categ_id) payload.categ_id = parseInt(values.categ_id, 10)
   payload.list_price = parseFloat(values.list_price) || 0
   if (values.compare_list_price) payload.compare_list_price = parseFloat(values.compare_list_price)
   if (values.standard_price) payload.standard_price = parseFloat(values.standard_price)
-  if (values.weight) payload.weight = parseFloat(values.weight)
-  if (values.volume) payload.volume = parseFloat(values.volume)
-  if (values.sale_delay) payload.sale_delay = parseInt(values.sale_delay, 10)
-  payload.hs_code = values.hs_code.trim() || false
   payload.sale_ok = values.sale_ok === '1'
   payload.invoice_policy = values.invoice_policy || false
   payload.description_sale = values.description_sale.trim() || false
@@ -527,6 +521,12 @@ function buildPayload(values: FormValues): Partial<OdooProduct> {
   payload.website_meta_title = values.website_meta_title.trim() || false
   payload.website_meta_description = values.website_meta_description.trim() || false
   payload.website_meta_keywords = values.website_meta_keywords.trim() || false
+  payload.tracking = values.tracking
+  if (values.weight) payload.weight = parseFloat(values.weight)
+  if (values.volume) payload.volume = parseFloat(values.volume)
+  if (values.sale_delay) payload.sale_delay = parseInt(values.sale_delay, 10)
+  payload.hs_code = values.hs_code.trim() || false
+  payload.priority = values.priority || '0'
   payload.description = values.description.trim() || false
 
   return payload as Partial<OdooProduct>
@@ -536,7 +536,12 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
   const isCreate = product === null
   const [values, setValues] = useState<FormValues>(() => initValues(product))
   const [subcategId, setSubcategId] = useState('')
+  const [brandId, setBrandId] = useState('')
+  const [publicCategId, setPublicCategId] = useState('')
+  const [publicSubcategId, setPublicSubcategId] = useState('')
   const [categories, setCategories] = useState<OdooCategory[]>([])
+  const [brands, setBrands] = useState<OdooCategory[]>([])
+  const [publicCategories, setPublicCategories] = useState<OdooCategory[]>([])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [pendingProperties, setPendingProperties] = useState<OdooPropertyValue[]>([])
@@ -545,13 +550,27 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
     listOdooCategories(200, 0)
       .then((r) => setCategories(Array.isArray(r?.items) ? r.items : []))
       .catch(() => {})
+    listOdooBrands(200, 0)
+      .then((r) => setBrands(Array.isArray(r?.items) ? r.items : []))
+      .catch(() => {})
+    listOdooPublicCategories(500, 0)
+      .then((r) => setPublicCategories(Array.isArray(r?.items) ? r.items : []))
+      .catch(() => {})
   }, [])
 
-  // Subcategorías: hijos de la categoría seleccionada
+  // Subcategorías internas: hijos de la categoría seleccionada
   const subcategories = values.categ_id
     ? categories.filter((c) => {
         if (!c.parent_id) return false
         return c.parent_id[0] === parseInt(values.categ_id, 10)
+      })
+    : []
+
+  // Subcategorías eCommerce: hijos de la categoría pública seleccionada
+  const publicSubcategories = publicCategId
+    ? publicCategories.filter((c) => {
+        if (!c.parent_id) return false
+        return c.parent_id[0] === parseInt(publicCategId, 10)
       })
     : []
 
@@ -571,8 +590,22 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
     setSubmitting(true)
     try {
       const payload = buildPayload(values)
-      // Si hay subcategoría seleccionada, sobreescribe categ_id con la subcategoría
-      if (subcategId) payload.categ_id = parseInt(subcategId, 10) as unknown as typeof payload.categ_id
+      // Subcategoría interna sobreescribe categ_id
+      if (subcategId) {
+        payload.categ_id = parseInt(subcategId, 10) as unknown as typeof payload.categ_id
+      }
+      // public_categ_ids agrupa marca + categoría eCommerce (Many2many independiente)
+      const publicIds: number[] = []
+      if (brandId) publicIds.push(parseInt(brandId, 10))
+      // Subcategoría eCommerce tiene prioridad sobre categoría eCommerce simple
+      if (publicSubcategId) {
+        publicIds.push(parseInt(publicSubcategId, 10))
+      } else if (publicCategId) {
+        publicIds.push(parseInt(publicCategId, 10))
+      }
+      if (publicIds.length > 0) {
+        ;(payload as Record<string, unknown>).public_categ_ids = publicIds.map((id) => [4, id])
+      }
       if (isCreate) {
         const created = await createOdooProduct(payload)
         if (pendingProperties.length > 0) {
@@ -615,13 +648,13 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
 
         <div className="overflow-y-auto flex-1 px-6 py-4 space-y-4">
 
-          {/* Información general */}
+          {/* 1. Identificación (campos obligatorios primero) */}
           <div className={SECTION_CLS}>
-            <p className={SECTION_TITLE_CLS}>Información general</p>
+            <p className={SECTION_TITLE_CLS}>Identificación</p>
             <div className="grid grid-cols-2 gap-3">
               <div className="col-span-2">
                 <label className={LABEL_CLS}>Nombre <span className="text-red-500">*</span></label>
-                <input type="text" value={values.name} onChange={(e) => set('name', e.target.value)} className={INPUT_CLS} />
+                <input type="text" value={values.name} onChange={(e) => set('name', e.target.value)} className={INPUT_CLS} autoFocus />
               </div>
               <div>
                 <label className={LABEL_CLS}>
@@ -629,27 +662,6 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
                 </label>
                 <input type="text" value={values.default_code} onChange={(e) => set('default_code', e.target.value)} className={INPUT_CLS} />
               </div>
-              <div>
-                <label className={LABEL_CLS}>Activo</label>
-                <select value={values.active} onChange={(e) => set('active', e.target.value)} className={INPUT_CLS}>
-                  <option value="1">Sí</option>
-                  <option value="0">No</option>
-                </select>
-              </div>
-              <div>
-                <label className={LABEL_CLS}>Favorito</label>
-                <select value={values.priority} onChange={(e) => set('priority', e.target.value)} className={INPUT_CLS}>
-                  <option value="0">Normal</option>
-                  <option value="1">Favorito</option>
-                </select>
-              </div>
-            </div>
-          </div>
-
-          {/* Tipo y categoría */}
-          <div className={SECTION_CLS}>
-            <p className={SECTION_TITLE_CLS}>Tipo y categoría</p>
-            <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className={LABEL_CLS}>Tipo de producto</label>
                 <select value={values.detailed_type} onChange={(e) => set('detailed_type', e.target.value)} className={INPUT_CLS}>
@@ -659,29 +671,35 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
                 </select>
               </div>
               <div>
-                <label className={LABEL_CLS}>Seguimiento</label>
-                <select value={values.tracking} onChange={(e) => set('tracking', e.target.value)} className={INPUT_CLS}>
-                  <option value="none">Sin seguimiento</option>
-                  <option value="lot">Por lote</option>
-                  <option value="serial">Por número de serie</option>
+                <label className={LABEL_CLS}>Activo</label>
+                <select value={values.active} onChange={(e) => set('active', e.target.value)} className={INPUT_CLS}>
+                  <option value="1">Sí</option>
+                  <option value="0">No</option>
                 </select>
               </div>
+            </div>
+          </div>
+
+          {/* 2. Clasificación */}
+          <div className={SECTION_CLS}>
+            <p className={SECTION_TITLE_CLS}>Clasificación</p>
+            <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className={LABEL_CLS}>Categoría</label>
+                <label className={LABEL_CLS}>Categoría interna</label>
                 <select
                   value={values.categ_id}
                   onChange={(e) => { set('categ_id', e.target.value); setSubcategId('') }}
                   className={INPUT_CLS}
                 >
-                  <option value="">— Sin cambio —</option>
+                  <option value="">— Sin categoría —</option>
                   {categories.map((c) => (
                     <option key={c.id} value={String(c.id)}>{c.complete_name || c.name}</option>
                   ))}
                 </select>
               </div>
-              {subcategories.length > 0 && (
+              {subcategories.length > 0 ? (
                 <div>
-                  <label className={LABEL_CLS}>Subcategoría</label>
+                  <label className={LABEL_CLS}>Subcategoría interna</label>
                   <select
                     value={subcategId}
                     onChange={(e) => setSubcategId(e.target.value)}
@@ -693,27 +711,55 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
                     ))}
                   </select>
                 </div>
-              )}
+              ) : <div />}
               <div>
-                <label className={LABEL_CLS}>HS Code</label>
-                <input type="text" value={values.hs_code} onChange={(e) => set('hs_code', e.target.value)} placeholder="p.ej. 8471300000" className={INPUT_CLS} />
+                <label className={LABEL_CLS}>Categoría eCommerce</label>
+                <select
+                  value={publicCategId}
+                  onChange={(e) => { setPublicCategId(e.target.value); setPublicSubcategId('') }}
+                  className={INPUT_CLS}
+                >
+                  <option value="">— Sin categoría web —</option>
+                  {publicCategories.map((c) => (
+                    <option key={c.id} value={String(c.id)}>{c.complete_name || c.name}</option>
+                  ))}
+                </select>
               </div>
-              {!isCreate && (
-                <>
-                  <div>
-                    <label className={LABEL_CLS}>Unidad de medida</label>
-                    <input type="text" value={uomLabel} disabled className={`${INPUT_CLS} bg-gray-50 text-gray-500`} />
-                  </div>
-                  <div>
-                    <label className={LABEL_CLS}>UdM de compra</label>
-                    <input type="text" value={uomPoLabel} disabled className={`${INPUT_CLS} bg-gray-50 text-gray-500`} />
-                  </div>
-                </>
-              )}
+              {publicSubcategories.length > 0 ? (
+                <div>
+                  <label className={LABEL_CLS}>Subcategoría eCommerce</label>
+                  <select
+                    value={publicSubcategId}
+                    onChange={(e) => setPublicSubcategId(e.target.value)}
+                    className={INPUT_CLS}
+                  >
+                    <option value="">— Usar categoría padre —</option>
+                    {publicSubcategories.map((c) => (
+                      <option key={c.id} value={String(c.id)}>{c.name}</option>
+                    ))}
+                  </select>
+                </div>
+              ) : <div />}
+              <div className="col-span-2">
+                <label className={LABEL_CLS}>Marca</label>
+                <select
+                  value={brandId}
+                  onChange={(e) => setBrandId(e.target.value)}
+                  className={INPUT_CLS}
+                >
+                  <option value="">— Sin marca —</option>
+                  {brands.map((b) => (
+                    <option key={b.id} value={String(b.id)}>{b.name}</option>
+                  ))}
+                </select>
+                {brands.length === 0 && (
+                  <p className="text-xs text-gray-400 mt-1">No hay marcas creadas. Crea marcas en la pestaña Marcas.</p>
+                )}
+              </div>
             </div>
           </div>
 
-          {/* Precios */}
+          {/* 3. Precios */}
           <div className={SECTION_CLS}>
             <p className={SECTION_TITLE_CLS}>Precios</p>
             <div className="grid grid-cols-3 gap-3">
@@ -732,26 +778,7 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
             </div>
           </div>
 
-          {/* Medidas y logística */}
-          <div className={SECTION_CLS}>
-            <p className={SECTION_TITLE_CLS}>Medidas y logística</p>
-            <div className="grid grid-cols-4 gap-3">
-              <div>
-                <label className={LABEL_CLS}>Peso (kg)</label>
-                <input type="number" step="0.001" min="0" value={values.weight} onChange={(e) => set('weight', e.target.value)} className={INPUT_CLS} />
-              </div>
-              <div>
-                <label className={LABEL_CLS}>Volumen (m³)</label>
-                <input type="number" step="0.001" min="0" value={values.volume} onChange={(e) => set('volume', e.target.value)} className={INPUT_CLS} />
-              </div>
-              <div>
-                <label className={LABEL_CLS}>Plazo cliente (días)</label>
-                <input type="number" step="1" min="0" value={values.sale_delay} onChange={(e) => set('sale_delay', e.target.value)} className={INPUT_CLS} />
-              </div>
-            </div>
-          </div>
-
-          {/* Ventas */}
+          {/* 4. Ventas */}
           <div className={SECTION_CLS}>
             <p className={SECTION_TITLE_CLS}>Ventas</p>
             <div className="grid grid-cols-2 gap-3">
@@ -776,7 +803,7 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
             </div>
           </div>
 
-          {/* Compras */}
+          {/* 5. Compras */}
           <div className={SECTION_CLS}>
             <p className={SECTION_TITLE_CLS}>Compras</p>
             <div className="grid grid-cols-2 gap-3">
@@ -801,7 +828,7 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
             </div>
           </div>
 
-          {/* eCommerce */}
+          {/* 6. eCommerce */}
           <div className={SECTION_CLS}>
             <p className={SECTION_TITLE_CLS}>eCommerce</p>
             <div className="grid grid-cols-2 gap-3">
@@ -834,13 +861,63 @@ function ProductModal({ product, onClose, onSuccess }: ProductModalProps) {
             </div>
           </div>
 
-          {/* Descripción interna */}
+          {/* 7. Logística */}
+          <div className={SECTION_CLS}>
+            <p className={SECTION_TITLE_CLS}>Logística</p>
+            <div className="grid grid-cols-4 gap-3">
+              <div>
+                <label className={LABEL_CLS}>Seguimiento</label>
+                <select value={values.tracking} onChange={(e) => set('tracking', e.target.value)} className={INPUT_CLS}>
+                  <option value="none">Sin seguimiento</option>
+                  <option value="lot">Por lote</option>
+                  <option value="serial">Por serie</option>
+                </select>
+              </div>
+              <div>
+                <label className={LABEL_CLS}>Peso (kg)</label>
+                <input type="number" step="0.001" min="0" value={values.weight} onChange={(e) => set('weight', e.target.value)} className={INPUT_CLS} />
+              </div>
+              <div>
+                <label className={LABEL_CLS}>Volumen (m³)</label>
+                <input type="number" step="0.001" min="0" value={values.volume} onChange={(e) => set('volume', e.target.value)} className={INPUT_CLS} />
+              </div>
+              <div>
+                <label className={LABEL_CLS}>Plazo cliente (días)</label>
+                <input type="number" step="1" min="0" value={values.sale_delay} onChange={(e) => set('sale_delay', e.target.value)} className={INPUT_CLS} />
+              </div>
+              <div>
+                <label className={LABEL_CLS}>HS Code</label>
+                <input type="text" value={values.hs_code} onChange={(e) => set('hs_code', e.target.value)} placeholder="p.ej. 8471300000" className={INPUT_CLS} />
+              </div>
+              <div>
+                <label className={LABEL_CLS}>Favorito</label>
+                <select value={values.priority} onChange={(e) => set('priority', e.target.value)} className={INPUT_CLS}>
+                  <option value="0">Normal</option>
+                  <option value="1">Favorito</option>
+                </select>
+              </div>
+              {!isCreate && (
+                <>
+                  <div>
+                    <label className={LABEL_CLS}>UdM</label>
+                    <input type="text" value={uomLabel} disabled className={`${INPUT_CLS} bg-gray-50 text-gray-500`} />
+                  </div>
+                  <div>
+                    <label className={LABEL_CLS}>UdM compra</label>
+                    <input type="text" value={uomPoLabel} disabled className={`${INPUT_CLS} bg-gray-50 text-gray-500`} />
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* 8. Descripción interna */}
           <div className={SECTION_CLS}>
             <p className={SECTION_TITLE_CLS}>Descripción interna</p>
             <textarea rows={4} value={values.description} onChange={(e) => set('description', e.target.value)} className={INPUT_CLS} />
           </div>
 
-          {/* Campos extra — visible cuando hay categoría seleccionada */}
+          {/* 9. Campos extra — visible cuando hay categoría interna seleccionada */}
           {values.categ_id && (
             <div className={SECTION_CLS}>
               <p className={SECTION_TITLE_CLS}>Campos extra</p>

--- a/frontend/src/types/odoo.ts
+++ b/frontend/src/types/odoo.ts
@@ -36,6 +36,7 @@ export interface OdooProduct {
   website_meta_title: string | false
   website_meta_description: string | false
   website_meta_keywords: string | false
+  public_categ_ids: number[]
 }
 
 export interface OdooCategory {

--- a/services/integrations/odoo/categories.py
+++ b/services/integrations/odoo/categories.py
@@ -200,7 +200,7 @@ class OooCategoryService:
             results = await self._client.list(
                 "product.category",
                 limit=1,
-                filters={"domain": [("name", "=", name)], "fields": ["id", "name", "complete_name"]},
+                filters={"domain": [("name", "=", name)], "fields": ["id", "name"]},
             )
             return results[0] if results else None
         except Exception as exc:
@@ -236,7 +236,7 @@ class OooCategoryService:
                 limit=1,
                 filters={
                     "domain": [("name", "=", name), ("parent_id", "=", parent_id)],
-                    "fields": ["id", "name", "complete_name"],
+                    "fields": ["id", "name"],
                 },
             )
             return results[0] if results else None
@@ -278,6 +278,439 @@ class OooCategoryService:
         created = await self.create_category(subcat_name, parent_id=parent_id)
         logger.info(
             "Subcategoría Odoo creada automáticamente",
+            extra={"name": subcat_name, "parent_name": parent_name, "id": created.get("id")},
+        )
+        return created
+
+    async def list_brands(
+        self,
+        brands_parent: str = "Marcas",
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict]:
+        """
+        Lista las marcas (subcategorías bajo la categoría padre ``brands_parent``).
+
+        Args:
+            brands_parent: nombre exacto de la categoría padre de marcas.
+            limit:         máximo de resultados.
+            offset:        desplazamiento para paginación.
+
+        Returns:
+            Lista de dicts de subcategorías (marcas). Vacía si el padre no existe.
+        """
+        parent = await self.find_category_by_name(brands_parent)
+        if not parent:
+            return []
+        parent_id = int(parent["id"])
+        all_cats = await self.list_categories(limit=500, offset=0)
+        brands = [
+            c for c in all_cats
+            if c.get("parent_id") and (
+                (isinstance(c["parent_id"], list) and c["parent_id"][0] == parent_id)
+                or c["parent_id"] == parent_id
+            )
+        ]
+        return brands[offset: offset + limit]
+
+    async def find_or_create_brand(
+        self,
+        brand_name: str,
+        brands_parent: str = "Marcas",
+    ) -> dict:
+        """
+        Busca una marca bajo ``brands_parent``, o la crea si no existe.
+
+        Args:
+            brand_name:    nombre exacto de la marca (subcategoría).
+            brands_parent: nombre exacto de la categoría padre de marcas.
+
+        Returns:
+            Dict de la subcategoría (marca) resuelta o creada.
+
+        Raises:
+            IntegrationError: si la categoría padre no existe en Odoo.
+        """
+        return await self.find_or_create_subcategory(brands_parent, brand_name)
+
+    # ── product.public.category (eCommerce) ──────────────────────────────────
+
+    _PUBLIC_CAT_FIELDS = ["id", "name", "parent_id", "child_id"]
+
+    async def _find_public_category_by_name(self, name: str) -> dict | None:
+        """
+        Busca una categoría pública (product.public.category) por nombre exacto.
+
+        Args:
+            name: nombre de la categoría a buscar.
+
+        Returns:
+            Dict con id y name si existe, None si no.
+        """
+        try:
+            results = await self._client.list(
+                "product.public.category",
+                limit=1,
+                filters={"domain": [("name", "=", name)], "fields": ["id", "name"]},
+            )
+            return results[0] if results else None
+        except Exception as exc:
+            logger.warning(
+                "Error buscando product.public.category por nombre",
+                exc_info=exc,
+                extra={"name": name},
+            )
+            return None
+
+    async def _find_public_category_by_name_and_parent(
+        self, name: str, parent_id: int
+    ) -> dict | None:
+        """
+        Busca categoría pública por nombre bajo un padre específico.
+
+        Args:
+            name:      nombre exacto.
+            parent_id: ID del padre en product.public.category.
+
+        Returns:
+            Dict si existe, None si no.
+        """
+        try:
+            results = await self._client.list(
+                "product.public.category",
+                limit=1,
+                filters={
+                    "domain": [("name", "=", name), ("parent_id", "=", parent_id)],
+                    "fields": ["id", "name"],
+                },
+            )
+            return results[0] if results else None
+        except Exception as exc:
+            logger.warning(
+                "Error buscando product.public.category por nombre y padre",
+                exc_info=exc,
+                extra={"name": name, "parent_id": parent_id},
+            )
+            return None
+
+    async def _ensure_brands_parent(self, brands_parent: str) -> dict:
+        """
+        Devuelve la categoría padre de marcas en product.public.category, creándola si no existe.
+
+        Args:
+            brands_parent: nombre exacto de la categoría raíz de marcas.
+
+        Returns:
+            Dict de la categoría padre (id, name, complete_name).
+
+        Raises:
+            IntegrationError: si falla la creación.
+        """
+        parent = await self._find_public_category_by_name(brands_parent)
+        if parent:
+            return parent
+        try:
+            created = await self._client.create(
+                "product.public.category",
+                {"name": brands_parent},
+            )
+            logger.info(
+                "Categoría padre de marcas creada automáticamente en product.public.category",
+                extra={"name": brands_parent, "id": created.get("id")},
+            )
+            return created
+        except Exception as exc:
+            logger.error("Error creando categoría padre de marcas Odoo", exc_info=exc)
+            raise IntegrationError(
+                f"Fallo creando categoría padre '{brands_parent}' en product.public.category"
+            ) from exc
+
+    async def list_brands_public(
+        self,
+        brands_parent: str = "Marcas",
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict]:
+        """
+        Lista marcas como subcategorías bajo ``brands_parent`` en product.public.category.
+        Si el padre no existe, lo crea automáticamente.
+
+        Args:
+            brands_parent: nombre exacto de la categoría padre de marcas.
+            limit:         máximo de resultados.
+            offset:        desplazamiento para paginación.
+
+        Returns:
+            Lista de dicts.
+        """
+        parent = await self._ensure_brands_parent(brands_parent)
+        parent_id = int(parent["id"])
+        try:
+            results = await self._client.list(
+                "product.public.category",
+                limit=500,
+                filters={
+                    "domain": [("parent_id", "=", parent_id)],
+                    "fields": self._PUBLIC_CAT_FIELDS,
+                    "order": "name asc",
+                },
+            )
+            return results[offset: offset + limit]
+        except Exception as exc:
+            logger.error("Error listando marcas públicas Odoo", exc_info=exc)
+            raise IntegrationError("Fallo listando marcas en product.public.category") from exc
+
+    async def find_or_create_brand_public(
+        self,
+        brand_name: str,
+        brands_parent: str = "Marcas",
+    ) -> dict:
+        """
+        Busca marca en product.public.category bajo ``brands_parent``, o la crea si no existe.
+        Si el padre tampoco existe, lo crea automáticamente.
+
+        Args:
+            brand_name:    nombre exacto de la marca.
+            brands_parent: nombre exacto de la categoría padre de marcas públicas.
+
+        Returns:
+            Dict de la marca (product.public.category) resuelta o creada.
+
+        Raises:
+            IntegrationError: si falla la creación en Odoo.
+        """
+        parent = await self._ensure_brands_parent(brands_parent)
+        parent_id = int(parent["id"])
+        existing = await self._find_public_category_by_name_and_parent(brand_name, parent_id)
+        if existing:
+            logger.debug(
+                "Marca pública Odoo encontrada",
+                extra={"name": brand_name, "parent_id": parent_id},
+            )
+            return existing
+        try:
+            created = await self._client.create(
+                "product.public.category",
+                {"name": brand_name, "parent_id": parent_id},
+            )
+            logger.info(
+                "Marca pública Odoo creada",
+                extra={"name": brand_name, "parent": brands_parent, "id": created.get("id")},
+            )
+            return created
+        except Exception as exc:
+            logger.error("Error creando marca pública Odoo", exc_info=exc)
+            raise IntegrationError(f"Fallo creando marca '{brand_name}' en Odoo") from exc
+
+    async def delete_brand_public(self, brand_id: int) -> bool:
+        """
+        Elimina una marca de product.public.category.
+
+        Args:
+            brand_id: ID de la marca en product.public.category.
+
+        Returns:
+            True si se eliminó.
+
+        Raises:
+            IntegrationError: si falla.
+        """
+        try:
+            result = await self._client.delete("product.public.category", brand_id)
+            logger.info("Marca pública Odoo eliminada", extra={"id": brand_id})
+            return result
+        except Exception as exc:
+            logger.error("Error eliminando marca pública Odoo", exc_info=exc, extra={"id": brand_id})
+            raise IntegrationError(f"Fallo eliminando marca Odoo {brand_id}") from exc
+
+    # ── product.public.category — CRUD completo (eCommerce) ──────────────────
+
+    async def list_public_categories(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict]:
+        """
+        Lista todas las categorías de eCommerce (product.public.category) con paginación.
+
+        Args:
+            limit:  máximo de resultados.
+            offset: desplazamiento.
+
+        Returns:
+            Lista de dicts de product.public.category.
+
+        Raises:
+            IntegrationError: si Odoo falla.
+        """
+        try:
+            return await self._client.list(
+                "product.public.category",
+                limit=limit,
+                offset=offset,
+                filters={"domain": [], "fields": self._PUBLIC_CAT_FIELDS, "order": "name asc"},
+            )
+        except Exception as exc:
+            logger.error("Error listando categorías públicas Odoo", exc_info=exc)
+            raise IntegrationError("Fallo listando categorías eCommerce Odoo") from exc
+
+    async def get_public_category_tree(self) -> list[dict]:
+        """
+        Construye árbol jerárquico completo de product.public.category.
+        Pagina hasta obtener todas y organiza la relación padre-hijo en memoria.
+
+        Returns:
+            Lista de nodos raíz con estructura children anidada.
+
+        Raises:
+            IntegrationError: si Odoo falla durante la paginación.
+        """
+        all_cats: list[dict] = []
+        offset = 0
+        limit = 100
+        try:
+            while True:
+                batch = await self.list_public_categories(limit=limit, offset=offset)
+                if not batch:
+                    break
+                all_cats.extend(batch)
+                if len(batch) < limit:
+                    break
+                offset += limit
+        except IntegrationError:
+            raise
+
+        cats_by_id: dict[int, dict] = {c["id"]: {**c, "children": []} for c in all_cats}
+        roots: list[dict] = []
+        for cat in all_cats:
+            raw_parent = cat.get("parent_id")
+            if raw_parent and isinstance(raw_parent, list) and len(raw_parent) >= 1:
+                parent_id = raw_parent[0]
+                if parent_id in cats_by_id:
+                    cats_by_id[parent_id]["children"].append(cats_by_id[cat["id"]])
+                else:
+                    roots.append(cats_by_id[cat["id"]])
+            else:
+                roots.append(cats_by_id[cat["id"]])
+
+        logger.debug("Árbol eCommerce Odoo construido", extra={"roots": len(roots), "total": len(all_cats)})
+        return roots
+
+    async def create_public_category(self, name: str, parent_id: int | None = None) -> dict:
+        """
+        Crea una categoría de eCommerce en product.public.category.
+
+        Args:
+            name:      nombre de la categoría.
+            parent_id: ID del padre (opcional).
+
+        Returns:
+            Categoría creada.
+
+        Raises:
+            IntegrationError: si falla.
+        """
+        data: dict = {"name": name}
+        if parent_id is not None:
+            data["parent_id"] = parent_id
+        try:
+            result = await self._client.create("product.public.category", data)
+            logger.info("Categoría eCommerce Odoo creada", extra={"id": result.get("id"), "name": name})
+            return result
+        except Exception as exc:
+            logger.error("Error creando categoría eCommerce Odoo", exc_info=exc)
+            raise IntegrationError("Fallo creando categoría eCommerce Odoo") from exc
+
+    async def update_public_category(self, category_id: int, data: dict) -> dict:
+        """
+        Actualiza una categoría de eCommerce existente.
+
+        Args:
+            category_id: ID de la categoría en product.public.category.
+            data:        campos a actualizar.
+
+        Returns:
+            Categoría actualizada.
+
+        Raises:
+            IntegrationError: si falla.
+        """
+        try:
+            result = await self._client.update("product.public.category", category_id, data)
+            logger.info("Categoría eCommerce Odoo actualizada", extra={"id": category_id})
+            return result
+        except Exception as exc:
+            logger.error("Error actualizando categoría eCommerce Odoo", exc_info=exc, extra={"id": category_id})
+            raise IntegrationError(f"Fallo actualizando categoría eCommerce Odoo {category_id}") from exc
+
+    async def delete_public_category(self, category_id: int) -> bool:
+        """
+        Elimina una categoría de eCommerce.
+
+        Args:
+            category_id: ID de la categoría en product.public.category.
+
+        Returns:
+            True si se eliminó.
+
+        Raises:
+            IntegrationError: si falla.
+        """
+        try:
+            result = await self._client.delete("product.public.category", category_id)
+            logger.info("Categoría eCommerce Odoo eliminada", extra={"id": category_id})
+            return result
+        except Exception as exc:
+            logger.error("Error eliminando categoría eCommerce Odoo", exc_info=exc, extra={"id": category_id})
+            raise IntegrationError(f"Fallo eliminando categoría eCommerce Odoo {category_id}") from exc
+
+    async def count_public_categories(self) -> int:
+        """
+        Cuenta el total de categorías de eCommerce.
+
+        Returns:
+            Número de categorías en product.public.category.
+        """
+        from services.integrations.odoo.client import OdooClient
+        if not isinstance(self._client, OdooClient):
+            return 0
+        return await self._client.search_count("product.public.category")
+
+    async def find_or_create_public_subcategory(
+        self,
+        parent_name: str,
+        subcat_name: str,
+    ) -> dict:
+        """
+        Busca subcategoría de eCommerce bajo un padre por nombre, o la crea si no existe.
+        Usado durante importación CSV para resolver categorías eCommerce con subcategoría.
+
+        Args:
+            parent_name: nombre exacto de la categoría padre en product.public.category.
+            subcat_name: nombre exacto de la subcategoría.
+
+        Returns:
+            Dict de la subcategoría resuelta o creada.
+
+        Raises:
+            IntegrationError: si el padre no existe o falla la creación.
+        """
+        parent = await self._find_public_category_by_name(parent_name)
+        if not parent:
+            raise IntegrationError(
+                f"Categoría eCommerce padre '{parent_name}' no existe en Odoo. Créala primero."
+            )
+        parent_id = int(parent["id"])
+        existing = await self._find_public_category_by_name_and_parent(subcat_name, parent_id)
+        if existing:
+            logger.debug(
+                "Subcategoría eCommerce Odoo encontrada",
+                extra={"name": subcat_name, "parent_id": parent_id},
+            )
+            return existing
+        created = await self.create_public_category(subcat_name, parent_id=parent_id)
+        logger.info(
+            "Subcategoría eCommerce Odoo creada automáticamente",
             extra={"name": subcat_name, "parent_name": parent_name, "id": created.get("id")},
         )
         return created

--- a/services/integrations/odoo/products.py
+++ b/services/integrations/odoo/products.py
@@ -291,8 +291,14 @@ class OdooProductService:
         "website_meta_description": "str",
         "website_meta_keywords": "str",
         "description": "str",
-        # Campo virtual: nombre de subcategoría — resuelto antes de enviar a Odoo
+        # Campo virtual: nombre de subcategoría interna — resuelto antes de enviar a Odoo
         "subcateg_id": "str",
+        # Campo virtual: nombre de marca (subcategoría bajo "Marcas") — resuelto antes de enviar a Odoo
+        "brand_id": "str",
+        # Campo virtual: categoría eCommerce (product.public.category) — resuelto antes de enviar a Odoo
+        "public_categ_id": "str",
+        # Campo virtual: subcategoría eCommerce — resuelto junto a public_categ_id
+        "public_subcateg_id": "str",
     }
 
     @classmethod
@@ -334,6 +340,9 @@ class OdooProductService:
         batch_size: int = 100,
         categ_name_to_id: dict[str, int] | None = None,
         subcateg_pair_to_id: dict[str, int] | None = None,
+        brand_name_to_id: dict[str, int] | None = None,
+        public_categ_name_to_id: dict[str, int] | None = None,
+        public_subcateg_pair_to_id: dict[str, int] | None = None,
     ) -> dict:
         """
         Importa múltiples productos desde CSV con upsert por default_code.
@@ -345,14 +354,17 @@ class OdooProductService:
           4. Actualización concurrente de existentes (N llamadas, sin búsqueda previa).
 
         Args:
-            rows:                 lista de dicts {columna_csv: valor_string}.
-            mapping:              dict {columna_csv: campo_odoo}. Columnas mapeadas a "" se ignoran.
-            overwrite:            si True, actualiza productos existentes; si False, los omite.
-            concurrency:          máximo de actualizaciones simultáneas contra Odoo.
-            batch_size:           tamaño del lote para búsquedas masivas y creaciones.
-            categ_name_to_id:     mapa {nombre_categoría: id_odoo} pre-validado en el endpoint.
-            subcateg_pair_to_id:  mapa {"padre||hijo": id_odoo} de subcategorías resueltas.
-                                  Si presente, sobreescribe categ_id con el ID de la subcategoría.
+            rows:                     lista de dicts {columna_csv: valor_string}.
+            mapping:                  dict {columna_csv: campo_odoo}. Columnas mapeadas a "" se ignoran.
+            overwrite:                si True, actualiza productos existentes; si False, los omite.
+            concurrency:              máximo de actualizaciones simultáneas contra Odoo.
+            batch_size:               tamaño del lote para búsquedas masivas y creaciones.
+            categ_name_to_id:         mapa {nombre_categoría: id_odoo} pre-validado en el endpoint.
+            subcateg_pair_to_id:      mapa {"padre||hijo": id_odoo} de subcategorías internas.
+                                      Si presente, sobreescribe categ_id con el ID de la subcategoría.
+            brand_name_to_id:         mapa {nombre_marca: id_odoo} de marcas resueltas bajo "Marcas".
+            public_categ_name_to_id:  mapa {nombre_cat_ecommerce: id_odoo} de categorías eCommerce.
+            public_subcateg_pair_to_id: mapa {"padre||hijo": id_odoo} de subcategorías eCommerce.
 
         Returns:
             Dict con claves: created (int), updated (int), skipped (int),
@@ -372,7 +384,36 @@ class OdooProductService:
                 if coerced is not False:
                     product_data[odoo_field] = coerced
 
-            # Resolver subcategoría — si hay par (padre||hijo) usa el ID de la subcategoría
+            # Acumular IDs para public_categ_ids (Many2many) — marca + categoría eCommerce
+            public_ids: list[int] = []
+
+            # Marca → public_categ_ids
+            if "brand_id" in product_data and brand_name_to_id:
+                brand_name = str(product_data["brand_id"]).strip()
+                if brand_name in brand_name_to_id:
+                    public_ids.append(brand_name_to_id[brand_name])
+                del product_data["brand_id"]
+
+            # Subcategoría eCommerce (tiene prioridad sobre categoría eCommerce simple)
+            if "public_subcateg_id" in product_data and public_subcateg_pair_to_id:
+                pub_parent = str(product_data.get("public_categ_id", "")).strip()
+                pub_sub = str(product_data["public_subcateg_id"]).strip()
+                pair_key = f"{pub_parent}||{pub_sub}"
+                if pair_key in public_subcateg_pair_to_id:
+                    public_ids.append(public_subcateg_pair_to_id[pair_key])
+                del product_data["public_subcateg_id"]
+                if "public_categ_id" in product_data:
+                    del product_data["public_categ_id"]
+            elif "public_categ_id" in product_data and public_categ_name_to_id:
+                pub_cat_name = str(product_data["public_categ_id"]).strip()
+                if pub_cat_name in public_categ_name_to_id:
+                    public_ids.append(public_categ_name_to_id[pub_cat_name])
+                del product_data["public_categ_id"]
+
+            if public_ids:
+                product_data["public_categ_ids"] = [(4, pid) for pid in public_ids]
+
+            # Resolver subcategoría / categoría interna (independiente de marca)
             if "subcateg_id" in product_data and subcateg_pair_to_id:
                 parent_name = str(product_data.get("categ_id", "")).strip()
                 subcat_name = str(product_data["subcateg_id"]).strip()
@@ -381,7 +422,6 @@ class OdooProductService:
                     product_data["categ_id"] = subcateg_pair_to_id[pair_key]
                 del product_data["subcateg_id"]
             elif "categ_id" in product_data and categ_name_to_id:
-                # Sin subcategoría: resolver categoría principal por nombre
                 cat_name = str(product_data["categ_id"]).strip()
                 if cat_name in categ_name_to_id:
                     product_data["categ_id"] = categ_name_to_id[cat_name]


### PR DESCRIPTION
## Summary

- New `product.public.category` CRUD in `OooCategoryService` (7 methods): list, tree, create, update, delete, count, find-or-create subcategory
- `bulk_upsert_products` now accepts `public_categ_name_to_id` / `public_subcateg_pair_to_id`; combines brand + eCommerce category IDs into a single `public_categ_ids` Many2many write
- New `router_ecommerce_categories` (`/odoo/ecommerce/categories`) with full CRUD + tree endpoint; new `router_brands` (`/odoo/brands`) for Odoo brand management
- New **Categorías web** tab in `OdooPanel` with `OdooEcommerceCategories` tree (same UX as internal categories, purple globe icon)
- New `OdooBrands` panel for managing brands stored as `product.public.category` subcategories
- Brand selector always visible in `ProductModal` (was conditional); new eCommerce category + subcategory selectors
- `ProductModal` form fields reordered by priority (identification → classification → prices → sales → purchases → eCommerce → logistics → other)
- `OdooCsvImport` `FIELD_LABELS` reordered by same priority; new `public_categ_id` / `public_subcateg_id` columns supported

## Test plan

- [ ] Create eCommerce categories via Categorías web tree — verify create / edit / delete
- [ ] Create product with brand + eCommerce subcategory — verify both IDs in `public_categ_ids`
- [ ] CSV import with `public_categ_id` and `public_subcateg_id` mapped — verify resolution and assignment
- [ ] Brand selector visible in modal even with zero brands (shows hint)

> **Note:** stacked on `feat/dolibarr-brands`. Retarget to `main` after #117 merges.